### PR TITLE
iSCSIボリュームとVMの接続の実装

### DIFF
--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +19,121 @@ import (
 	"github.com/takara9/marmot/pkg/util"
 	"github.com/takara9/marmot/pkg/virt"
 )
+
+func findHostStatusByNodeName(statuses []api.HostStatus, nodeName string) *api.HostStatus {
+	node := strings.TrimSpace(nodeName)
+	if node == "" {
+		return nil
+	}
+	for i := range statuses {
+		if statuses[i].NodeName == nil {
+			continue
+		}
+		if strings.TrimSpace(*statuses[i].NodeName) == node {
+			return &statuses[i]
+		}
+	}
+	return nil
+}
+
+func normalizeISCSITargetName(targetIQN string) string {
+	t := strings.TrimSpace(targetIQN)
+	if t == "" {
+		return ""
+	}
+	if strings.Contains(t, "/") {
+		return t
+	}
+	return t + "/0"
+}
+
+func resolveISCSIServerNode(statuses []api.HostStatus) string {
+	active := filterActiveHosts(statuses)
+	if len(active) == 0 {
+		return ""
+	}
+
+	// 明示設定がある場合はその中から決定的に1つ選ぶ
+	type candidate struct {
+		nodeName string
+		hostID   uint32
+	}
+	var explicits []candidate
+	for _, s := range active {
+		if s.IscsiServer == nil || !*s.IscsiServer || s.NodeName == nil || s.HostId == nil {
+			continue
+		}
+		node := strings.TrimSpace(*s.NodeName)
+		if node == "" {
+			continue
+		}
+		hid, ok := parseHostIDHex(*s.HostId)
+		if !ok {
+			continue
+		}
+		explicits = append(explicits, candidate{nodeName: node, hostID: hid})
+	}
+	if len(explicits) > 0 {
+		sort.Slice(explicits, func(i, j int) bool {
+			if explicits[i].hostID != explicits[j].hostID {
+				return explicits[i].hostID < explicits[j].hostID
+			}
+			return explicits[i].nodeName < explicits[j].nodeName
+		})
+		return explicits[0].nodeName
+	}
+
+	for _, s := range active {
+		if s.NodeName == nil {
+			continue
+		}
+		node := strings.TrimSpace(*s.NodeName)
+		if node == "" {
+			continue
+		}
+		if IsSchedulerLeader(node, statuses) {
+			return node
+		}
+	}
+
+	return ""
+}
+
+func (m *Marmot) resolveISCSIDiskAttachment(nodeName string, disk api.Volume) (targetName, host, port, initiator string, err error) {
+	if m == nil || m.Db == nil {
+		return "", "", "", "", errors.New("marmot db is nil")
+	}
+	if disk.Spec == nil || disk.Spec.IscsiTargetIqn == nil {
+		return "", "", "", "", errors.New("iscsi target iqn is missing")
+	}
+
+	statuses, err := m.Db.GetAllHostStatus()
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	iscsiServerNode := resolveISCSIServerNode(statuses)
+	if iscsiServerNode == "" {
+		return "", "", "", "", errors.New("failed to resolve iscsi server node")
+	}
+	iscsiServerStatus := findHostStatusByNodeName(statuses, iscsiServerNode)
+	if iscsiServerStatus == nil || iscsiServerStatus.IpAddress == nil || strings.TrimSpace(*iscsiServerStatus.IpAddress) == "" {
+		return "", "", "", "", fmt.Errorf("iscsi server hoststatus ip is missing: %s", iscsiServerNode)
+	}
+
+	initiator = strings.TrimSpace(getISCSIInitiatorID())
+	if initiator == "" {
+		vmHostStatus := findHostStatusByNodeName(statuses, nodeName)
+		if vmHostStatus != nil && vmHostStatus.InitiatorId != nil {
+			initiator = strings.TrimSpace(*vmHostStatus.InitiatorId)
+		}
+	}
+	if initiator == "" {
+		return "", "", "", "", fmt.Errorf("iscsi initiator id is missing on vm host: %s", strings.TrimSpace(nodeName))
+	}
+
+	return normalizeISCSITargetName(*disk.Spec.IscsiTargetIqn), strings.TrimSpace(*iscsiServerStatus.IpAddress), "3260", initiator, nil
+}
 
 // サーバーの生成 コントローラーから呼び出される
 func (m *Marmot) CreateServerManage(id string) (string, error) {
@@ -542,11 +658,21 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 				}
 				virtSpec.DiskSpecs = append(virtSpec.DiskSpecs, ds)
 			case *disk.Spec.Type == "lvm":
