### PR TITLE
ボリュームの機能洗練化

### DIFF
--- a/cmd/mactl/cmd/server_create.go
+++ b/cmd/mactl/cmd/server_create.go
@@ -5,15 +5,44 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/client"
 	"github.com/takara9/marmot/pkg/config"
 	"github.com/takara9/marmot/pkg/util"
 	"go.yaml.in/yaml/v3"
 )
 
 var configFilename string
+
+// resolveVolumeIdByName は名前でボリュームを検索し、一意に特定できた場合はそのIDを返す。
+// 同名ボリュームが複数ある場合はエラーを返す。
+func resolveVolumeIdByName(m *client.MarmotEndpoint, name string) (string, error) {
+	byteBody, _, err := m.ListVolumes()
+	if err != nil {
+		return "", fmt.Errorf("ListVolumes failed: %w", err)
+	}
+	var volumes []api.Volume
+	if err := json.Unmarshal(byteBody, &volumes); err != nil {
+		return "", fmt.Errorf("failed to parse volume list: %w", err)
+	}
+	var matched []api.Volume
+	for _, v := range volumes {
+		if v.Metadata != nil && v.Metadata.Name != nil && *v.Metadata.Name == name {
+			matched = append(matched, v)
+		}
+	}
+	switch len(matched) {
+	case 0:
+		return "", fmt.Errorf("ボリューム名 %q に一致するボリュームが見つかりません", name)
+	case 1:
+		return matched[0].Id, nil
+	default:
+		return "", fmt.Errorf("ボリューム名 %q に一致するボリュームが複数存在します (%d件)", name, len(matched))
+	}
+}
 
 var serverCreateCmd = &cobra.Command{
 	Use:   "create",
@@ -65,6 +94,12 @@ var serverCreateCmd = &cobra.Command{
 		if comment := pickServerComment(conf); comment != nil {
 			virtualServer.Metadata.Comment = util.StringPtr(*comment)
 		}
+		if conf.NodeSelector != nil {
+			node := strings.TrimSpace(*conf.NodeSelector)
+			if node != "" {
+				virtualServer.Metadata.NodeName = util.StringPtr(node)
+			}
+		}
 		// 無設定を許容、デフォルトをAPI側に任せる
 		if conf.Cpu != nil {
 			virtualServer.Spec.Cpu = util.IntPtrInt(*conf.Cpu)
@@ -79,10 +114,30 @@ var serverCreateCmd = &cobra.Command{
 		}
 
 		if conf.BootVolume != nil {
-			virtualServer.Spec.BootVolume.Metadata.Name = util.StringPtr("boot")
-			virtualServer.Spec.BootVolume.Spec.Type = util.StringPtr(*conf.BootVolume.Type)
-			if conf.BootVolume.Size != nil {
-				virtualServer.Spec.BootVolume.Spec.Size = util.IntPtrInt(*conf.BootVolume.Size)
+			bootPvId := ""
+			if conf.BootVolume.PersistentVolumeId != nil && *conf.BootVolume.PersistentVolumeId != "" {
+				bootPvId = *conf.BootVolume.PersistentVolumeId
+			} else if conf.BootVolume.PersistentVolumeName != nil && *conf.BootVolume.PersistentVolumeName != "" {
+				resolved, err := resolveVolumeIdByName(m, *conf.BootVolume.PersistentVolumeName)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "boot_volume:", err)
+					return err
+				}
+				bootPvId = resolved
+			}
+			if bootPvId != "" {
+				virtualServer.Spec.BootVolume.Metadata.Id = util.StringPtr(bootPvId)
+				virtualServer.Spec.BootVolume.Id = bootPvId
+				virtualServer.Spec.BootVolume.Metadata.Name = nil
+				virtualServer.Spec.BootVolume.Spec = nil
+			} else {
+				virtualServer.Spec.BootVolume.Metadata.Name = util.StringPtr("boot")
+				if conf.BootVolume.Type != nil {
+					virtualServer.Spec.BootVolume.Spec.Type = util.StringPtr(*conf.BootVolume.Type)
+				}
+				if conf.BootVolume.Size != nil {
+					virtualServer.Spec.BootVolume.Spec.Size = util.IntPtrInt(*conf.BootVolume.Size)
+				}
 			}
 		}
 
@@ -162,11 +217,31 @@ var serverCreateCmd = &cobra.Command{
 			for i, vol := range *conf.Storage {
 				meta := api.Metadata{}
 				volumes[i].Metadata = &meta
+					pvId := ""
+				if vol.PersistentVolumeId != nil && *vol.PersistentVolumeId != "" {
+					pvId = *vol.PersistentVolumeId
+				} else if vol.PersistentVolumeName != nil && *vol.PersistentVolumeName != "" {
+					resolved, err := resolveVolumeIdByName(m, *vol.PersistentVolumeName)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "storage[%d]: %v\n", i, err)
+						return err
+					}
+					pvId = resolved
+				}
+				if pvId != "" {
+					volumes[i].Metadata.Id = util.StringPtr(pvId)
+					volumes[i].Id = pvId
+					continue
+				}
 				volumes[i].Metadata.Name = util.StringPtr(vol.Name)
-				volumes[i].Metadata.Comment = util.StringPtr(*vol.Comment)
+				if vol.Comment != nil {
+					volumes[i].Metadata.Comment = util.StringPtr(*vol.Comment)
+				}
 				spec := api.VolSpec{}
 				volumes[i].Spec = &spec
-				volumes[i].Spec.Size = util.IntPtrInt(*vol.Size)
+				if vol.Size != nil {
+					volumes[i].Spec.Size = util.IntPtrInt(*vol.Size)
+				}
 				if vol.Type == nil {
 					volumes[i].Spec.Type = util.StringPtr("qcow2")
 				} else {

--- a/cmd/mactl/cmd/server_create.go
+++ b/cmd/mactl/cmd/server_create.go
@@ -217,7 +217,7 @@ var serverCreateCmd = &cobra.Command{
 			for i, vol := range *conf.Storage {
 				meta := api.Metadata{}
 				volumes[i].Metadata = &meta
-					pvId := ""
+				pvId := ""
 				if vol.PersistentVolumeId != nil && *vol.PersistentVolumeId != "" {
 					pvId = *vol.PersistentVolumeId
 				} else if vol.PersistentVolumeName != nil && *vol.PersistentVolumeName != "" {

--- a/cmd/mactl/cmd/volume_detail.go
+++ b/cmd/mactl/cmd/volume_detail.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -35,7 +37,10 @@ var volumeDetailCmd = &cobra.Command{
 
 			switch outputStyle {
 			case "text":
-				fmt.Println("ボリュームの詳細情報。Id", volumeId)
+				printVolumeDetailReport(data)
+				if len(args) > 1 {
+					fmt.Println()
+				}
 				continue
 
 			case "json":
@@ -69,4 +74,58 @@ var volumeDetailCmd = &cobra.Command{
 
 func init() {
 	volumeCmd.AddCommand(volumeDetailCmd)
+}
+
+func printVolumeDetailReport(volume api.Volume) {
+	fmt.Println("Volume Details")
+	fmt.Println("Summary")
+	printVolumeDetailField("Name", stringValue(volume.Metadata, func(m *api.Metadata) *string { return m.Name }))
+	printVolumeDetailField("Id", formatID(volume.Id))
+	printVolumeDetailField("State", formatVolumeStatus(volume.Status))
+	printVolumeDetailField("Kind", stringValue(volume.Spec, func(s *api.VolSpec) *string { return s.Kind }))
+	printVolumeDetailField("Type", stringValue(volume.Spec, func(s *api.VolSpec) *string { return s.Type }))
+	printVolumeDetailField("Size", intValue(volume.Spec, func(s *api.VolSpec) *int { return s.Size }, " GB"))
+	fmt.Println()
+
+	fmt.Println("Status")
+	printVolumeDetailField("Message", stringValue(volume.Status, func(s *api.Status) *string { return s.Message }))
+	printVolumeDetailField("Created At", timeValue(volume.Status, func(s *api.Status) *time.Time { return s.CreationTimeStamp }))
+	printVolumeDetailField("Last Updated", timeValue(volume.Status, func(s *api.Status) *time.Time { return s.LastUpdateTimeStamp }))
+	fmt.Println()
+
+	fmt.Println("Storage")
+	printVolumeDetailField("Path", stringValue(volume.Spec, func(s *api.VolSpec) *string { return s.Path }))
+	printVolumeDetailField("Volume Group", stringValue(volume.Spec, func(s *api.VolSpec) *string { return s.VolumeGroup }))
+	printVolumeDetailField("Logical Vol.", stringValue(volume.Spec, func(s *api.VolSpec) *string { return s.LogicalVolume }))
+	printVolumeDetailField("OS Variant", stringValue(volume.Spec, func(s *api.VolSpec) *string { return s.OsVariant }))
+	if volume.Spec != nil && volume.Spec.Persistent != nil {
+		printVolumeDetailField("Persistent", boolValue(volume.Spec.Persistent))
+	} else {
+		printVolumeDetailField("Persistent", "N/A")
+	}
+	fmt.Println()
+
+	fmt.Println("Metadata")
+	printVolumeDetailField("Node Name", stringValue(volume.Metadata, func(m *api.Metadata) *string { return m.NodeName }))
+	printVolumeDetailField("UUID", stringValue(volume.Metadata, func(m *api.Metadata) *string { return m.Uuid }))
+	printVolumeDetailField("Comment", stringValue(volume.Metadata, func(m *api.Metadata) *string { return m.Comment }))
+	printVolumeDetailField("Key", stringValue(volume.Metadata, func(m *api.Metadata) *string { return m.Key }))
+}
+
+func printVolumeDetailField(label, value string) {
+	fmt.Printf("  %-13s %s\n", label+":", value)
+}
+
+func formatVolumeStatus(status *api.Status) string {
+	if status == nil {
+		return "N/A"
+	}
+	statusText := db.VolStatus[status.StatusCode]
+	if statusText == "" && status.Status != nil {
+		statusText = *status.Status
+	}
+	if statusText == "" {
+		statusText = fmt.Sprintf("UNKNOWN(%d)", status.StatusCode)
+	}
+	return fmt.Sprintf("%s (%d)", statusText, status.StatusCode)
 }

--- a/cmd/mactl/cmd/volume_list.go
+++ b/cmd/mactl/cmd/volume_list.go
@@ -40,11 +40,16 @@ var volumeListCmd = &cobra.Command{
 					return creationTime(data[i].Status).Before(creationTime(data[j].Status))
 				})
 
-				fmt.Printf("%-2v  %1v%-6v  %-16v  %-4v  %-5v  %-8v  %-12v  %-20v\n", "NO", "", "ID", "NAME", "KIND", "TYPE", "SIZE(GB)", "STATUS", "PATH")
+				fmt.Printf("%-2v  %1v%-6v  %-16v  %-10v  %-4v  %-5v  %-8v  %-12v  %-20v\n", "NO", "", "ID", "NAME", "NODE", "KIND", "TYPE", "SIZE(GB)", "STATUS", "PATH")
 				for i, v := range data {
+					nodeName := ""
+					if v.Metadata != nil && v.Metadata.NodeName != nil {
+						nodeName = *v.Metadata.NodeName
+					}
 					fmt.Printf("%2d", i+1)
 					fmt.Printf("  %1v%-6v", deletionMarker(v.Status), v.Id)
 					fmt.Printf("  %-16v", *v.Metadata.Name)
+					fmt.Printf("  %-10v", nodeName)
 					fmt.Printf("  %-4v", *v.Spec.Kind)
 					fmt.Printf("  %-5v", *v.Spec.Type)
 					fmt.Printf("  %-8v", *v.Spec.Size)

--- a/cmd/mactl/testdata/test-server-36-existing-volume-id.yaml
+++ b/cmd/mactl/testdata/test-server-36-existing-volume-id.yaml
@@ -1,0 +1,12 @@
+name: test-server-36
+cpu: 1
+memory: 1024
+os_variant: ubuntu22.04
+boot_volume:
+  persistent_volume_id: "b7fd113"
+storage:
+  - persistent_volume_id: "data1234"
+  - persistent_volume_name: "my-data-vol"
+network:
+  - name: "default"
+comment: "Attach existing volumes by id"

--- a/cmd/mactl/testdata/test-server-37-node-selector.yaml
+++ b/cmd/mactl/testdata/test-server-37-node-selector.yaml
@@ -1,0 +1,11 @@
+name: test-server-37
+cpu: 1
+memory: 1024
+os_variant: ubuntu24.04
+node-selector: "marmot1"
+boot_volume:
+  type: qcow2
+  size: 16
+network:
+  - name: "default"
+comment: "Schedule this server on a specific node"

--- a/pkg/config/config-server.go
+++ b/pkg/config/config-server.go
@@ -13,6 +13,7 @@ type Server struct {
 	Cpu            *int       `yaml:"cpu,omitempty"`
 	Memory         *int       `yaml:"memory,omitempty"`
 	OsVariant      *string    `yaml:"os_variant,omitempty"`
+	NodeSelector   *string    `yaml:"node-selector,omitempty"`
 	BootVolume     *VolSpec   `yaml:"boot_volume,omitempty"`
 	Playbook       *string    `yaml:"playbook,omitempty"`
 	Network        *[]Network `yaml:"network,omitempty"`
@@ -25,11 +26,13 @@ type Server struct {
 
 // VolSpec defines model for VolSpec.
 type VolSpec struct {
-	Name    string  `yaml:"name"`
-	Size    *int    `yaml:"size,omitempty"`
-	Comment *string `yaml:"comment,omitempty"`
-	Type    *string `yaml:"type,omitempty"`
-	Kind    *string `yaml:"kind,omitempty"`
+	Name               string  `yaml:"name"`
+	Size               *int    `yaml:"size,omitempty"`
+	Comment            *string `yaml:"comment,omitempty"`
+	Type               *string `yaml:"type,omitempty"`
+	Kind               *string `yaml:"kind,omitempty"`
+	PersistentVolumeId *string `yaml:"persistent_volume_id,omitempty"`
+	PersistentVolumeName *string `yaml:"persistent_volume_name,omitempty"`
 }
 
 type Route struct {

--- a/pkg/config/config-server.go
+++ b/pkg/config/config-server.go
@@ -26,12 +26,12 @@ type Server struct {
 
 // VolSpec defines model for VolSpec.
 type VolSpec struct {
-	Name               string  `yaml:"name"`
-	Size               *int    `yaml:"size,omitempty"`
-	Comment            *string `yaml:"comment,omitempty"`
-	Type               *string `yaml:"type,omitempty"`
-	Kind               *string `yaml:"kind,omitempty"`
-	PersistentVolumeId *string `yaml:"persistent_volume_id,omitempty"`
+	Name                 string  `yaml:"name"`
+	Size                 *int    `yaml:"size,omitempty"`
+	Comment              *string `yaml:"comment,omitempty"`
+	Type                 *string `yaml:"type,omitempty"`
+	Kind                 *string `yaml:"kind,omitempty"`
+	PersistentVolumeId   *string `yaml:"persistent_volume_id,omitempty"`
 	PersistentVolumeName *string `yaml:"persistent_volume_name,omitempty"`
 }
 


### PR DESCRIPTION
## 概要
mactl のサーバー作成YAMLとボリューム関連CLIを改善し、既存ボリューム再利用・ノード固定配置・可読性向上を行いました。

## 主な変更

- server create YAMLに persistent_volume_id を追加し、既存ボリュームID指定でアタッチ可能に対応
- existing_volume_id を persistent_volume_id に名称統一
- server create時、既存ボリューム指定時に Metadata.id だけでなく Volume.id も設定するよう修正
- server create YAMLに persistent_volume_name を追加
- persistent_volume_name 指定時は volume list から名前解決してIDに変換
- 同名ボリュームが複数ある場合はエラーで中断（誤アタッチ防止）
- server create YAMLに node-selector を追加
- node-selector 指定時は Metadata.nodeName に反映し、スケジューラーが再割当しない形で指定ノードに配置
- volume list の text出力に NODE 列（nodeName）を追加
- volume detail の text出力をセクション分けした整形表示へ改善（Summary/Status/Storage/Metadata）

## 互換性・注意点

YAMLキー existing_volume_id は persistent_volume_id に変更しました
persistent_volume_name は名前が一意な場合のみ使用可能です（重複時はエラー）

## 動作確認

- 実施コマンド:
  - go test ./cmd/mactl/cmd -run TestDoesNotExist -count=1
- 結果:
  - ビルド/コンパイル成功


## 期待効果

- 既存ボリューム再利用時の指定方法が柔軟化
- ボリューム誤指定のリスク低減
- サーバー配置先の明示化
- CLI text出力の可読性向上