### PR TITLE
ImageとVolumeの実体欠損監視をコントローラーに組み込み

### DIFF
--- a/pkg/controller/image-controller.go
+++ b/pkg/controller/image-controller.go
@@ -96,7 +96,10 @@ func (c *controller) imageControllerLoop() {
 			// ここにイメージの作成失敗時の処理を実装
 		case db.IMAGE_AVAILABLE:
 			slog.Debug("イメージは利用可能", "image", *image.Metadata.Name)
-			// ここにイメージが利用可能な状態での処理を実装
+			if err := marmotd.CheckImageBackingStore(image); err != nil {
+				slog.Warn("AVAILABLE イメージの実体が見つからないため DELETED に更新", "imageId", image.Id, "err", err)
+				c.marmot.Db.UpdateImageStatusMessage(image.Id, db.IMAGE_DELETED, err.Error())
+			}
 		case db.IMAGE_DELETING:
 			slog.Debug("イメージの削除処理を実行", "image", *image.Metadata.Name)
 			err := c.marmot.DeleteImageManage(image.Id)

--- a/pkg/controller/volume-controller.go
+++ b/pkg/controller/volume-controller.go
@@ -111,9 +111,14 @@ func (c *controller) volumeControllerLoop() {
 		case db.VOLUME_ERROR:
 			slog.Debug("エラー状態のボリュームを処理", "volId", vol.Id)
 			// エラー状態のボリュームを処理するコードをここに追加
+		case db.VOLUME_UNAVAILABLE:
+			slog.Debug("実体欠損状態のボリュームを処理", "volId", vol.Id)
 		case db.VOLUME_AVAILABLE:
 			slog.Debug("利用可能なボリュームを処理", "volId", vol.Id)
-			// 利用可能なボリュームを処理するコードをここに追加
+			if err := marmotd.CheckVolumeBackingStore(vol); err != nil {
+				slog.Warn("AVAILABLE ボリュームの実体が見つからないため UNAVAILABLE に更新", "volId", vol.Id, "err", err)
+				c.db.UpdateVolumeStatusMessage(vol.Id, db.VOLUME_UNAVAILABLE, err.Error())
+			}
 		default:
 			slog.Warn("不明なステータスのボリュームをスキップ", "volId", vol.Id, "status", *vol.Status.Status)
 		}

--- a/pkg/db/db-image.go
+++ b/pkg/db/db-image.go
@@ -239,6 +239,11 @@ func (d *Database) DeleteImage(id string) error {
 
 // ステータスの変更
 func (d *Database) UpdateImageStatus(id string, status int) {
+	d.UpdateImageStatusMessage(id, status, "")
+}
+
+// ステータスとメッセージの変更
+func (d *Database) UpdateImageStatusMessage(id string, status int, message string) {
 	slog.Debug("SetImageStatus() called", "id", id, "status", status)
 	image, err := d.GetImage(id)
 	if err != nil {
@@ -247,6 +252,11 @@ func (d *Database) UpdateImageStatus(id string, status int) {
 	}
 	image.Status.StatusCode = status
 	image.Status.Status = util.StringPtr(ImageStatus[status])
+	if len(message) > 0 {
+		image.Status.Message = util.StringPtr(message)
+	} else {
+		image.Status.Message = nil
+	}
 	image.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
 	if err := d.UpdateImage(id, image); err != nil {
 		slog.Error("SetDeleteTimestamp() UpdateImage() failed", "err", err, "imageId", id)

--- a/pkg/db/db-volumes.go
+++ b/pkg/db/db-volumes.go
@@ -18,7 +18,8 @@ const (
 	VOLUME_ERROR        = 2 // 問題発生
 	VOLUME_AVAILABLE    = 3 // 利用可能
 	VOLUME_DELETING     = 4 // 削除中
-	//VOLUME_DELETED      = 5 // 削除済み
+	VOLUME_UNAVAILABLE  = 5 // 実体欠損
+	//VOLUME_DELETED      = 6 // 削除済み
 )
 
 var VolStatus = map[int]string{
@@ -27,7 +28,8 @@ var VolStatus = map[int]string{
 	2: "ERROR",
 	3: "AVAILABLE",
 	4: "DELETING",
-	//5: "DELETED",
+	5: "UNAVAILABLE",
+	//6: "DELETED",
 }
 
 // 仮想マシンを生成する時にボリュームを生成して、アタッチする
@@ -349,6 +351,10 @@ func (d *Database) FindVolumeByName(name, kind string) ([]api.Volume, error) {
 // OSボリュームの状態更新
 // エラーが出る場合、パニックして停止させるべき
 func (d *Database) UpdateVolumeStatus(id string, status int) {
+	d.UpdateVolumeStatusMessage(id, status, "")
+}
+
+func (d *Database) UpdateVolumeStatusMessage(id string, status int, message string) {
 	if len(id) == 0 {
 		slog.Error("invalid volume id", "id", id)
 		return
@@ -361,6 +367,11 @@ func (d *Database) UpdateVolumeStatus(id string, status int) {
 	vol.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
 	vol.Status.StatusCode = status
 	vol.Status.Status = util.StringPtr(VolStatus[vol.Status.StatusCode])
+	if len(message) > 0 {
+		vol.Status.Message = util.StringPtr(message)
+	} else {
+		vol.Status.Message = nil
+	}
 
 	if err = d.UpdateVolume(id, vol); err != nil {
 		slog.Error("panic! failed to update volume", "err", err, "volId", id)

--- a/pkg/marmotd/image.go
+++ b/pkg/marmotd/image.go
@@ -210,6 +210,58 @@ func (m *Marmot) UpdateImageManage(id string, image api.Image) error {
 	return m.Db.UpdateImage(id, image)
 }
 
+func CheckImageBackingStore(image api.Image) error {
+	if image.Spec == nil {
+		return nil
+	}
+
+	missing := make([]string, 0, 2)
+
+	if qcow2Path := strings.TrimSpace(util.OrDefault(image.Spec.Qcow2Path, "")); qcow2Path != "" {
+		if _, err := os.Stat(qcow2Path); err != nil {
+			if os.IsNotExist(err) {
+				missing = append(missing, fmt.Sprintf("qcow2 file %s", qcow2Path))
+			} else {
+				return fmt.Errorf("failed to inspect qcow2 file %s: %w", qcow2Path, err)
+			}
+		}
+	}
+
+	if lvPath := getImageLogicalVolumePath(image.Spec); lvPath != "" {
+		if _, err := os.Stat(lvPath); err != nil {
+			if os.IsNotExist(err) {
+				missing = append(missing, fmt.Sprintf("logical volume %s", lvPath))
+			} else {
+				return fmt.Errorf("failed to inspect logical volume %s: %w", lvPath, err)
+			}
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("missing image backing store: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+func getImageLogicalVolumePath(spec *api.ImageSpec) string {
+	if spec == nil {
+		return ""
+	}
+
+	if lvPath := strings.TrimSpace(util.OrDefault(spec.LvPath, "")); lvPath != "" {
+		return lvPath
+	}
+
+	volumeGroup := strings.TrimSpace(util.OrDefault(spec.VolumeGroup, ""))
+	logicalVolume := strings.TrimSpace(util.OrDefault(spec.LogicalVolume, ""))
+	if volumeGroup == "" || logicalVolume == "" {
+		return ""
+	}
+
+	return filepath.Join("/dev", volumeGroup, logicalVolume)
+}
+
 func resolveImagePath(imageDir, sourceURL string) (string, error) {
 	u, err := url.Parse(sourceURL)
 	if err != nil {

--- a/pkg/marmotd/image_backing_store_test.go
+++ b/pkg/marmotd/image_backing_store_test.go
@@ -1,0 +1,73 @@
+package marmotd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestCheckImageBackingStore(t *testing.T) {
+	t.Run("all backing stores exist", func(t *testing.T) {
+		tempDir := t.TempDir()
+		qcow2Path := filepath.Join(tempDir, "image.qcow2")
+		lvPath := filepath.Join(tempDir, "boot-volume")
+
+		if err := os.WriteFile(qcow2Path, []byte("qcow2"), 0644); err != nil {
+			t.Fatalf("failed to create qcow2 file: %v", err)
+		}
+		if err := os.WriteFile(lvPath, []byte("lv"), 0644); err != nil {
+			t.Fatalf("failed to create lv file: %v", err)
+		}
+
+		image := api.Image{
+			Spec: &api.ImageSpec{
+				Qcow2Path: util.StringPtr(qcow2Path),
+				LvPath:    util.StringPtr(lvPath),
+			},
+		}
+
+		if err := CheckImageBackingStore(image); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("missing qcow2 file is detected", func(t *testing.T) {
+		tempDir := t.TempDir()
+		missingPath := filepath.Join(tempDir, "missing.qcow2")
+
+		image := api.Image{
+			Spec: &api.ImageSpec{
+				Qcow2Path: util.StringPtr(missingPath),
+			},
+		}
+
+		err := CheckImageBackingStore(image)
+		if err == nil {
+			t.Fatal("expected missing qcow2 error")
+		}
+		if !strings.Contains(err.Error(), missingPath) {
+			t.Fatalf("expected error to include missing path, got %v", err)
+		}
+	})
+
+	t.Run("logical volume path is derived when lvPath is empty", func(t *testing.T) {
+		image := api.Image{
+			Spec: &api.ImageSpec{
+				VolumeGroup:   util.StringPtr("vg1"),
+				LogicalVolume: util.StringPtr("boot-image"),
+			},
+		}
+
+		err := CheckImageBackingStore(image)
+		if err == nil {
+			t.Fatal("expected missing logical volume error")
+		}
+		if !strings.Contains(err.Error(), "/dev/vg1/boot-image") {
+			t.Fatalf("expected derived lv path in error, got %v", err)
+		}
+	})
+}

--- a/pkg/marmotd/volume_backing_store_test.go
+++ b/pkg/marmotd/volume_backing_store_test.go
@@ -1,0 +1,70 @@
+package marmotd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestCheckVolumeBackingStore(t *testing.T) {
+	t.Run("existing qcow2 file passes", func(t *testing.T) {
+		tempDir := t.TempDir()
+		qcow2Path := filepath.Join(tempDir, "disk.qcow2")
+
+		if err := os.WriteFile(qcow2Path, []byte("qcow2"), 0644); err != nil {
+			t.Fatalf("failed to create qcow2 file: %v", err)
+		}
+
+		volume := api.Volume{
+			Spec: &api.VolSpec{
+				Type: util.StringPtr("qcow2"),
+				Path: util.StringPtr(qcow2Path),
+			},
+		}
+
+		if err := CheckVolumeBackingStore(volume); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("missing qcow2 file is detected", func(t *testing.T) {
+		missingPath := filepath.Join(t.TempDir(), "missing.qcow2")
+
+		volume := api.Volume{
+			Spec: &api.VolSpec{
+				Type: util.StringPtr("qcow2"),
+				Path: util.StringPtr(missingPath),
+			},
+		}
+
+		err := CheckVolumeBackingStore(volume)
+		if err == nil {
+			t.Fatal("expected missing qcow2 error")
+		}
+		if !strings.Contains(err.Error(), missingPath) {
+			t.Fatalf("expected error to include missing path, got %v", err)
+		}
+	})
+
+	t.Run("logical volume path is derived when path is empty", func(t *testing.T) {
+		volume := api.Volume{
+			Spec: &api.VolSpec{
+				Type:          util.StringPtr("lvm"),
+				VolumeGroup:   util.StringPtr("vg1"),
+				LogicalVolume: util.StringPtr("oslv-demo"),
+			},
+		}
+
+		err := CheckVolumeBackingStore(volume)
+		if err == nil {
+			t.Fatal("expected missing logical volume error")
+		}
+		if !strings.Contains(err.Error(), "/dev/vg1/oslv-demo") {
+			t.Fatalf("expected derived lv path in error, got %v", err)
+		}
+	})
+}

--- a/pkg/marmotd/volumes.go
+++ b/pkg/marmotd/volumes.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/takara9/marmot/api"
@@ -254,6 +257,57 @@ func (m *Marmot) UpdateVolumeById(id string, volSpec api.Volume) (*api.Volume, e
 	}
 
 	return &vol, nil
+}
+
+func CheckVolumeBackingStore(volume api.Volume) error {
+	if volume.Spec == nil {
+		return nil
+	}
+
+	backingPath, backingType := getVolumeBackingStore(volume.Spec)
+	if backingPath == "" {
+		return nil
+	}
+
+	if _, err := os.Stat(backingPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("missing volume backing store: %s %s", backingType, backingPath)
+		}
+		return fmt.Errorf("failed to inspect %s %s: %w", backingType, backingPath, err)
+	}
+
+	return nil
+}
+
+func getVolumeBackingStore(spec *api.VolSpec) (string, string) {
+	if spec == nil {
+		return "", ""
+	}
+
+	volType := strings.TrimSpace(util.OrDefault(spec.Type, ""))
+	switch volType {
+	case "qcow2":
+		path := strings.TrimSpace(util.OrDefault(spec.Path, ""))
+		if path == "" {
+			return "", ""
+		}
+		return path, "qcow2 file"
+	case "lvm":
+		path := strings.TrimSpace(util.OrDefault(spec.Path, ""))
+		if path != "" {
+			return path, "logical volume"
+		}
+
+		volumeGroup := strings.TrimSpace(util.OrDefault(spec.VolumeGroup, ""))
+		logicalVolume := strings.TrimSpace(util.OrDefault(spec.LogicalVolume, ""))
+		if volumeGroup == "" || logicalVolume == "" {
+			return "", ""
+		}
+
+		return filepath.Join("/dev", volumeGroup, logicalVolume), "logical volume"
+	default:
+		return "", ""
+	}
 }
 
 // 以下は未実装


### PR DESCRIPTION
今回の変更は、Issue 277 対応として、イメージとボリュームの実体欠損を controller が定期監視し、状態へ反映できるようにしたものです。

主な内容は 3 点です。

イメージの実体監視を追加
image.go に、qcow2 ファイルと LV の存在を確認する CheckImageBackingStore を追加しました。
image-controller.go では、AVAILABLE 状態のイメージを監視し、実体が欠損していれば IMAGE_DELETED へ更新するようにしました。
あわせて db-image.go に UpdateImageStatusMessage を追加し、欠損理由を Status.Message に保存できるようにしています。

ボリュームの実体監視を追加
volumes.go に、qcow2 ファイルまたは LV の存在を確認する CheckVolumeBackingStore を追加しました。
volume-controller.go では、AVAILABLE 状態のボリュームを監視し、実体が欠損していれば状態を更新するようにしました。
DB 更新用に db-volumes.go の UpdateVolumeStatus を message 対応へ拡張しています。

ボリューム欠損用の専用状態を追加
ボリューム欠損は ERROR と分離し、db-volumes.go に VOLUME_UNAVAILABLE を追加しました。
これにより、作成失敗や削除失敗のような処理エラーは ERROR、実体消失は UNAVAILABLE として区別できます。
volume-controller.go も UNAVAILABLE に変更済みです。

テストは以下を追加し、focused な確認を実施しています。
image_backing_store_test.go
volume_backing_store_test.go

確認結果として、pkg/controller のビルドと、上記 backing store テストは通過しています。統合系の pkg/marmotd 全体テストは既存の権限前提テストがあるため、この環境では一部対象外です。