-				ds := virt.DiskSpec{
-					Dev:  fmt.Sprintf("vd%c", 'b'+i),
-					Src:  *disk.Spec.Path,
-					Bus:  uint(11 + i),
-					Type: "raw",
+				ds := virt.DiskSpec{Dev: fmt.Sprintf("vd%c", 'b'+i), Bus: uint(11 + i)}
+				isISCSIDataDisk := disk.Spec.Iscsi != nil && *disk.Spec.Iscsi
+				if isISCSIDataDisk {
+					targetName, host, port, initiator, err := m.resolveISCSIDiskAttachment(assignedNodeName, disk)
+					if err != nil {
+						return "", err
+					}
+					ds.Type = "iscsi"
+					ds.ISCSITarget = targetName
+					ds.ISCSIHost = host
+					ds.ISCSIPort = port
+					ds.ISCSIInitiator = initiator
+				} else {
+					ds.Src = *disk.Spec.Path
+					ds.Type = "raw"
 				}
 				virtSpec.DiskSpecs = append(virtSpec.DiskSpecs, ds)
 			}
@@ -558,12 +684,12 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 
 	virtSpec.ChannelSpecs = []virt.ChannelSpec{
 		//{"unix", channelPath + "/" + channelFile, channelFile, "channel0", 1},
-		{"spicevmc", "", "com.redhat.spice.0", "channel1", 2},
+		{Type: "spicevmc", Path: "", Name: "com.redhat.spice.0", Alias: "channel1", Port: 2},
 	}
 	virtSpec.Clocks = []virt.ClockSpec{
-		{"rtc", "catchup", ""},
-		{"pit", "delay", ""},
-		{"hpet", "", "no"},
+		{Name: "rtc", TickPolicy: "catchup", Present: ""},
+		{Name: "pit", TickPolicy: "delay", Present: ""},
+		{Name: "hpet", TickPolicy: "", Present: "no"},
 	}
 
 	dom := virt.CreateDomainXML(virtSpec)

--- a/pkg/virt/libvirtXml2.go
+++ b/pkg/virt/libvirtXml2.go
@@ -20,10 +20,14 @@ func pciAddr(b, s, f uint) *libvirtxml.DomainAddress {
 func stringPtr(s string) *string { return &s }
 
 type DiskSpec struct {
-	Dev  string
-	Src  string
-	Bus  uint
-	Type string
+	Dev            string
+	Src            string
+	Bus            uint
+	Type           string
+	ISCSITarget    string
+	ISCSIHost      string
+	ISCSIPort      string
+	ISCSIInitiator string
 }
 
 type NetSpec struct {
@@ -170,6 +174,24 @@ func CreateDomainXML(vs ServerSpec) *libvirtxml.Domain {
 				File: &libvirtxml.DomainDiskSourceFile{File: d.Src},
 			}
 			dom.Devices.Disks = append(dom.Devices.Disks, cdrom)
+
+		case "iscsi":
+			// "iscsi" is an attachment source protocol, not a qemu image format.
+			// Keep driver format as raw while using network source protocol=iscsi.
+			disk.Driver.Type = "raw"
+			disk.Source = &libvirtxml.DomainDiskSource{
+				Network: &libvirtxml.DomainDiskSourceNetwork{
+					Protocol: "iscsi",
+					Name:     d.ISCSITarget,
+					Hosts: []libvirtxml.DomainDiskSourceHost{
+						{Name: d.ISCSIHost, Port: d.ISCSIPort},
+					},
+					Initiator: &libvirtxml.DomainDiskSourceNetworkInitiator{
+						IQN: &libvirtxml.DomainDiskSourceNetworkIQN{Name: d.ISCSIInitiator},
+					},
+				},
+			}
+			dom.Devices.Disks = append(dom.Devices.Disks, disk)
 
 		}
 	}

