### PR TITLE
スケジュールのロジック変更

### DIFF
--- a/cmd/mactl/cmd/common.go
+++ b/cmd/mactl/cmd/common.go
@@ -22,6 +22,14 @@ func creationTime(s *api.Status) time.Time {
 	return time.Time{}
 }
 
+// deletionMarker は削除要求済み(DeletionTimeStamp != nil)なら "*" を返す。
+func deletionMarker(status *api.Status) string {
+	if status != nil && status.DeletionTimeStamp != nil {
+		return "*"
+	}
+	return ""
+}
+
 // コンフィグからエンドポイントを取り出してセットする
 //
 // 優先順位:

--- a/cmd/mactl/cmd/image_list.go
+++ b/cmd/mactl/cmd/image_list.go
@@ -66,10 +66,10 @@ var imageListCmd = &cobra.Command{
 					return creationTime(data[i].Status).Before(creationTime(data[j].Status))
 				})
 
-				fmt.Printf("  %2s  %-8s  %-16s  %-12s  %-12s  %-7s  %-4s  %-5s  %-25s\n", "No", "IMAGE-ID", "IMAGE-NAME", "STATUS", "NODE-NAME", "ROLE", "LV", "QCOW2", "CREATED-AT")
+				fmt.Printf("  %2s  %1s%-8s  %-16s  %-12s  %-12s  %-7s  %-4s  %-5s  %-25s\n", "No", "", "IMAGE-ID", "IMAGE-NAME", "STATUS", "NODE-NAME", "ROLE", "LV", "QCOW2", "CREATED-AT")
 				for i, image := range data {
 					fmt.Printf("  %2d", i+1)
-					fmt.Printf("  %-8v", image.Id)
+					fmt.Printf("  %1v%-8v", deletionMarker(image.Status), image.Id)
 					if image.Metadata.Name != nil {
 						fmt.Printf("  %-16v", *image.Metadata.Name)
 					} else {

--- a/cmd/mactl/cmd/network_list.go
+++ b/cmd/mactl/cmd/network_list.go
@@ -138,10 +138,11 @@ func filterNetworksForList(data []api.VirtualNetwork, showAll bool) []api.Virtua
 func formatNetworkListText(data []api.VirtualNetwork) string {
 	var builder strings.Builder
 
-	fmt.Fprintf(&builder, "  %2s  %-10s  %-20s  %-12s  %-20s  %-18s  %-20s\n", "No", "NETWORK-ID", "NETWORK-NAME", "NODE-NAME", "BRIDGE-NAME", "IP-NET", "STATUS")
+	fmt.Fprintf(&builder, "  %2s  %1s%-10s  %-20s  %-12s  %-20s  %-18s  %-20s\n", "No", "", "NETWORK-ID", "NETWORK-NAME", "NODE-NAME", "BRIDGE-NAME", "IP-NET", "STATUS")
 	for i, network := range data {
-		fmt.Fprintf(&builder, "  %2d  %-10v  %-20v  %-12v  %-20v  %-18v  %-20v\n",
+		fmt.Fprintf(&builder, "  %2d  %1s%-10v  %-20v  %-12v  %-20v  %-18v  %-20v\n",
 			i+1,
+			deletionMarker(network.Status),
 			network.Id,
 			stringValue(network.Metadata, func(m *api.Metadata) *string { return m.Name }),
 			stringValue(network.Metadata, func(m *api.Metadata) *string { return m.NodeName }),

--- a/cmd/mactl/cmd/network_list_test.go
+++ b/cmd/mactl/cmd/network_list_test.go
@@ -43,6 +43,26 @@ var _ = Describe("formatNetworkListText", func() {
 		Expect(strings.Contains(output, "10.10.0.0/24")).To(BeTrue(), output)
 		Expect(strings.Contains(output, db.NetworkStatus[int(db.NETWORK_ACTIVE)])).To(BeTrue(), output)
 	})
+
+	It("prefixes ID with * when DeletionTimeStamp is set", func() {
+		now := time.Now()
+		name := "test-net-deleting"
+		statusText := "DELETING"
+
+		output := formatNetworkListText([]api.VirtualNetwork{{
+			Id: "net99",
+			Metadata: &api.Metadata{
+				Name: &name,
+			},
+			Status: &api.Status{
+				Status:            &statusText,
+				StatusCode:        int(db.NETWORK_DELETING),
+				DeletionTimeStamp: &now,
+			},
+		}})
+
+		Expect(strings.Contains(output, "*net99")).To(BeTrue(), output)
+	})
 })
 
 var _ = Describe("network list sort", func() {

--- a/cmd/mactl/cmd/server_create.go
+++ b/cmd/mactl/cmd/server_create.go
@@ -62,8 +62,8 @@ var serverCreateCmd = &cobra.Command{
 			}
 		}
 
-		if conf.Comment != nil {
-			virtualServer.Metadata.Comment = util.StringPtr(*conf.Comment)
+		if comment := pickServerComment(conf); comment != nil {
+			virtualServer.Metadata.Comment = util.StringPtr(*comment)
 		}
 		// 無設定を許容、デフォルトをAPI側に任せる
 		if conf.Cpu != nil {
@@ -227,4 +227,14 @@ var serverCreateCmd = &cobra.Command{
 func init() {
 	serverCmd.AddCommand(serverCreateCmd)
 	serverCreateCmd.Flags().StringVarP(&configFilename, "configfile", "f", "vm-server.yaml", "Configuration file or raw URL for the server")
+}
+
+func pickServerComment(conf config.Server) *string {
+	if conf.Metadata != nil && conf.Metadata.Comment != nil {
+		return conf.Metadata.Comment
+	}
+	if conf.MetadataLegacy != nil && conf.MetadataLegacy.Comment != nil {
+		return conf.MetadataLegacy.Comment
+	}
+	return conf.Comment
 }

--- a/cmd/mactl/cmd/server_list.go
+++ b/cmd/mactl/cmd/server_list.go
@@ -90,7 +90,7 @@ var serverListCmd = &cobra.Command{
 func formatServerListText(data []api.Server) string {
 	var builder strings.Builder
 
-	builder.WriteString(fmt.Sprintf("  %2s  %-10s  %-20s  %-12s  %-3s  %-8s  %-12s  %-15s  %-15s\n", "No", "Server-ID", "Server-Name", "Status", "CPU", "RAM(MB)", "Node", "IP-Address", "Network"))
+	builder.WriteString(fmt.Sprintf("  %2s  %-10s  %-20s  %-12s  %-3s  %-8s  %-12s  %-15s  %-15s\n", "NO", "SERVER-ID", "SERVER-NAME", "STATUS", "CPU", "RAM(MB)", "NODE", "IP-ADDRESS", "NETWORK"))
 	for i, server := range data {
 		networkLines := serverNetworkLines(server)
 		builder.WriteString(fmt.Sprintf("  %2d  %-10v  %-20v  %-12v  %-3v  %-8v  %-12v  %-15v  %-15v\n",

--- a/cmd/mactl/cmd/server_list.go
+++ b/cmd/mactl/cmd/server_list.go
@@ -90,11 +90,12 @@ var serverListCmd = &cobra.Command{
 func formatServerListText(data []api.Server) string {
 	var builder strings.Builder
 
-	builder.WriteString(fmt.Sprintf("  %2s  %-10s  %-20s  %-12s  %-3s  %-8s  %-12s  %-15s  %-15s\n", "NO", "SERVER-ID", "SERVER-NAME", "STATUS", "CPU", "RAM(MB)", "NODE", "IP-ADDRESS", "NETWORK"))
+	builder.WriteString(fmt.Sprintf("  %2s  %1s%-10s  %-20s  %-12s  %-3s  %-8s  %-12s  %-15s  %-15s\n", "NO", "", "SERVER-ID", "SERVER-NAME", "STATUS", "CPU", "RAM(MB)", "NODE", "IP-ADDRESS", "NETWORK"))
 	for i, server := range data {
 		networkLines := serverNetworkLines(server)
-		builder.WriteString(fmt.Sprintf("  %2d  %-10v  %-20v  %-12v  %-3v  %-8v  %-12v  %-15v  %-15v\n",
+		builder.WriteString(fmt.Sprintf("  %2d  %1s%-10v  %-20v  %-12v  %-3v  %-8v  %-12v  %-15v  %-15v\n",
 			i+1,
+			deletionMarker(server.Status),
 			server.Id,
 			serverDisplayName(server),
 			serverStatusText(server),
@@ -106,7 +107,8 @@ func formatServerListText(data []api.Server) string {
 		))
 
 		for _, networkLine := range networkLines[1:] {
-			builder.WriteString(fmt.Sprintf("  %2s  %-10s  %-20s  %-12s  %-3s  %-8s  %-12s  %-15v  %-15v\n",
+			builder.WriteString(fmt.Sprintf("  %2s  %1s%-10s  %-20s  %-12s  %-3s  %-8s  %-12s  %-15v  %-15v\n",
+				"",
 				"",
 				"",
 				"",

--- a/cmd/mactl/cmd/server_list_test.go
+++ b/cmd/mactl/cmd/server_list_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -70,5 +71,25 @@ var _ = Describe("formatServerListText", func() {
 		Expect(lines).To(HaveLen(2), output)
 		Expect(lines[1]).To(ContainSubstring("592a2"), output)
 		Expect(lines[1]).To(ContainSubstring("N/A"), output)
+	})
+
+	It("prefixes ID with * when DeletionTimeStamp is set", func() {
+		name := "test-server-deleting"
+		now := time.Now()
+
+		output := formatServerListText([]api.Server{{
+			Id: "a1b2c",
+			Metadata: &api.Metadata{
+				Name: &name,
+			},
+			Status: &api.Status{
+				StatusCode:         int(db.SERVER_DELETING),
+				DeletionTimeStamp: &now,
+			},
+		}})
+
+		lines := strings.Split(strings.TrimSpace(output), "\n")
+		Expect(lines).To(HaveLen(2), output)
+		Expect(lines[1]).To(ContainSubstring("*a1b2c"), output)
 	})
 })

--- a/cmd/mactl/cmd/server_list_test.go
+++ b/cmd/mactl/cmd/server_list_test.go
@@ -38,7 +38,7 @@ var _ = Describe("formatServerListText", func() {
 
 		lines := strings.Split(strings.TrimSpace(output), "\n")
 		Expect(lines).To(HaveLen(4), output)
-		Expect(lines[0]).To(ContainSubstring("IP-Address"), output)
+		Expect(lines[0]).To(ContainSubstring("IP-ADDRESS"), output)
 		Expect(lines[1]).To(ContainSubstring("3f738"), output)
 		Expect(lines[1]).To(ContainSubstring("192.168.100.2"), output)
 		Expect(lines[1]).To(ContainSubstring("test-net-4"), output)

--- a/cmd/mactl/cmd/volume_list.go
+++ b/cmd/mactl/cmd/volume_list.go
@@ -40,7 +40,7 @@ var volumeListCmd = &cobra.Command{
 					return creationTime(data[i].Status).Before(creationTime(data[j].Status))
 				})
 
-				fmt.Printf("%-2v  %-6v  %-16v  %-4v  %-5v  %-8v  %-12v  %-20v\n", "No", "Id", "Name", "Kind", "Type", "Size(GB)", "Status", "Path")
+				fmt.Printf("%-2v  %-6v  %-16v  %-4v  %-5v  %-8v  %-12v  %-20v\n", "NO", "ID", "NAME", "KIND", "TYPE", "SIZE(GB)", "STATUS", "PATH")
 				for i, v := range data {
 					fmt.Printf("%2d", i+1)
 					fmt.Printf("  %-6v", v.Id)

--- a/cmd/mactl/cmd/volume_list.go
+++ b/cmd/mactl/cmd/volume_list.go
@@ -40,10 +40,10 @@ var volumeListCmd = &cobra.Command{
 					return creationTime(data[i].Status).Before(creationTime(data[j].Status))
 				})
 
-				fmt.Printf("%-2v  %-6v  %-16v  %-4v  %-5v  %-8v  %-12v  %-20v\n", "NO", "ID", "NAME", "KIND", "TYPE", "SIZE(GB)", "STATUS", "PATH")
+				fmt.Printf("%-2v  %1v%-6v  %-16v  %-4v  %-5v  %-8v  %-12v  %-20v\n", "NO", "", "ID", "NAME", "KIND", "TYPE", "SIZE(GB)", "STATUS", "PATH")
 				for i, v := range data {
 					fmt.Printf("%2d", i+1)
-					fmt.Printf("  %-6v", v.Id)
+					fmt.Printf("  %1v%-6v", deletionMarker(v.Status), v.Id)
 					fmt.Printf("  %-16v", *v.Metadata.Name)
 					fmt.Printf("  %-4v", *v.Spec.Kind)
 					fmt.Printf("  %-5v", *v.Spec.Type)

--- a/pkg/config/config-server.go
+++ b/pkg/config/config-server.go
@@ -9,16 +9,18 @@ type Auth struct {
 
 // Server defines model for Server.
 type Server struct {
-	Name       string     `yaml:"name"`
-	Cpu        *int       `yaml:"cpu,omitempty"`
-	Memory     *int       `yaml:"memory,omitempty"`
-	OsVariant  *string    `yaml:"os_variant,omitempty"`
-	BootVolume *Volume    `yaml:"boot_volume,omitempty"`
-	Playbook   *string    `yaml:"playbook,omitempty"`
-	Network    *[]Network `yaml:"network,omitempty"`
-	Storage    *[]Volume  `yaml:"storage,omitempty"`
-	Auth       *Auth      `yaml:"auth,omitempty"`
-	Comment    *string    `yaml:"comment,omitempty"`
+	Name           string     `yaml:"name"`
+	Cpu            *int       `yaml:"cpu,omitempty"`
+	Memory         *int       `yaml:"memory,omitempty"`
+	OsVariant      *string    `yaml:"os_variant,omitempty"`
+	BootVolume     *Volume    `yaml:"boot_volume,omitempty"`
+	Playbook       *string    `yaml:"playbook,omitempty"`
+	Network        *[]Network `yaml:"network,omitempty"`
+	Storage        *[]Volume  `yaml:"storage,omitempty"`
+	Auth           *Auth      `yaml:"auth,omitempty"`
+	Comment        *string    `yaml:"comment,omitempty"`
+	Metadata       *Metadata  `yaml:"metadata,omitempty"`
+	MetadataLegacy *Metadata  `yaml:"Metadata,omitempty"`
 }
 
 // Volume defines model for Volume.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -65,4 +65,36 @@ var _ = Describe("ReadYamlConfig", func() {
 		err := config.ReadYamlConfig(server.URL, &conf)
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("reads metadata.comment from a YAML config", func() {
+		tmpDir := GinkgoT().TempDir()
+		configPath := filepath.Join(tmpDir, "server-metadata.yaml")
+		content := "name: metadata-server\nmetadata:\n  comment: created-from-metadata\n"
+
+		err := os.WriteFile(configPath, []byte(content), 0o600)
+		Expect(err).NotTo(HaveOccurred())
+
+		var conf config.Server
+		err = config.ReadYamlConfig(configPath, &conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conf.Metadata).NotTo(BeNil())
+		Expect(conf.Metadata.Comment).NotTo(BeNil())
+		Expect(*conf.Metadata.Comment).To(Equal("created-from-metadata"))
+	})
+
+	It("reads Metadata.comment from a YAML config", func() {
+		tmpDir := GinkgoT().TempDir()
+		configPath := filepath.Join(tmpDir, "server-Metadata.yaml")
+		content := "name: metadata-server\nMetadata:\n  comment: created-from-Metadata\n"
+
+		err := os.WriteFile(configPath, []byte(content), 0o600)
+		Expect(err).NotTo(HaveOccurred())
+
+		var conf config.Server
+		err = config.ReadYamlConfig(configPath, &conf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conf.MetadataLegacy).NotTo(BeNil())
+		Expect(conf.MetadataLegacy.Comment).NotTo(BeNil())
+		Expect(*conf.MetadataLegacy.Comment).To(Equal("created-from-Metadata"))
+	})
 })

--- a/pkg/marmotd/scheduler.go
+++ b/pkg/marmotd/scheduler.go
@@ -78,7 +78,7 @@ func parseHostIDHex(v string) (uint32, bool) {
 }
 
 // SelectNode はアクティブなホスト群からスコアが最良のノード名を返す。
-// スコアは RunningVMs の数（少ないほど優先）。同点の場合は NodeName 昇順。
+// スコアは割り当て済みVM数（TotalVMs, 少ないほど優先）。同点の場合は NodeName 昇順。
 func SelectNode(statuses []api.HostStatus) (string, error) {
 	active := filterActiveHosts(statuses)
 	if len(active) == 0 {
@@ -97,10 +97,10 @@ func SelectNode(statuses []api.HostStatus) (string, error) {
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
-		runningI := runningVMs(candidates[i])
-		runningJ := runningVMs(candidates[j])
-		if runningI != runningJ {
-			return runningI < runningJ
+		allocatedI := allocatedVMs(candidates[i])
+		allocatedJ := allocatedVMs(candidates[j])
+		if allocatedI != allocatedJ {
+			return allocatedI < allocatedJ
 		}
 		// 同点の場合はノード名昇順（決定的な選択）
 		return *candidates[i].NodeName < *candidates[j].NodeName
@@ -109,10 +109,10 @@ func SelectNode(statuses []api.HostStatus) (string, error) {
 	return *candidates[0].NodeName, nil
 }
 
-// runningVMs は HostAllocation.RunningVMs の値を返す。未設定の場合は 0。
-func runningVMs(s api.HostStatus) int {
-	if s.Allocation != nil && s.Allocation.RunningVMs != nil {
-		return *s.Allocation.RunningVMs
+// allocatedVMs は HostAllocation.TotalVMs の値を返す。未設定の場合は 0。
+func allocatedVMs(s api.HostStatus) int {
+	if s.Allocation != nil && s.Allocation.TotalVMs != nil {
+		return *s.Allocation.TotalVMs
 	}
 	return 0
 }

--- a/pkg/marmotd/scheduler_test.go
+++ b/pkg/marmotd/scheduler_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 // テスト用ヘルパー: HostStatus を生成する
-func newHostStatus(nodeName, hostID string, runningVMs int, updatedSecondsAgo int) api.HostStatus {
+func newHostStatus(nodeName, hostID string, totalVMs int, updatedSecondsAgo int) api.HostStatus {
 	t := time.Now().Add(-time.Duration(updatedSecondsAgo) * time.Second)
 	return api.HostStatus{
 		NodeName:    util.StringPtr(nodeName),
 		HostId:      util.StringPtr(hostID),
 		LastUpdated: &t,
 		Allocation: &api.HostAllocation{
-			RunningVMs: util.IntPtrInt(runningVMs),
+			TotalVMs: util.IntPtrInt(totalVMs),
 		},
 	}
 }
@@ -102,8 +102,8 @@ var _ = Describe("スケジューラー", func() {
 	})
 
 	Describe("SelectNode", func() {
-		Context("RunningVMs が異なる複数のアクティブノードがある場合", func() {
-			It("RunningVMs が最小のノードを選択する", func() {
+		Context("割り当て済みVM数(TotalVMs) が異なる複数のアクティブノードがある場合", func() {
+			It("TotalVMs が最小のノードを選択する", func() {
 				statuses := []api.HostStatus{
 					newHostStatus("hv1", "00000001", 5, 5),
 					newHostStatus("hv2", "00000002", 2, 5),
@@ -115,7 +115,7 @@ var _ = Describe("スケジューラー", func() {
 			})
 		})
 
-		Context("RunningVMs が同点の場合", func() {
+		Context("TotalVMs が同点の場合", func() {
 			It("NodeName 辞書順で先頭のノードを選択する（決定的）", func() {
 				statuses := []api.HostStatus{
 					newHostStatus("hv3", "00000003", 3, 5),
@@ -129,7 +129,7 @@ var _ = Describe("スケジューラー", func() {
 		})
 
 		Context("Allocation が未設定のノードがある場合", func() {
-			It("RunningVMs = 0 として扱い選択する", func() {
+			It("TotalVMs = 0 として扱い選択する", func() {
 				t := time.Now().Add(-5 * time.Second)
 				statuses := []api.HostStatus{
 					{NodeName: util.StringPtr("hv1"), HostId: util.StringPtr("00000001"), LastUpdated: &t, Allocation: nil},


### PR DESCRIPTION
## 概要
スケジューラーのノード選定基準を変更し、RUNNING台数ではなく割当済み台数が少ないノードを優先するようにしました。
あわせて、mactl の一覧ヘッダー表記を大文字に統一しました。

## 変更内容
スケジューラーの選定ロジック変更

- scheduler.go
  - SelectNode の比較指標を RunningVMs から TotalVMs に変更
  - 同点時は従来通り NodeName 昇順で決定
- スケジューラーテストの更新
  - scheduler_test.go
  - テストデータと説明文を TotalVMs 基準に合わせて更新
- mactl 一覧ヘッダーの大文字統一
  - server_list.go
  - server_list_test.go
  - volume_list.go

## 動作確認
- go test ./cmd/mactl/cmd -run Test -count=1
- go test ./pkg/marmotd -run TestMarmotd -ginkgo.focus="SelectNode" -count=1
- go test ./pkg/controller -count=1 （テストファイルなし）


## 補足
pkg/controller 側は scheduler-controller.go から SelectNode を呼び出しているため、実際の判定変更は scheduler 側実装の更新で反映されます。