--- a/pkg/virt/libvirtXml2_iscsi_test.go
+++ b/pkg/virt/libvirtXml2_iscsi_test.go
@@ -1,0 +1,46 @@
+package virt_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/pkg/virt"
+)
+
+func TestCreateDomainXML_ISCSIDisk(t *testing.T) {
+	vs := virt.ServerSpec{
+		UUID:      "00000000-0000-0000-0000-000000000001",
+		Name:      "vm-iscsi-test",
+		RAM:       1024 * 1024,
+		CountVCPU: 2,
+		Machine:   "pc-q35-4.2",
+		DiskSpecs: []virt.DiskSpec{
+			{
+				Dev:            "vdb",
+				Bus:            11,
+				Type:           "iscsi",
+				ISCSITarget:    "iqn.2024-01.com.marmot:target-abcde/0",
+				ISCSIHost:      "192.168.1.210",
+				ISCSIPort:      "3260",
+				ISCSIInitiator: "iqn.2004-10.com.marmot:marmot1",
+			},
+		},
+	}
+
+	dom := virt.CreateDomainXML(vs)
+	xml, err := dom.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	xmlStr := string(xml)
+	if !strings.Contains(xmlStr, "<source protocol=\"iscsi\" name=\"iqn.2024-01.com.marmot:target-abcde/0\">") {
+		t.Fatalf("iscsi source is missing: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, "<host name=\"192.168.1.210\" port=\"3260\"></host>") {
+		t.Fatalf("iscsi host/port is missing: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, "<initiator>") || !strings.Contains(xmlStr, "<iqn name=\"iqn.2004-10.com.marmot:marmot1\"></iqn>") {
+		t.Fatalf("iscsi initiator is missing: %s", xmlStr)
+	}
+}

--- a/pkg/virt/libvirtXml2_test.go
+++ b/pkg/virt/libvirtXml2_test.go
@@ -59,9 +59,9 @@ var _ = Describe("VirtualServers", Ordered, func() {
 			vs1.Machine = "pc-q35-4.2"
 
 			vs1.DiskSpecs = []virt.DiskSpec{
-				{"vda", "/dev/vg1/oslv", 3, "raw"},
-				{"vdb", "/dev/vg1/lvdata", 10, "raw"},
-				{"vdc", "/var/lib/marmot/volumes/data-vol-1.qcow2", 11, "qcow2"},
+				{Dev: "vda", Src: "/dev/vg1/oslv", Bus: 3, Type: "raw"},
+				{Dev: "vdb", Src: "/dev/vg1/lvdata", Bus: 10, Type: "raw"},
+				{Dev: "vdc", Src: "/var/lib/marmot/volumes/data-vol-1.qcow2", Bus: 11, Type: "qcow2"},
 			}
 			channelFile := "org.qemu.guest_agent.0"
 
@@ -82,13 +82,13 @@ var _ = Describe("VirtualServers", Ordered, func() {
 				},
 			}
 			vs1.ChannelSpecs = []virt.ChannelSpec{
-				{"unix", channelPath + "/" + channelFile, channelFile, "channel0", 1},
-				{"spicevmc", "", "com.redhat.spice.0", "channel1", 2},
+				{Type: "unix", Path: channelPath + "/" + channelFile, Name: channelFile, Alias: "channel0", Port: 1},
+				{Type: "spicevmc", Path: "", Name: "com.redhat.spice.0", Alias: "channel1", Port: 2},
 			}
 			vs1.Clocks = []virt.ClockSpec{
-				{"rtc", "catchup", ""},
-				{"pit", "delay", ""},
-				{"hpet", "", "no"},
+				{Name: "rtc", TickPolicy: "catchup", Present: ""},
+				{Name: "pit", TickPolicy: "delay", Present: ""},
+				{Name: "hpet", TickPolicy: "", Present: "no"},
 			}
 			dom1 = virt.CreateDomainXML(vs1)
 			xml1, err = dom1.Marshal()
@@ -110,8 +110,8 @@ var _ = Describe("VirtualServers", Ordered, func() {
 			vs2.Machine = "pc-q35-4.2"
 
 			vs2.DiskSpecs = []virt.DiskSpec{
-				{"vda", bootdiskpath, 3, "qcow2"},
-				{"vdb", "/var/lib/marmot/volumes/data-vol-2.qcow2", 10, "qcow2"},
+				{Dev: "vda", Src: bootdiskpath, Bus: 3, Type: "qcow2"},
+				{Dev: "vdb", Src: "/var/lib/marmot/volumes/data-vol-2.qcow2", Bus: 10, Type: "qcow2"},
 			}
 			channelFile := "org.qemu.guest_agent.0"
 			channelPath, err := util.CreateChannelDir(hostname2)
@@ -132,13 +132,13 @@ var _ = Describe("VirtualServers", Ordered, func() {
 				},
 			}
 			vs2.ChannelSpecs = []virt.ChannelSpec{
-				{"unix", channelPath + "/" + channelFile, channelFile, "channel0", 1},
-				{"spicevmc", "", "com.redhat.spice.0", "channel1", 2},
+				{Type: "unix", Path: channelPath + "/" + channelFile, Name: channelFile, Alias: "channel0", Port: 1},
+				{Type: "spicevmc", Path: "", Name: "com.redhat.spice.0", Alias: "channel1", Port: 2},
 			}
 			vs2.Clocks = []virt.ClockSpec{
-				{"rtc", "catchup", ""},
-				{"pit", "delay", ""},
-				{"hpet", "", "no"},
+				{Name: "rtc", TickPolicy: "catchup", Present: ""},
+				{Name: "pit", TickPolicy: "delay", Present: ""},
+				{Name: "hpet", TickPolicy: "", Present: "no"},
 			}
 
 			dom2 = virt.CreateDomainXML(vs2)
@@ -196,4 +196,3 @@ var _ = Describe("VirtualServers", Ordered, func() {
 		})
 	})
 })
-


### PR DESCRIPTION
## 概要
MEMOに記載の「VM起動時のイニシエーターの設定」に沿って、Spec.iscsi=true の LVMデータボリュームを VM起動時に iSCSI ディスクとして接続できるように実装しました。  
あわせて、libvirt エラーの原因だった driver format 指定を修正しています。

## 背景（発生していた問題）
server create 時に以下エラーでプロビジョニングが失敗していました。  
unsupported configuration: unknown driver format value 'iscsi'

原因は、iSCSI を「接続元プロトコル」ではなく「driver format」として扱っていたためです。

## 変更内容
1. iSCSI アタッチ解決ロジックを復旧
- server.go
- iSCSIサーバーノード解決、ターゲット名正規化、initiator IQN 解決を実装
- Storage の lvm + iscsi=true を iSCSIディスクとして組み立て

2. libvirt XML 生成で iSCSI network disk を出力
- libvirtXml2.go
- DiskSpec に iSCSI用項目を追加
- source protocol=iscsi, host/port, initiator/iqn を出力

3. driver format 修正（今回の障害対策）
- libvirtXml2.go
- iSCSI時の driver type を raw に固定
- iSCSI は source protocol 側で表現する形に修正

4. テスト整備
- libvirtXml2_iscsi_test.go を追加
- libvirtXml2_test.go の構造体リテラルを keyed 形式へ更新

## MEMOとの整合
設計メモの「VM起動時のイニシエーターの設定」に記載の以下要素を実装で満たす形にしています。
1. source protocol='iscsi' と target name
2. host name + port=3260
3. initiator iqn
4. target dev の重複回避（既存割当方針を維持）

対象メモ: MEMO-block-storage-design.md

## 確認結果
1. go test ./pkg/virt -run TestCreateDomainXML_ISCSIDisk -v  
- PASS

2. go test ./pkg/marmotd -run TestMarmotd -ginkgo.dry-run -v  
- PASS

## レビューポイント
1. iSCSIサーバー選定ロジック（明示設定優先、フォールバック時の決定性）
2. initiator IQN 解決順（ローカル取得→HostStatusフォールバック）
3. libvirt XML の iSCSI出力形式が運用環境の target 設定と一致しているか