### PR TITLE
APIのタグをK8sの様式に修正

### DIFF
--- a/api/marmot-api-v1.go
+++ b/api/marmot-api-v1.go
@@ -83,8 +83,8 @@ type HostCapacity struct {
 
 // HostStatus defines model for HostStatus.
 type HostStatus struct {
-	Allocation  *HostAllocation `json:"Allocation,omitempty" yaml:"Allocation,omitempty"`
-	Capacity    *HostCapacity   `json:"Capacity,omitempty" yaml:"Capacity,omitempty"`
+	Allocation  *HostAllocation `json:"allocation,omitempty" yaml:"allocation,omitempty"`
+	Capacity    *HostCapacity   `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 	HostId      *string         `json:"hostId,omitempty" yaml:"hostId,omitempty"`
 	InitiatorId *string         `json:"initiatorId,omitempty" yaml:"initiatorId,omitempty"`
 	IpAddress   *string         `json:"ipAddress,omitempty" yaml:"ipAddress,omitempty"`
@@ -95,30 +95,30 @@ type HostStatus struct {
 
 // IPAddress defines model for IPAddress.
 type IPAddress struct {
-	HostId    *string `json:"HostId,omitempty" yaml:"HostId,omitempty"`
-	IPAddress *string `json:"IPAddress,omitempty" yaml:"IPAddress,omitempty"`
-	Netmask   *string `json:"Netmask,omitempty" yaml:"Netmask,omitempty"`
-	NetworkId *string `json:"NetworkId,omitempty" yaml:"NetworkId,omitempty"`
+	HostId    *string `json:"hostId,omitempty" yaml:"hostId,omitempty"`
+	IPAddress *string `json:"iPAddress,omitempty" yaml:"iPAddress,omitempty"`
+	Netmask   *string `json:"netmask,omitempty" yaml:"netmask,omitempty"`
+	NetworkId *string `json:"networkId,omitempty" yaml:"networkId,omitempty"`
 }
 
 // IPNetwork defines model for IPNetwork.
 type IPNetwork struct {
-	AddressMaskLen   *string `json:"AddressMaskLen,omitempty" yaml:"AddressMaskLen,omitempty"`
-	EndAddress       *string `json:"EndAddress,omitempty" yaml:"EndAddress,omitempty"`
-	Gateway          *string `json:"Gateway,omitempty" yaml:"Gateway,omitempty"`
-	Id               string  `json:"Id" yaml:"Id"`
-	Netmask          *string `json:"Netmask,omitempty" yaml:"Netmask,omitempty"`
-	Netmasklen       *int    `json:"Netmasklen,omitempty" yaml:"Netmasklen,omitempty"`
-	NetworkAddress   *string `json:"NetworkAddress,omitempty" yaml:"NetworkAddress,omitempty"`
-	StartAddress     *string `json:"StartAddress,omitempty" yaml:"StartAddress,omitempty"`
+	AddressMaskLen   *string `json:"addressMaskLen,omitempty" yaml:"addressMaskLen,omitempty"`
+	EndAddress       *string `json:"endAddress,omitempty" yaml:"endAddress,omitempty"`
+	Gateway          *string `json:"gateway,omitempty" yaml:"gateway,omitempty"`
+	Id               string  `json:"id" yaml:"id"`
+	Netmask          *string `json:"netmask,omitempty" yaml:"netmask,omitempty"`
+	Netmasklen       *int    `json:"netmasklen,omitempty" yaml:"netmasklen,omitempty"`
+	NetworkAddress   *string `json:"networkAddress,omitempty" yaml:"networkAddress,omitempty"`
+	StartAddress     *string `json:"startAddress,omitempty" yaml:"startAddress,omitempty"`
 	VirtualNetworkId *string `json:"virtualNetworkId,omitempty" yaml:"virtualNetworkId,omitempty"`
 }
 
 // Image defines model for Image.
 type Image struct {
-	Metadata *Metadata  `json:"Metadata,omitempty" yaml:"Metadata,omitempty"`
-	Spec     *ImageSpec `json:"Spec,omitempty" yaml:"Spec,omitempty"`
-	Status   *Status    `json:"Status,omitempty" yaml:"Status,omitempty"`
+	Metadata *Metadata  `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Spec     *ImageSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Status   *Status    `json:"status,omitempty" yaml:"status,omitempty"`
 	Id       string     `json:"id" yaml:"id"`
 }
 
@@ -129,27 +129,27 @@ type ImageSpec struct {
 	LvPath        *string `json:"lvPath,omitempty" yaml:"lvPath,omitempty"`
 	Qcow2Path     *string `json:"qcow2Path,omitempty" yaml:"qcow2Path,omitempty"`
 	Size          *int    `json:"size,omitempty" yaml:"size,omitempty"`
-	SourceUrl     *string `json:"source_url,omitempty" yaml:"source_url,omitempty"`
+	SourceUrl     *string `json:"sourceUrl,omitempty" yaml:"sourceUrl,omitempty"`
 	Type          *string `json:"type,omitempty" yaml:"type,omitempty"`
 	VolumeGroup   *string `json:"volumeGroup,omitempty" yaml:"volumeGroup,omitempty"`
 }
 
 // Job defines model for Job.
 type Job struct {
-	Metadata *Metadata `json:"Metadata,omitempty" yaml:"Metadata,omitempty"`
-	Spec     *JobSpec  `json:"Spec,omitempty" yaml:"Spec,omitempty"`
-	Status   *Status   `json:"Status,omitempty" yaml:"Status,omitempty"`
+	Metadata *Metadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Spec     *JobSpec  `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Status   *Status   `json:"status,omitempty" yaml:"status,omitempty"`
 	Id       string    `json:"id" yaml:"id"`
 }
 
 // JobSpec defines model for JobSpec.
 type JobSpec struct {
-	Command     *[]string  `json:"Command,omitempty" yaml:"Command,omitempty"`
-	ExitCode    *int       `json:"ExitCode,omitempty" yaml:"ExitCode,omitempty"`
-	FinishTime  *time.Time `json:"FinishTime,omitempty" yaml:"FinishTime,omitempty"`
-	MaxTime     *time.Time `json:"MaxTime,omitempty" yaml:"MaxTime,omitempty"`
-	RequestTime *time.Time `json:"RequestTime,omitempty" yaml:"RequestTime,omitempty"`
-	StartTime   *time.Time `json:"StartTime,omitempty" yaml:"StartTime,omitempty"`
+	Command     *[]string  `json:"command,omitempty" yaml:"command,omitempty"`
+	ExitCode    *int       `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
+	FinishTime  *time.Time `json:"finishTime,omitempty" yaml:"finishTime,omitempty"`
+	MaxTime     *time.Time `json:"maxTime,omitempty" yaml:"maxTime,omitempty"`
+	RequestTime *time.Time `json:"requestTime,omitempty" yaml:"requestTime,omitempty"`
+	StartTime   *time.Time `json:"startTime,omitempty" yaml:"startTime,omitempty"`
 }
 
 // Metadata defines model for Metadata.
@@ -208,16 +208,16 @@ type Route struct {
 
 // Server defines model for Server.
 type Server struct {
-	Metadata *Metadata   `json:"Metadata,omitempty" yaml:"Metadata,omitempty"`
-	Spec     *ServerSpec `json:"Spec,omitempty" yaml:"Spec,omitempty"`
-	Status   *Status     `json:"Status,omitempty" yaml:"Status,omitempty"`
+	Metadata *Metadata   `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Spec     *ServerSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Status   *Status     `json:"status,omitempty" yaml:"status,omitempty"`
 	Id       string      `json:"id" yaml:"id"`
 }
 
 // ServerSpec defines model for ServerSpec.
 type ServerSpec struct {
-	NetworkInterface *[]NetworkInterface `json:"NetworkInterface,omitempty" yaml:"NetworkInterface,omitempty"`
-	Storage          *[]Volume           `json:"Storage,omitempty" yaml:"Storage,omitempty"`
+	NetworkInterface *[]NetworkInterface `json:"networkInterface,omitempty" yaml:"networkInterface,omitempty"`
+	Storage          *[]Volume           `json:"storage,omitempty" yaml:"storage,omitempty"`
 	Auth             *Auth               `json:"auth,omitempty" yaml:"auth,omitempty"`
 	BootVolume       *Volume             `json:"bootVolume,omitempty" yaml:"bootVolume,omitempty"`
 	Cpu              *int                `json:"cpu,omitempty" yaml:"cpu,omitempty"`
@@ -254,9 +254,9 @@ type Version struct {
 
 // VirtualNetwork defines model for VirtualNetwork.
 type VirtualNetwork struct {
-	Metadata *Metadata           `json:"Metadata,omitempty" yaml:"Metadata,omitempty"`
-	Spec     *VirtualNetworkSpec `json:"Spec,omitempty" yaml:"Spec,omitempty"`
-	Status   *Status             `json:"Status,omitempty" yaml:"Status,omitempty"`
+	Metadata *Metadata           `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Spec     *VirtualNetworkSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Status   *Status             `json:"status,omitempty" yaml:"status,omitempty"`
 	Id       string              `json:"id" yaml:"id"`
 }
 
@@ -310,9 +310,9 @@ type VolSpec struct {
 
 // Volume defines model for Volume.
 type Volume struct {
-	Metadata *Metadata `json:"Metadata,omitempty" yaml:"Metadata,omitempty"`
-	Spec     *VolSpec  `json:"Spec,omitempty" yaml:"Spec,omitempty"`
-	Status   *Status   `json:"Status,omitempty" yaml:"Status,omitempty"`
+	Metadata *Metadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Spec     *VolSpec  `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Status   *Status   `json:"status,omitempty" yaml:"status,omitempty"`
 	Id       string    `json:"id" yaml:"id"`
 }
 

--- a/cmd/mactl/cmd/common.go
+++ b/cmd/mactl/cmd/common.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log/slog"
-	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -33,59 +31,11 @@ func deletionMarker(status *api.Status) string {
 // コンフィグからエンドポイントを取り出してセットする
 //
 // 優先順位:
-//  1. --api フラグで明示指定された URL
+//  1. --api フラグで明示指定された URL または .marmot ファイルパス
 //  2. $HOME/.marmot に登録されたアクティブエンドポイント
 //     ($HOME/.marmot が無い場合は /etc/marmot/.marmot.example からコピーして自動作成)
 func getClientConfig() (*client.MarmotEndpoint, error) {
-	var rawURL string
-
-	if len(apiConfigFilename) > 0 {
-		// --api フラグで URL が直接指定された場合
-		rawURL = apiConfigFilename
-		// URL形式でなければ旧来のファイルパスとして扱う
-		if u, err := url.Parse(apiConfigFilename); err == nil && u.Scheme != "" && u.Host != "" {
-			rawURL = apiConfigFilename
-		} else {
-			// ファイルパスとして読み込む（後方互換）
-			err := config.ReadYamlConfig(apiConfigFilename, &mactlConfig)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read config file: %w", err)
-			}
-			rawURL = mactlConfig.ApiServerUrl
-		}
-	} else {
-		// $HOME/.marmot を保証し（なければサンプルからコピー）、読み込む
-		if err := config.EnsureMarmotConfig(); err != nil {
-			return nil, err
-		}
-		marmotCfgPath := config.MarmotConfigPath()
-		marmotCfg, err := config.ReadMarmotConfig(marmotCfgPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read %s: %w", marmotCfgPath, err)
-		}
-		activeURL, err := marmotCfg.ActiveEndpoint()
-		if err != nil {
-			return nil, err
-		}
-		rawURL = activeURL
-	}
-
-	if len(rawURL) == 0 {
-		rawURL = "http://localhost:8750"
-	}
-
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		slog.Error("mactlConfig", "read error", err)
-		return nil, err
-	}
-
-	return client.NewMarmotdEp(
-		u.Scheme,
-		u.Host,
-		"/api/v1",
-		60,
-	)
+	return config.GetClientConfig2(apiConfigFilename)
 }
 
 // clearScreen はターミナル画面をクリアする。

--- a/cmd/mactl/cmd/root.go
+++ b/cmd/mactl/cmd/root.go
@@ -5,11 +5,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/takara9/marmot/pkg/config"
 )
 
 var apiConfigFilename string
-var mactlConfig config.ClientConfig
 var clusterConfigFilename string
 var outputStyle string
 var watchMode bool

--- a/cmd/mactl/mactl-vm-deploy-1_test.go
+++ b/cmd/mactl/mactl-vm-deploy-1_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,8 +14,6 @@ import (
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/db"
 )
-
-const testNetworkConfigRawURL = "https://raw.githubusercontent.com/takara9/marmot/refs/heads/main/cmd/mactl/testdata/test-network-02-test-net-2.yaml"
 
 var _ = Describe("MarmotdTest", Ordered, func() {
 	var mockServer *mockServerHandle
@@ -213,7 +212,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("DB登録をチェック JSON形式", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "list", "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "list", "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -229,7 +228,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想ネットワークのリスト テキスト形式", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -237,7 +236,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var netId1 string
 		It("仮想ネットワークの作成 test-net-1", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "create", "--configfile", "testdata/test-network-01-test-net-1.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "create", "--configfile", "testdata/test-network-01-test-net-1.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -252,7 +251,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想ネットワークの状態確認 test-net-1", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "detail", netId1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "detail", netId1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -267,7 +266,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var netId2 string
 		It("仮想ネットワークの作成 test-net-2 raw URL", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "create", "--configfile", testNetworkConfigRawURL, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "create", "--configfile", "testdata/test-network-02-test-net-2.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -282,7 +281,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想ネットワークの状態確認 test-net-2", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "detail", netId2, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "detail", netId2, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -297,7 +296,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var netId3 string
 		It("仮想ネットワークの作成 test-net-3", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "create", "--configfile", "testdata/test-network-03-host-bridge.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "create", "--configfile", "testdata/test-network-03-host-bridge.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -312,7 +311,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想ネットワークの状態確認 test-net-3", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "detail", netId3, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "detail", netId3, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -326,14 +325,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想ネットワークのリスト", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 		})
 
 		It("IPネットワークのリスト ipn", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "ipn", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "ipn", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -345,7 +344,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想ネットワーク配下のIPネットワークのリスト ipn-by-vn", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "ipn-by-vn", netId1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "ipn-by-vn", netId1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -359,7 +358,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 	Context("OSイメージの準備", func() {
 		It("OSイメージのリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "list", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "list", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -371,7 +370,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var imageID string
 		It("OSイメージの登録", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "create", "--configfile", "testdata/test-image-01-ubuntu22.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "create", "--configfile", "testdata/test-image-01-ubuntu22.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -383,7 +382,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("OSイメージの個別詳細取得", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "detail", imageID, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "detail", imageID, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Println(string(stdoutStderr))
@@ -395,7 +394,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("OSイメージのリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -406,7 +405,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 	Context("様々に条件を変えてサーバーのデプロイ", func() {
 		var serverId_1, serverId_2 string
 		It("仮想サーバー作成 test-00", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-00-none.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-00-none.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -419,7 +418,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 		It("仮想サーバーの状態確認 test-00", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -434,7 +433,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーの削除 test-00", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -442,14 +441,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-00", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -457,14 +463,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーのリスト", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -475,7 +481,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバー作成 test-01 defaultネットワークに繋いだ", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-01-default.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-01-default.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -489,7 +495,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-01", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -504,7 +510,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーの削除 test-01", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -512,14 +518,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-01", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -527,14 +540,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーのリスト", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -546,7 +559,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		// ホストが繋がっているネットワークに繋がったて、DHCPを利用する仮想マシンを作成する
 		It("仮想サーバー作成 test-02 host-bridgeネットワークに繋いだ", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-02-host-bridge.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-02-host-bridge.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -560,7 +573,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-02", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -575,7 +588,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーの削除 test-02", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -583,14 +596,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-02", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -598,14 +618,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーで削除を確認 test-02", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -617,7 +637,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		// ホストのネットワークに繋がった仮想マシンで、IPアドレス指定で起動する
 		It("仮想サーバー作成 test-03 host-bridgeでIPアドレス指定", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-03-host-bridge-ip.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-03-host-bridge-ip.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -631,7 +651,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-03", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -646,7 +666,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーの削除 test-03", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -654,14 +674,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-03", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -669,14 +696,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーで削除を確認 test-03", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -688,7 +715,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		// 複数ボリュームを待つ仮想マシンを作成する
 		It("仮想サーバー作成 test-04 複数ボリューム", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-04-multi-vol-qcow2.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-04-multi-vol-qcow2.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -702,7 +729,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-04", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -717,7 +744,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーの削除 test-04", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -725,14 +752,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-04", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -740,14 +774,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーで削除を確認 test-04", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -759,7 +793,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		// LVMのブートボリュームで起動する仮想マシンを作成
 		It("仮想サーバー作成 test-05 +LVMボリュームで起動する仮想マシン", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-05-boot-lvm.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-05-boot-lvm.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -773,7 +807,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-05", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -788,7 +822,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーの削除 test-05", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -796,14 +830,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-05", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -811,14 +852,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーで削除を確認 test-05", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -830,7 +871,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		// LVMでブートするマシンで複数ボリュームを待つ仮想マシンを作成する
 		It("仮想サーバー作成 test-06 KVMボリュームで起動、複数のボリュームを持つ仮想マシン", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-06-multivol-lvm.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-06-multivol-lvm.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -844,7 +885,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-06", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -859,7 +900,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーの削除 test-06", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -867,14 +908,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-06", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -882,14 +930,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーで削除を確認 test-06", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -901,7 +949,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		//host-bridgeネットワークに繋がった仮想マシンで、IPアドレス指定で起動する。
 		It("仮想サーバー作成 test-07 KVMボリュームで起動、複数のボリュームを持つ仮想マシン", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-07-host-bridge-ip.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-07-host-bridge-ip.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -915,7 +963,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-07", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -930,7 +978,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーの削除 test-07", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -938,14 +986,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-07", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -953,14 +1008,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーで削除を確認 test-07", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -989,7 +1044,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		//VLANに接続する仮想マシンで、IPアドレス指定で起動する。
 		It("仮想サーバー作成 test-08 VLAN接続の仮想マシン", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-08-host-bridge-vlan.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-08-host-bridge-vlan.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -1003,7 +1058,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-08", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -1018,7 +1073,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーの削除 test-08", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -1026,14 +1081,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-08", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -1041,14 +1103,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーで削除を確認 test-08", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -1060,7 +1122,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		//仮想ネットへ接続の仮想マシン 09
 		It("仮想サーバー作成 test-09 仮想ネットへ接続の仮想マシン", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-09-net-2-set-IP.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-09-net-2-set-IP.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -1074,7 +1136,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-09", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -1089,7 +1151,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバー作成 test-10 仮想ネットへ接続の仮想マシン", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-10-net-2-set-IP.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-10-net-2-set-IP.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -1103,7 +1165,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-10", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_2, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_2, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -1118,7 +1180,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーのリスト表示 test-9, test-10", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -1126,7 +1188,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("割り当て済みIPアドレスのリスト ips", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "list", "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "list", "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 
@@ -1144,7 +1206,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 				}
 				g.Expect(defaultVnetID).NotTo(BeEmpty())
 
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "ipn-by-vn", defaultVnetID, "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "ipn-by-vn", defaultVnetID, "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 
@@ -1153,7 +1215,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(len(ipnets)).To(BeNumerically(">", 0))
 
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "ips", ipnets[0].Id, "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "ips", ipnets[0].Id, "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -1166,7 +1228,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーの削除 test-09", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -1174,21 +1236,28 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-09", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 		})
 
 		It("仮想サーバーの削除 test-10", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_2, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_2, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -1196,14 +1265,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-10", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_2, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_2, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -1211,14 +1287,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーで削除を確認 test-09, test-10", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server

--- a/cmd/mactl/mactl-vm-deploy-2_test.go
+++ b/cmd/mactl/mactl-vm-deploy-2_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -216,7 +217,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("DB登録をチェック JSON形式", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "list", "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "list", "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -232,7 +233,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想ネットワークのリスト", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -240,7 +241,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var netId1 string
 		It("仮想ネットワークの作成 test-net-1", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "create", "--configfile", "testdata/test-network-01-test-net-1.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "create", "--configfile", "testdata/test-network-01-test-net-1.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -255,7 +256,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想ネットワークの状態確認 test-net-1", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "detail", netId1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "detail", netId1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -270,7 +271,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var netId2 string
 		It("仮想ネットワークの作成 test-net-2 raw URL", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "create", "--configfile", testNetworkConfigRawURL, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "create", "--configfile", "testdata/test-network-02-test-net-2.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -285,7 +286,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想ネットワークの状態確認 test-net-2", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "detail", netId2, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "detail", netId2, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -300,7 +301,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var netId3 string
 		It("仮想ネットワークの作成 test-net-3", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "create", "--configfile", "testdata/test-network-03-host-bridge.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "create", "--configfile", "testdata/test-network-03-host-bridge.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -315,7 +316,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想ネットワークの状態確認 test-net-3", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "detail", netId3, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "detail", netId3, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -365,7 +366,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("mactl network delete実行で同名オブジェクトにDeletionTimeStampが伝播する", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "delete", deletePropagationHeadID, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "delete", deletePropagationHeadID, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -391,14 +392,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想ネットワークのリスト", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 		})
 
 		It("IPネットワークのリスト ipn", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "ipn", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "ipn", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -410,7 +411,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想ネットワーク配下のIPネットワークのリスト ipn-by-vn", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "ipn-by-vn", netId1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "ipn-by-vn", netId1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -424,7 +425,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 	Context("OSイメージの準備", func() {
 		It("OSイメージのリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "list", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "list", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -436,7 +437,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var imageID string
 		It("OSイメージの登録", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "create", "--configfile", "testdata/test-image-01-ubuntu22.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "create", "--configfile", "testdata/test-image-01-ubuntu22.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -448,7 +449,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("OSイメージの個別詳細取得", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "detail", imageID, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "detail", imageID, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Println(string(stdoutStderr))
@@ -460,7 +461,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("OSイメージのリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -471,7 +472,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 	Context("様々に条件を変えてサーバーのデプロイ", func() {
 		var serverId_1, serverId_2, serverId_3 string
 		It("仮想サーバー作成 test-11 仮想ネットへ接続の仮想マシン", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-11-net-2-auto-IP.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-11-net-2-auto-IP.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -484,7 +485,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバー作成 test-12 仮想ネットへ接続の仮想マシン", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-12-net-2-auto-IP.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-12-net-2-auto-IP.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -498,7 +499,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-11", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -514,7 +515,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの状態確認 test-12", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_2, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_2, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -529,21 +530,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想サーバーのリスト表示 test-11, test-12", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 		})
 
 		It("仮想サーバーの削除 test-11", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 		})
 
 		It("仮想サーバーの削除 test-12", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_2, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_2, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -551,14 +552,25 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-11", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") ||
+						strings.Contains(strings.ToLower(string(stdoutStderr)), "404") {
+						return
+					}
+					_, dbErr := mockServer.server.Ma.Db.GetServerById(serverId_1)
+					if errors.Is(dbErr, db.ErrNotFound) {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -566,14 +578,25 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除状態確認 test-12", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_2, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_2, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") ||
+						strings.Contains(strings.ToLower(string(stdoutStderr)), "404") {
+						return
+					}
+					_, dbErr := mockServer.server.Ma.Db.GetServerById(serverId_2)
+					if errors.Is(dbErr, db.ErrNotFound) {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -581,14 +604,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーで削除を確認 test-11, test-12", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -601,7 +624,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		It("仮想サーバー作成 test-20,21,22 同一仮想ネットで複数の仮想マシン", func() {
 			for i := 20; i <= 22; i++ {
 				configFile := fmt.Sprintf("testdata/test-server-%02d-test-net-3.yaml", i)
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", configFile, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", configFile, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -624,7 +647,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		It("仮想サーバーの状態確認 test-20,21,22", func() {
 			for _, serverId := range []string{serverId_1, serverId_2, serverId_3} {
 				Eventually(func(g Gomega) {
-					cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId, "--output", "json")
+					cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId, "--output", "json")
 					stdoutStderr, err := cmd.CombinedOutput()
 					g.Expect(err).NotTo(HaveOccurred())
 					fmt.Println(string(stdoutStderr))
@@ -641,7 +664,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーをリストで確認 test-20, test-21, test-22", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -649,7 +672,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーの削除 test-20,21,22", func() {
 			for _, serverId := range []string{serverId_1, serverId_2, serverId_3} {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -659,14 +682,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		It("仮想サーバーの削除状態確認 test-20,21,22", func() {
 			for _, serverId := range []string{serverId_1, serverId_2, serverId_3} {
 				Eventually(func(g Gomega) {
-					cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId, "--output", "json")
+					cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId, "--output", "json")
 					stdoutStderr, err := cmd.CombinedOutput()
-					g.Expect(err).NotTo(HaveOccurred())
 					fmt.Println(string(stdoutStderr))
+
+					if err != nil {
+						// 削除処理が速く進むと detail が NotFound になりうるため終端状態として許容する。
+						if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+							return
+						}
+					}
+					g.Expect(err).NotTo(HaveOccurred())
 
 					var server api.Server
 					err = json.Unmarshal(stdoutStderr, &server)
-					Expect(err).NotTo(HaveOccurred())
+					g.Expect(err).NotTo(HaveOccurred())
 					GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 					g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 				}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -675,14 +705,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想サーバーで削除を確認 test-20,21,22", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server

--- a/cmd/mactl/mactl-vm-deploy-3_test.go
+++ b/cmd/mactl/mactl-vm-deploy-3_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -211,7 +213,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("DB登録をチェック", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "list", "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "list", "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -227,7 +229,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想ネットワークのリスト", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -235,7 +237,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var netId1 string
 		It("仮想ネットワークの作成 test-net-1", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "create", "--configfile", "testdata/test-network-01-test-net-1.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "create", "--configfile", "testdata/test-network-01-test-net-1.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -250,7 +252,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想ネットワークの状態確認 test-net-1", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "detail", netId1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "detail", netId1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -265,7 +267,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var netId2 string
 		It("仮想ネットワークの作成 test-net-2 raw URL", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "create", "--configfile", testNetworkConfigRawURL, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "create", "--configfile", "testdata/test-network-02-test-net-2.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -280,7 +282,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想ネットワークの状態確認 test-net-2", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "detail", netId2, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "detail", netId2, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -295,7 +297,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var netId3 string
 		It("仮想ネットワークの作成 test-net-3", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "create", "--configfile", "testdata/test-network-03-host-bridge.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "create", "--configfile", "testdata/test-network-03-host-bridge.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -310,7 +312,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("仮想ネットワークの状態確認 test-net-3", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "detail", netId3, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "detail", netId3, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -324,14 +326,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想ネットワークのリスト", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 		})
 
 		It("IPネットワークのリスト ipn", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "ipn", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "ipn", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -343,7 +345,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("仮想ネットワーク配下のIPネットワークのリスト ipn-by-vn", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "network", "ipn-by-vn", netId1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "network", "ipn-by-vn", netId1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -357,7 +359,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 	Context("OSイメージの準備", func() {
 		It("OSイメージのリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "list", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "list", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -369,7 +371,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		var imageID string
 		It("OSイメージの登録", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "create", "--configfile", "testdata/test-image-01-ubuntu22.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "create", "--configfile", "testdata/test-image-01-ubuntu22.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -381,7 +383,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("OSイメージの個別詳細取得", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "detail", imageID, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "detail", imageID, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Println(string(stdoutStderr))
@@ -393,7 +395,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("OSイメージのリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -405,7 +407,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		var serverId_1, serverId_2, serverId_3 string
 
 		It("外部接続の仮想サーバー作成 test-23", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-23-test-net-3-host-bridge-ip.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-23-test-net-3-host-bridge-ip.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -419,7 +421,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("外部接続の仮想サーバーの状態確認 test-23", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -434,7 +436,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("外部接続の仮想サーバーの削除 test-23", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -442,14 +444,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("外部接続の仮想サーバーの削除状態確認 test-23", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -457,14 +466,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("外部接続の仮想サーバーで削除を確認 test-23", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -478,7 +487,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		It("マルチホームの仮想サーバー作成 test-28,29,30", func() {
 			for i := 28; i <= 30; i++ {
 				configFile := fmt.Sprintf("testdata/test-server-%02d-multihome.yaml", i)
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", configFile, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", configFile, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -499,12 +508,12 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("マルチホームの仮想サーバーの状態確認 test-28", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
 
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -519,13 +528,13 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("マルチホームの仮想サーバーの状態確認 test-29", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_2, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_2, "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -540,13 +549,13 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("マルチホームの仮想サーバーの状態確認 test-30", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_3, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_3, "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -562,7 +571,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("マルチホームの仮想サーバーの削除 test-28,29,30", func() {
 			for _, serverId := range []string{serverId_1, serverId_2, serverId_3} {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -572,14 +581,26 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		It("マルチホームの仮想サーバーの削除状態確認 test-28,29,30", func() {
 			for _, serverId := range []string{serverId_1, serverId_2, serverId_3} {
 				Eventually(func(g Gomega) {
-					cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId, "--output", "json")
+					cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId, "--output", "json")
 					stdoutStderr, err := cmd.CombinedOutput()
-					g.Expect(err).NotTo(HaveOccurred())
 					fmt.Println(string(stdoutStderr))
+
+					if err != nil {
+						// Accept not found as terminal state when deletion finishes before polling.
+						if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") ||
+							strings.Contains(strings.ToLower(string(stdoutStderr)), "404") {
+							return
+						}
+						_, dbErr := mockServer.server.Ma.Db.GetServerById(serverId)
+						if errors.Is(dbErr, db.ErrNotFound) {
+							return
+						}
+					}
+					g.Expect(err).NotTo(HaveOccurred())
 
 					var server api.Server
 					err = json.Unmarshal(stdoutStderr, &server)
-					Expect(err).NotTo(HaveOccurred())
+					g.Expect(err).NotTo(HaveOccurred())
 					GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 					g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 				}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -588,14 +609,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("マルチホームの仮想サーバーで削除を確認 test-28,29,30", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -609,7 +630,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		It("マルチホームでホストブリッジ接続の仮想サーバー作成 test-31,32,33", func() {
 			for i := 31; i <= 33; i++ {
 				configFile := fmt.Sprintf("testdata/test-server-%02d-multihome-host-bridge.yaml", i)
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", configFile, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", configFile, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -640,7 +661,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 					case 33:
 						serverId = serverId_3
 					}
-					cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId, "--output", "json")
+					cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId, "--output", "json")
 					stdoutStderr, err := cmd.CombinedOutput()
 					g.Expect(err).NotTo(HaveOccurred())
 					fmt.Println(string(stdoutStderr))
@@ -657,7 +678,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("マルチホームでホストブリッジ接続の仮想サーバーの削除 test-31,32,33", func() {
 			for _, serverId := range []string{serverId_1, serverId_2, serverId_3} {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -667,14 +688,25 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		It("マルチホームでホストブリッジ接続の仮想サーバーの削除状態確認 test-31,32,33", func() {
 			for _, serverId := range []string{serverId_1, serverId_2, serverId_3} {
 				Eventually(func(g Gomega) {
-					cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId, "--output", "json")
+					cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId, "--output", "json")
 					stdoutStderr, err := cmd.CombinedOutput()
-					g.Expect(err).NotTo(HaveOccurred())
 					fmt.Println(string(stdoutStderr))
+
+					if err != nil {
+						// Accept not found as terminal state when deletion finishes before polling.
+						if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") || strings.Contains(strings.ToLower(string(stdoutStderr)), "404") {
+							return
+						}
+						_, dbErr := mockServer.server.Ma.Db.GetServerById(serverId)
+						if errors.Is(dbErr, db.ErrNotFound) {
+							return
+						}
+					}
+					g.Expect(err).NotTo(HaveOccurred())
 
 					var server api.Server
 					err = json.Unmarshal(stdoutStderr, &server)
-					Expect(err).NotTo(HaveOccurred())
+					g.Expect(err).NotTo(HaveOccurred())
 					GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 					g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 				}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -683,14 +715,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("マルチホームでホストブリッジ接続の仮想サーバーで削除を確認 test-31,32,33", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server
@@ -701,7 +733,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("SSH-KEYを設定したサーバー作成 test-34", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--configfile", "testdata/test-server-34-sshkey.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", "testdata/test-server-34-sshkey.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -715,7 +747,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("外部接続の仮想サーバーの状態確認 test-34", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
@@ -730,7 +762,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		})
 
 		It("外部接続の仮想サーバーの削除 test-34", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", serverId_1, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "delete", serverId_1, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -738,14 +770,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("外部接続の仮想サーバーの削除状態確認 test-34", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", serverId_1, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverId_1, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
-				g.Expect(err).NotTo(HaveOccurred())
 				fmt.Println(string(stdoutStderr))
+
+				if err != nil {
+					// Accept not found as terminal state when deletion finishes before polling.
+					if strings.Contains(strings.ToLower(string(stdoutStderr)), "not found") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred())
 
 				var server api.Server
 				err = json.Unmarshal(stdoutStderr, &server)
-				Expect(err).NotTo(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("  - %s (%s)\n", *server.Metadata.Name, server.Id)
 				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
@@ -753,14 +792,14 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 
 		It("外部接続の仮想サーバーで削除を確認 test-34", func() {
 			By("仮想サーバーのリスト")
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
 
 			By("仮想サーバーのリスト JSON形式")
 			Eventually(func(g Gomega) {
-				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
+				cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
 				stdoutStderr, err = cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var servers []api.Server

--- a/cmd/mactl/mactl_test.go
+++ b/cmd/mactl/mactl_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 			stdoutStderr1, err := cmd1.CombinedOutput()
 			GinkgoWriter.Println(string(stdoutStderr1))
 
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "version")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "version")
 			stdoutStderr, err := cmd.CombinedOutput()
 			GinkgoWriter.Println(string(stdoutStderr))
 
@@ -89,7 +89,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("mactl version JSON形式でバージョンを取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "version", "--output", "json", "--api", "testdata/config_marmot.conf")
+			cmd := exec.Command("./bin/mactl-test", "version", "--output", "json", "--api", "testdata/.marmot")
 			stdoutStderr, err := cmd.CombinedOutput()
 			GinkgoWriter.Println("err: ", err)
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -97,7 +97,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("mactl version TEXT形式でバージョンを取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "version", "--output", "text", "--api", "testdata/config_marmot.conf")
+			cmd := exec.Command("./bin/mactl-test", "version", "--output", "text", "--api", "testdata/.marmot")
 			stdoutStderr, err := cmd.CombinedOutput()
 			GinkgoWriter.Println("err: ", err)
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -105,7 +105,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("mactl version YAML形式でバージョンを取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "version", "--output", "yaml", "--api", "testdata/config_marmot.conf")
+			cmd := exec.Command("./bin/mactl-test", "version", "--output", "yaml", "--api", "testdata/.marmot")
 			stdoutStderr, err := cmd.CombinedOutput()
 			GinkgoWriter.Println("err: ", err)
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -115,7 +115,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 	Context("クライアントからのアクセステスト ボリューム編", func() {
 		It("ボリュームのリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -123,7 +123,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		var volumeID string
 		It("ボリュームの作成  data qcow2 2G", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "create", "-f", "testdata/test-volume-01-data-qcow2.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "create", "-f", "testdata/test-volume-01-data-qcow2.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -140,7 +140,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		It("ボリュームの個別詳細取得", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "detail", volumeID, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "detail", volumeID, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Println(string(stdoutStderr))
@@ -152,14 +152,14 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("ボリュームの削除", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "delete", volumeID, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "delete", volumeID, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
 
 			By("削除したボリュームの状態を確認")
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "detail", volumeID, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "detail", volumeID, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var volume api.Volume
@@ -170,7 +170,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("ボリュームの作成  data lvm 2G", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "create", "-f", "testdata/test-volume-02-data-lvm.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "create", "-f", "testdata/test-volume-02-data-lvm.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -187,7 +187,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		It("ボリュームの個別詳細取得", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "detail", volumeID, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "detail", volumeID, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Println(string(stdoutStderr))
@@ -199,14 +199,14 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("ボリュームの削除", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "delete", volumeID, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "delete", volumeID, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
 
 			By("削除したボリュームの状態を確認")
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "detail", volumeID, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "detail", volumeID, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var volume api.Volume
@@ -217,7 +217,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 			By("削除したボリュームが消えることを確認")
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list", "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list", "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var volumes []api.Volume
@@ -229,7 +229,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		var volumeID3 string
 		It("ボリュームの作成  os qcow2 失敗ケース", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "create", "-f", "testdata/test-volume-03-os-qcow2.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "create", "-f", "testdata/test-volume-03-os-qcow2.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -246,7 +246,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		var volumeID4 string
 		It("ボリュームの作成  os lvm 失敗ケース", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "create", "-f", "testdata/test-volume-04-os-lvm.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "create", "-f", "testdata/test-volume-04-os-lvm.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -263,7 +263,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		It("ボリュームのリスト取得 ", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list", "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list", "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 
 				Expect(err).NotTo(HaveOccurred())
@@ -283,19 +283,19 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("ボリュームのTEXTリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
 		})
 
 		It("ボリュームの削除", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "delete", volumeID3, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "delete", volumeID3, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
 
-			cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "delete", volumeID4, "--output", "json")
+			cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "delete", volumeID4, "--output", "json")
 			stdoutStderr, err = cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -303,7 +303,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		It("ボリュームのリスト取得 削除され無くなることを確認", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list", "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list", "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 
 				Expect(err).NotTo(HaveOccurred())
@@ -322,28 +322,28 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("ボリュームのリスト取得 テキスト形式", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
 		})
 
 		It("ボリュームのリスト取得 JSON形式", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
 		})
 
 		It("ボリュームのリスト取得 YAML形式", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list", "--output", "yaml")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list", "--output", "yaml")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
 		})
 
 		It("ボリュームの作成 名前変更用", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "create", "-f", "testdata/test-volume-05-rename-source.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "create", "-f", "testdata/test-volume-05-rename-source.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -360,7 +360,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		It("ボリュームの個別詳細取得", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "detail", volumeID, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "detail", volumeID, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Println(string(stdoutStderr))
@@ -372,7 +372,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("ボリューム名変更", func() {
-			cmdDel := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "rename", volumeID, "NEW-NAME", "--output", "json")
+			cmdDel := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "rename", volumeID, "NEW-NAME", "--output", "json")
 			stdoutStderr, err := cmdDel.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Print("stdoutStderr=", string(stdoutStderr))
@@ -382,7 +382,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 			Expect(*volume.Metadata.Name).To(Equal("NEW-NAME"))
 
 			By("ボリューム名変更後も metadata.nodeName が保持されることを確認")
-			cmdDetail := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "detail", volumeID, "--output", "json")
+			cmdDetail := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "detail", volumeID, "--output", "json")
 			stdoutStderr, err = cmdDetail.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			var detail api.Volume
@@ -394,14 +394,14 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("ボリュームの削除", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "delete", volumeID, "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "delete", volumeID, "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
 
 			By("削除したボリュームの状態を確認")
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "detail", volumeID, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "detail", volumeID, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var volume api.Volume
@@ -412,7 +412,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 			By("削除したボリュームがリストから無くなることを確認")
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list", "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list", "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				var volumes []api.Volume
@@ -431,7 +431,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("ボリュームのリスト取得 テキスト形式", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -440,7 +440,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 	Context("OSイメージの準備", func() {
 		It("OSイメージのリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "list", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "list", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -452,7 +452,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		var imageID string
 		It("OSイメージの登録", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "create", "--configfile", "testdata/test-image-01-ubuntu22.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "create", "--configfile", "testdata/test-image-01-ubuntu22.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println(string(stdoutStderr))
@@ -464,7 +464,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		It("OSイメージの個別詳細取得", func() {
 			Eventually(func(g Gomega) {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "detail", imageID, "--output", "json")
+				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "detail", imageID, "--output", "json")
 				stdoutStderr, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Println(string(stdoutStderr))
@@ -476,7 +476,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("OSイメージのリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -485,7 +485,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		var volumeID3 string
 		It("ボリュームの作成  os qcow2 成功ケース", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "create", "-f", "testdata/test-volume-06-boot-qcow2.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "create", "-f", "testdata/test-volume-06-boot-qcow2.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -502,7 +502,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 
 		var volumeID4 string
 		It("ボリュームの作成  os lvm 成功ケース", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "create", "-f", "testdata/test-volume-07-os-lvm-success.yaml", "--output", "json")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "create", "-f", "testdata/test-volume-07-os-lvm-success.yaml", "--output", "json")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -518,7 +518,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("OSイメージのリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "image", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "image", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
@@ -526,147 +526,12 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		})
 
 		It("ボリュームリスト取得", func() {
-			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "volume", "list", "--output", "text")
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "volume", "list", "--output", "text")
 			stdoutStderr, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println(string(stdoutStderr))
 		})
 	})
-
-	/*
-		Context("基本的なCLIからのアクセステスト サーバー編", func() {
-			var ctx context.Context
-			var cancel context.CancelFunc
-			var containerID string
-
-			It("モックサーバー用etcdの起動", func() {
-				cmd := exec.Command("docker", "run", "-d", "--name", "etcd0", "-p", "3379:2379", "-p", "3380:2380", "ghcr.io/takara9/etcd:3.6.5")
-				output, err := cmd.CombinedOutput()
-				if err != nil {
-					Fail(fmt.Sprintf("Failed to start container: %s, %v", string(output), err))
-				}
-				containerID = string(output[:12]) // 最初の12文字をIDとして取得
-				fmt.Printf("Container started with ID: %s\n", containerID)
-			})
-
-			It("モックサーバーの起動", func() {
-				ctx, cancel = context.WithCancel(context.Background())
-				startMockServer(ctx)
-			})
-
-			It("モックサーバー起動の確認", func() {
-				By("Trying to connect to marmot")
-				Eventually(func(g Gomega) {
-					cmd := exec.Command("curl", "http://localhost:8080/ping")
-					err := cmd.Run()
-					GinkgoWriter.Println(cmd, "err= ", err)
-					g.Expect(err).NotTo(HaveOccurred())
-				}).Should(Succeed())
-			})
-
-			var id1 string
-			It("サーバー単体の作成 raw URL", func() {
-				// このコマンドで、marmotd側でエラーが発生する。
-				// エラーが発生する理由は、サーバー生成部分が未実装のため
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--output", "json", "--configfile", testServerConfigRawURL)
-				stdoutStderr, _ := cmd.CombinedOutput()
-				GinkgoWriter.Println(string(stdoutStderr))
-				var resp api.Success
-				err := json.Unmarshal(stdoutStderr, &resp)
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println("server id:", resp.Id)
-				id1 = resp.Id
-				Expect(len(resp.Id)).To(BeNumerically(">", 0))
-			})
-
-			var id2 string
-			It("サーバークラスタの作成", func() {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "create", "--output", "json", "--configfile", "testdata/test-server-2.yaml")
-				stdoutStderr, err := cmd.CombinedOutput()
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println(string(stdoutStderr))
-				var resp api.Success
-				err = json.Unmarshal(stdoutStderr, &resp)
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println("server id:", resp.Id)
-				id2 = resp.Id
-				fmt.Println("id2=", id2)
-				Expect(len(resp.Id)).To(BeNumerically(">", 0))
-			})
-
-			It("サーバーのリスト取得 text", func() {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "text")
-				stdoutStderr, err := cmd.CombinedOutput()
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println(string(stdoutStderr))
-			})
-
-			It("サーバーのリスト取得 json", func() {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
-				stdoutStderr, err := cmd.CombinedOutput()
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println(string(stdoutStderr))
-			})
-
-			It("サーバーのリスト取得 yaml", func() {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "yaml")
-				stdoutStderr, err := cmd.CombinedOutput()
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println(string(stdoutStderr))
-			})
-
-			It("サーバーの削除 id1", func() {
-				fmt.Println("Deleting server id1=", id1)
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "delete", id1, "--output", "json")
-				stdoutStderr, err := cmd.CombinedOutput()
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println(string(stdoutStderr))
-			})
-
-			It("サーバーの個別詳細取得 yaml", func() {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", id2, "--output", "yaml")
-				stdoutStderr, err := cmd.CombinedOutput()
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println(string(stdoutStderr))
-			})
-
-			It("サーバーの名前変更", func() {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "update", id2, "--name", "new-server-name", "--output", "yaml")
-				stdoutStderr, err := cmd.CombinedOutput()
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println(string(stdoutStderr))
-			})
-
-			It("サーバーの個別詳細取得 yaml", func() {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "detail", id2, "--output", "yaml")
-				stdoutStderr, err := cmd.CombinedOutput()
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println(string(stdoutStderr))
-			})
-
-			It("サーバーのリスト取得", func() {
-				cmd := exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "server", "list", "--output", "json")
-				stdoutStderr, err := cmd.CombinedOutput()
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Println(string(stdoutStderr))
-			})
-
-			It("モックの停止", func() {
-				cmd := exec.Command("docker", "kill", containerID)
-				_, err := cmd.CombinedOutput()
-				if err != nil {
-					fmt.Printf("Failed to stop container: %v\n", err)
-				}
-				cmd = exec.Command("docker", "rm", containerID)
-				_, err = cmd.CombinedOutput()
-				if err != nil {
-					fmt.Printf("Failed to remove container: %v\n", err)
-				}
-
-				cancel() // モックサーバー停止
-			})
-		})
-	*/
 
 	Context("ep コマンドのテスト（エンドポイント管理）", func() {
 		var tmpHome string
@@ -868,7 +733,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// --api でモックサーバーを明示指定すれば成功する
-			cmd = exec.Command("./bin/mactl-test", "--api", "testdata/config_marmot.conf", "version")
+			cmd = exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "version")
 			cmd.Env = epEnv()
 			output, err := cmd.CombinedOutput()
 			GinkgoWriter.Println(string(output))

--- a/cmd/mactl/testdata/.marmot
+++ b/cmd/mactl/testdata/.marmot
@@ -1,0 +1,3 @@
+current: 0
+endpoints:
+  - http://localhost:8080

--- a/cmd/mactl/testdata/test-image-01-ubuntu22.yaml
+++ b/cmd/mactl/testdata/test-image-01-ubuntu22.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Image
-Metadata:
-  name: ubuntu22.04
-Spec:
-  source_url: http://hmc/ubuntu-22.04-server-cloudimg-amd64.img
+metadata:
+    name: ubuntu22.04
+spec:
+    sourceUrl: http://hmc/ubuntu-22.04-server-cloudimg-amd64.img

--- a/cmd/mactl/testdata/test-network-01-test-net-1.yaml
+++ b/cmd/mactl/testdata/test-network-01-test-net-1.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: VirtualNetwork
-Metadata:
-  name: test-net-1
-Spec:
-  forwardMode: bridge
-
-
+metadata:
+    name: test-net-1
+spec:
+    forwardMode: bridge

--- a/cmd/mactl/testdata/test-network-02-test-net-2.yaml
+++ b/cmd/mactl/testdata/test-network-02-test-net-2.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: VirtualNetwork
-Metadata:
-  name: test-net-2
-Spec:
-  forwardMode: bridge
-  IPNetworkAddress: "192.168.100.0/25"
-
+metadata:
+    name: test-net-2
+spec:
+    forwardMode: bridge
+    iPNetworkAddress: "192.168.100.0/25"

--- a/cmd/mactl/testdata/test-network-03-host-bridge.yaml
+++ b/cmd/mactl/testdata/test-network-03-host-bridge.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: VirtualNetwork
-Metadata:
-  name: test-net-3
-Spec:
-  #bridgeName: br3
-  forwardMode: bridge
-
+metadata:
+    name: test-net-3
+spec:
+    #bridgeName: br3
+    forwardMode: bridge

--- a/cmd/mactl/testdata/test-server-00-none.yaml
+++ b/cmd/mactl/testdata/test-server-00-none.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-00
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
+metadata:
+    name: test-server-00
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024

--- a/cmd/mactl/testdata/test-server-01-default.yaml
+++ b/cmd/mactl/testdata/test-server-01-default.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-01
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "default"
+metadata:
+    name: test-server-01
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "default"

--- a/cmd/mactl/testdata/test-server-02-host-bridge.yaml
+++ b/cmd/mactl/testdata/test-server-02-host-bridge.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-02
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "host-bridge"
+metadata:
+    name: test-server-02
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "host-bridge"

--- a/cmd/mactl/testdata/test-server-03-host-bridge-ip.yaml
+++ b/cmd/mactl/testdata/test-server-03-host-bridge-ip.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-03
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "host-bridge"
-      address: "192.168.1.36"
-      netmasklen: 24
-      routes:
-        - to: "default"
-          via: "192.168.1.1"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-          - 8.8.8.8
-          - 8.8.4.4
-        search:
-          - labo.local
-          - lab.local
+metadata:
+    name: test-server-03
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "host-bridge"
+          address: "192.168.1.36"
+          netmasklen: 24
+          routes:
+            - to: "default"
+              via: "192.168.1.1"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+                - 8.8.8.8
+                - 8.8.4.4
+            search:
+                - labo.local
+                - lab.local

--- a/cmd/mactl/testdata/test-server-04-multi-vol-qcow2.yaml
+++ b/cmd/mactl/testdata/test-server-04-multi-vol-qcow2.yaml
@@ -1,29 +1,29 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-04
-  comment: "This is a test server configuration"
-Spec:
-  cpu: 2
-  memory: 2048
-  osVariant: ubuntu22.04
-  bootVolume:
-    Spec:
-      type: qcow2
-  NetworkInterface:
-    - networkname: "host-bridge"
-  Storage:
-    - Metadata:
-        name: "data-disk-1"
-        comment: "data volume"
-      Spec:
-        size: 100
-        type: qcow2
-        kind: data
-    - Metadata:
-        name: "data-disk-2"
-        comment: "backup volume"
-      Spec:
-        size: 100
-        type: qcow2
-        kind: data
+metadata:
+    name: test-server-04
+    comment: "This is a test server configuration"
+spec:
+    cpu: 2
+    memory: 2048
+    osVariant: ubuntu22.04
+    bootVolume:
+        spec:
+            type: qcow2
+    networkInterface:
+        - networkname: "host-bridge"
+    storage:
+        - metadata:
+            name: "data-disk-1"
+            comment: "data volume"
+          spec:
+            size: 100
+            type: qcow2
+            kind: data
+        - metadata:
+            name: "data-disk-2"
+            comment: "backup volume"
+          spec:
+            size: 100
+            type: qcow2
+            kind: data

--- a/cmd/mactl/testdata/test-server-05-boot-lvm.yaml
+++ b/cmd/mactl/testdata/test-server-05-boot-lvm.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-05
-  comment: "This is a test server configuration"
-Spec:
-  cpu: 2
-  memory: 2048
-  osVariant: ubuntu22.04
-  bootVolume:
-    Spec:
-      type: lvm
-  NetworkInterface:
-    - networkname: "host-bridge"
+metadata:
+    name: test-server-05
+    comment: "This is a test server configuration"
+spec:
+    cpu: 2
+    memory: 2048
+    osVariant: ubuntu22.04
+    bootVolume:
+        spec:
+            type: lvm
+    networkInterface:
+        - networkname: "host-bridge"

--- a/cmd/mactl/testdata/test-server-06-multivol-lvm.yaml
+++ b/cmd/mactl/testdata/test-server-06-multivol-lvm.yaml
@@ -1,29 +1,29 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-06
-  comment: "This is a test server configuration"
-Spec:
-  cpu: 2
-  memory: 2048
-  osVariant: ubuntu22.04
-  bootVolume:
-    Spec:
-      type: lvm
-  NetworkInterface:
-    - networkname: "host-bridge"
-  Storage:
-    - Metadata:
-        name: "data-disk-1"
-        comment: "data volume"
-      Spec:
-        size: 10
-        type: lvm
-        kind: data
-    - Metadata:
-        name: "data-disk-2"
-        comment: "backup volume"
-      Spec:
-        size: 10
-        type: lvm
-        kind: data
+metadata:
+    name: test-server-06
+    comment: "This is a test server configuration"
+spec:
+    cpu: 2
+    memory: 2048
+    osVariant: ubuntu22.04
+    bootVolume:
+        spec:
+            type: lvm
+    networkInterface:
+        - networkname: "host-bridge"
+    storage:
+        - metadata:
+            name: "data-disk-1"
+            comment: "data volume"
+          spec:
+            size: 10
+            type: lvm
+            kind: data
+        - metadata:
+            name: "data-disk-2"
+            comment: "backup volume"
+          spec:
+            size: 10
+            type: lvm
+            kind: data

--- a/cmd/mactl/testdata/test-server-07-host-bridge-ip.yaml
+++ b/cmd/mactl/testdata/test-server-07-host-bridge-ip.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-07
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "host-bridge"
-      address: "192.168.1.37"
-      netmasklen: 24
-      routes:
-        - to: "default"
-          via: "192.168.1.1"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-          - 8.8.8.8
-          - 8.8.4.4
-        search:
-          - labo.local
-          - lab.local
+metadata:
+    name: test-server-07
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "host-bridge"
+          address: "192.168.1.37"
+          netmasklen: 24
+          routes:
+            - to: "default"
+              via: "192.168.1.1"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+                - 8.8.8.8
+                - 8.8.4.4
+            search:
+                - labo.local
+                - lab.local

--- a/cmd/mactl/testdata/test-server-08-host-bridge-vlan.yaml
+++ b/cmd/mactl/testdata/test-server-08-host-bridge-vlan.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-08
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "ovs-network"
-      portgroup: "vlan-1002"
-      vlans:
-        - 1002
-      address: "192.168.1.37"
-      netmasklen: 24
-      routes:
-        - to: "default"
-          via: "192.168.1.1"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-          - 8.8.8.8
-          - 8.8.4.4
-        search:
-          - labo.local
-          - lab.local
+metadata:
+    name: test-server-08
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "ovs-network"
+          portgroup: "vlan-1002"
+          vlans:
+            - 1002
+          address: "192.168.1.37"
+          netmasklen: 24
+          routes:
+            - to: "default"
+              via: "192.168.1.1"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+                - 8.8.8.8
+                - 8.8.4.4
+            search:
+                - labo.local
+                - lab.local

--- a/cmd/mactl/testdata/test-server-09-net-2-set-IP.yaml
+++ b/cmd/mactl/testdata/test-server-09-net-2-set-IP.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-09
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "test-net-2"
-      address: "192.168.100.36"
-      netmasklen: 25
-      routes:
-        - to: "default"
-          via: "192.168.100.1"
+metadata:
+    name: test-server-09
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "test-net-2"
+          address: "192.168.100.36"
+          netmasklen: 25
+          routes:
+            - to: "default"
+              via: "192.168.100.1"

--- a/cmd/mactl/testdata/test-server-1.yaml
+++ b/cmd/mactl/testdata/test-server-1.yaml
@@ -1,29 +1,29 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-1
-  comment: "This is a test server configuration"
-Spec:
-  cpu: 2
-  memory: 2048
-  osVariant: ubuntu22.04
-  bootVolume:
-    Spec:
-      type: qcow2
-  NetworkInterface:
-    - networkname: "default"
-  Storage:
-    - Metadata:
-        name: "data-disk-1"
-        comment: "data volume"
-      Spec:
-        size: 100
-        type: qcow2
-        kind: data
-    - Metadata:
-        name: "data-disk-2"
-        comment: "backup volume"
-      Spec:
-        size: 100
-        type: qcow2
-        kind: data
+metadata:
+    name: test-server-1
+    comment: "This is a test server configuration"
+spec:
+    cpu: 2
+    memory: 2048
+    osVariant: ubuntu22.04
+    bootVolume:
+        spec:
+            type: qcow2
+    networkInterface:
+        - networkname: "default"
+    storage:
+        - metadata:
+            name: "data-disk-1"
+            comment: "data volume"
+          spec:
+            size: 100
+            type: qcow2
+            kind: data
+        - metadata:
+            name: "data-disk-2"
+            comment: "backup volume"
+          spec:
+            size: 100
+            type: qcow2
+            kind: data

--- a/cmd/mactl/testdata/test-server-10-net-2-set-IP.yaml
+++ b/cmd/mactl/testdata/test-server-10-net-2-set-IP.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-10
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "test-net-2"
-      address: "192.168.100.38"
-      netmasklen: 25
-      routes:
-        - to: "default"
-          via: "192.168.100.1"
+metadata:
+    name: test-server-10
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "test-net-2"
+          address: "192.168.100.38"
+          netmasklen: 25
+          routes:
+            - to: "default"
+              via: "192.168.100.1"

--- a/cmd/mactl/testdata/test-server-11-net-2-auto-IP.yaml
+++ b/cmd/mactl/testdata/test-server-11-net-2-auto-IP.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-11
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "test-net-2"
+metadata:
+    name: test-server-11
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "test-net-2"

--- a/cmd/mactl/testdata/test-server-12-net-2-auto-IP.yaml
+++ b/cmd/mactl/testdata/test-server-12-net-2-auto-IP.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-12
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "test-net-2"
+metadata:
+    name: test-server-12
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "test-net-2"

--- a/cmd/mactl/testdata/test-server-2.yaml
+++ b/cmd/mactl/testdata/test-server-2.yaml
@@ -1,29 +1,29 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-2
-  comment: "This is a test server#2 configuration"
-Spec:
-  cpu: 2
-  memory: 2048
-  osVariant: ubuntu22.04
-  bootVolume:
-    Spec:
-      type: lvm
-  NetworkInterface:
-    - networkname: "default"
-  Storage:
-    - Metadata:
-        name: "data-disk-3"
-        comment: "data volume"
-      Spec:
-        size: 20
-        type: lvm
-        kind: data
-    - Metadata:
-        name: "data-disk-4"
-        comment: "backup volume"
-      Spec:
-        size: 20
-        type: qcow2
-        kind: data
+metadata:
+    name: test-server-2
+    comment: "This is a test server#2 configuration"
+spec:
+    cpu: 2
+    memory: 2048
+    osVariant: ubuntu22.04
+    bootVolume:
+        spec:
+            type: lvm
+    networkInterface:
+        - networkname: "default"
+    storage:
+        - metadata:
+            name: "data-disk-3"
+            comment: "data volume"
+          spec:
+            size: 20
+            type: lvm
+            kind: data
+        - metadata:
+            name: "data-disk-4"
+            comment: "backup volume"
+          spec:
+            size: 20
+            type: qcow2
+            kind: data

--- a/cmd/mactl/testdata/test-server-20-test-net-3.yaml
+++ b/cmd/mactl/testdata/test-server-20-test-net-3.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-20
-  comment: "プライベートネットとNAPTでホストネットに繋ぐ"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "test-net-3"
-    - networkname: "default"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-        search:
-          - labo.local
+metadata:
+    name: test-server-20
+    comment: "プライベートネットとNAPTでホストネットに繋ぐ"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "test-net-3"
+        - networkname: "default"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+            search:
+                - labo.local

--- a/cmd/mactl/testdata/test-server-21-test-net-3.yaml
+++ b/cmd/mactl/testdata/test-server-21-test-net-3.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-21
-  comment: "プライベートネットとNAPTでホストネットに繋ぐ"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "test-net-3"
-    - networkname: "default"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-        search:
-          - labo.local
+metadata:
+    name: test-server-21
+    comment: "プライベートネットとNAPTでホストネットに繋ぐ"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "test-net-3"
+        - networkname: "default"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+            search:
+                - labo.local

--- a/cmd/mactl/testdata/test-server-22-test-net-3.yaml
+++ b/cmd/mactl/testdata/test-server-22-test-net-3.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-22
-  comment: "プライベートネットとNAPTでホストネットに繋ぐ"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "test-net-3"
-    - networkname: "default"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-        search:
-          - labo.local
+metadata:
+    name: test-server-22
+    comment: "プライベートネットとNAPTでホストネットに繋ぐ"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "test-net-3"
+        - networkname: "default"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+            search:
+                - labo.local

--- a/cmd/mactl/testdata/test-server-23-test-net-3-host-bridge-ip.yaml
+++ b/cmd/mactl/testdata/test-server-23-test-net-3-host-bridge-ip.yaml
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-23
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "test-net-3"
-    - networkname: "host-bridge"
-      address: "192.168.1.99"
-      netmasklen: 24
-      nameservers:
-        addresses:
-          - 192.168.1.9
-        search:
-          - labo.local
+metadata:
+    name: test-server-23
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "test-net-3"
+        - networkname: "host-bridge"
+          address: "192.168.1.99"
+          netmasklen: 24
+          nameservers:
+            addresses:
+                - 192.168.1.9
+            search:
+                - labo.local

--- a/cmd/mactl/testdata/test-server-28-multihome.yaml
+++ b/cmd/mactl/testdata/test-server-28-multihome.yaml
@@ -1,13 +1,12 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-28
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  NetworkInterface:
-    - networkname: "test-net-2"
-    - networkname: "test-net-1"
-    - networkname: "default"
-
+metadata:
+    name: test-server-28
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    networkInterface:
+        - networkname: "test-net-2"
+        - networkname: "test-net-1"
+        - networkname: "default"

--- a/cmd/mactl/testdata/test-server-29-multihome.yaml
+++ b/cmd/mactl/testdata/test-server-29-multihome.yaml
@@ -1,14 +1,13 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-29
-  comment: "N/A image"
-Spec:
-  cpu: 1
-  memory: 1024
-  osVariant: ubuntu22.04
-  NetworkInterface:
-    - networkname: "test-net-2"
-    - networkname: "test-net-1"
-    - networkname: "default"
-
+metadata:
+    name: test-server-29
+    comment: "N/A image"
+spec:
+    cpu: 1
+    memory: 1024
+    osVariant: ubuntu22.04
+    networkInterface:
+        - networkname: "test-net-2"
+        - networkname: "test-net-1"
+        - networkname: "default"

--- a/cmd/mactl/testdata/test-server-30-multihome.yaml
+++ b/cmd/mactl/testdata/test-server-30-multihome.yaml
@@ -1,14 +1,13 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-29
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  osVariant: ubuntu22.04
-  NetworkInterface:
-    - networkname: "test-net-2"
-    - networkname: "test-net-1"
-    - networkname: "default"
-
+metadata:
+    name: test-server-29
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    osVariant: ubuntu22.04
+    networkInterface:
+        - networkname: "test-net-2"
+        - networkname: "test-net-1"
+        - networkname: "default"

--- a/cmd/mactl/testdata/test-server-30-multivolume.yaml
+++ b/cmd/mactl/testdata/test-server-30-multivolume.yaml
@@ -1,14 +1,13 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-30
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  osVariant: ubuntu22.04
-  NetworkInterface:
-    - networkname: "test-net-2"
-    - networkname: "test-net-1"
-    - networkname: "default"
-
+metadata:
+    name: test-server-30
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    osVariant: ubuntu22.04
+    networkInterface:
+        - networkname: "test-net-2"
+        - networkname: "test-net-1"
+        - networkname: "default"

--- a/cmd/mactl/testdata/test-server-31-multihome-host-bridge.yaml
+++ b/cmd/mactl/testdata/test-server-31-multihome-host-bridge.yaml
@@ -1,25 +1,25 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-31
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  osVariant: ubuntu22.04
-  NetworkInterface:
-    - networkname: "host-bridge"
-      address: "192.168.1.99"
-      netmasklen: 24
-      routes:
-        - to: "default"
-          via: "192.168.1.1"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-          - 8.8.8.8
-          - 8.8.4.4
-        search:
-          - labo.local
-          - lab.local
-    - networkname: "test-net-1"
+metadata:
+    name: test-server-31
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    osVariant: ubuntu22.04
+    networkInterface:
+        - networkname: "host-bridge"
+          address: "192.168.1.99"
+          netmasklen: 24
+          routes:
+            - to: "default"
+              via: "192.168.1.1"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+                - 8.8.8.8
+                - 8.8.4.4
+            search:
+                - labo.local
+                - lab.local
+        - networkname: "test-net-1"

--- a/cmd/mactl/testdata/test-server-32-multihome-host-bridge.yaml
+++ b/cmd/mactl/testdata/test-server-32-multihome-host-bridge.yaml
@@ -1,25 +1,25 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-32
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  osVariant: ubuntu22.04
-  NetworkInterface:
-    - networkname: "host-bridge"
-      address: "192.168.1.98"
-      netmasklen: 24
-      routes:
-        - to: "default"
-          via: "192.168.1.1"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-          - 8.8.8.8
-          - 8.8.4.4
-        search:
-          - labo.local
-          - lab.local
-    - networkname: "test-net-1"
+metadata:
+    name: test-server-32
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    osVariant: ubuntu22.04
+    networkInterface:
+        - networkname: "host-bridge"
+          address: "192.168.1.98"
+          netmasklen: 24
+          routes:
+            - to: "default"
+              via: "192.168.1.1"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+                - 8.8.8.8
+                - 8.8.4.4
+            search:
+                - labo.local
+                - lab.local
+        - networkname: "test-net-1"

--- a/cmd/mactl/testdata/test-server-33-multihome-host-bridge.yaml
+++ b/cmd/mactl/testdata/test-server-33-multihome-host-bridge.yaml
@@ -1,25 +1,25 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-33
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 4
-  memory: 8192
-  osVariant: ubuntu22.04
-  NetworkInterface:
-    - networkname: "host-bridge"
-      address: "192.168.1.98"
-      netmasklen: 24
-      routes:
-        - to: "default"
-          via: "192.168.1.1"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-          - 8.8.8.8
-          - 8.8.4.4
-        search:
-          - labo.local
-          - lab.local
-    - networkname: "test-net-1"
+metadata:
+    name: test-server-33
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 4
+    memory: 8192
+    osVariant: ubuntu22.04
+    networkInterface:
+        - networkname: "host-bridge"
+          address: "192.168.1.98"
+          netmasklen: 24
+          routes:
+            - to: "default"
+              via: "192.168.1.1"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+                - 8.8.8.8
+                - 8.8.4.4
+            search:
+                - labo.local
+                - lab.local
+        - networkname: "test-net-1"

--- a/cmd/mactl/testdata/test-server-34-sshkey.yaml
+++ b/cmd/mactl/testdata/test-server-34-sshkey.yaml
@@ -1,27 +1,27 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-34
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  osVariant: ubuntu22.04
-  auth:
-    url: https://github.com/takara9.keys
-  NetworkInterface:
-    - networkname: "host-bridge"
-      address: "192.168.1.198"
-      netmasklen: 24
-      routes:
-        - to: "default"
-          via: "192.168.1.1"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-          - 8.8.8.8
-          - 8.8.4.4
-        search:
-          - labo.local
-          - lab.local
-    - networkname: "test-net-1"
+metadata:
+    name: test-server-34
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    osVariant: ubuntu22.04
+    auth:
+        url: https://github.com/takara9.keys
+    networkInterface:
+        - networkname: "host-bridge"
+          address: "192.168.1.198"
+          netmasklen: 24
+          routes:
+            - to: "default"
+              via: "192.168.1.1"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+                - 8.8.8.8
+                - 8.8.4.4
+            search:
+                - labo.local
+                - lab.local
+        - networkname: "test-net-1"

--- a/cmd/mactl/testdata/test-server-35-sshkey.yaml
+++ b/cmd/mactl/testdata/test-server-35-sshkey.yaml
@@ -1,31 +1,31 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-35
-  comment: "This is a minimum configuration"
-Spec:
-  cpu: 1
-  memory: 1024
-  osVariant: ubuntu22.04
-  bootVolume:
-    Spec:
-      type: lvm
-  auth:
-    url: https://github.com/takara9.keys
-    user: user1
-  NetworkInterface:
-    - networkname: "host-bridge"
-      address: "192.168.1.197"
-      netmasklen: 24
-      routes:
-        - to: "default"
-          via: "192.168.1.1"
-      nameservers:
-        addresses:
-          - 192.168.1.9
-          - 8.8.8.8
-          - 8.8.4.4
-        search:
-          - labo.local
-          - lab.local
-    - networkname: "test-net-1"
+metadata:
+    name: test-server-35
+    comment: "This is a minimum configuration"
+spec:
+    cpu: 1
+    memory: 1024
+    osVariant: ubuntu22.04
+    bootVolume:
+        spec:
+            type: lvm
+    auth:
+        url: https://github.com/takara9.keys
+        user: user1
+    networkInterface:
+        - networkname: "host-bridge"
+          address: "192.168.1.197"
+          netmasklen: 24
+          routes:
+            - to: "default"
+              via: "192.168.1.1"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+                - 8.8.8.8
+                - 8.8.4.4
+            search:
+                - labo.local
+                - lab.local
+        - networkname: "test-net-1"

--- a/cmd/mactl/testdata/test-server-36-existing-volume-id.yaml
+++ b/cmd/mactl/testdata/test-server-36-existing-volume-id.yaml
@@ -1,21 +1,21 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-36
-  comment: "Attach existing volumes by id"
-Spec:
-  cpu: 1
-  memory: 1024
-  osVariant: ubuntu22.04
-  bootVolume:
-    id: "b7fd113"
-    Metadata:
-      id: "b7fd113"
-  Storage:
-    - id: "data1234"
-      Metadata:
-        id: "data1234"
-    - Metadata:
-        name: "my-data-vol"
-  NetworkInterface:
-    - networkname: "default"
+metadata:
+    name: test-server-36
+    comment: "Attach existing volumes by id"
+spec:
+    cpu: 1
+    memory: 1024
+    osVariant: ubuntu22.04
+    bootVolume:
+        id: "b7fd113"
+        metadata:
+            id: "b7fd113"
+    storage:
+        - id: "data1234"
+          metadata:
+            id: "data1234"
+        - metadata:
+            name: "my-data-vol"
+    networkInterface:
+        - networkname: "default"

--- a/cmd/mactl/testdata/test-server-37-node-selector.yaml
+++ b/cmd/mactl/testdata/test-server-37-node-selector.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-37
-  nodeName: "marmot1"
-  comment: "Schedule this server on a specific node"
-Spec:
-  cpu: 1
-  memory: 1024
-  osVariant: ubuntu24.04
-  bootVolume:
-    Spec:
-      type: qcow2
-      size: 16
-  NetworkInterface:
-    - networkname: "default"
+metadata:
+    name: test-server-37
+    nodeName: "marmot1"
+    comment: "Schedule this server on a specific node"
+spec:
+    cpu: 1
+    memory: 1024
+    osVariant: ubuntu24.04
+    bootVolume:
+        spec:
+            type: qcow2
+            size: 16
+    networkInterface:
+        - networkname: "default"

--- a/cmd/mactl/testdata/test-server-99.yaml
+++ b/cmd/mactl/testdata/test-server-99.yaml
@@ -1,29 +1,29 @@
 apiVersion: v1
 kind: Server
-Metadata:
-  name: test-server-2
-  comment: "This is a test server configuration"
-Spec:
-  cpu: 2
-  memory: 2048
-  osVariant: ubuntu22.04
-  bootVolume:
-    Spec:
-      type: qcow2
-  NetworkInterface:
-    - networkname: "default"
-  Storage:
-    - Metadata:
-        name: "data-disk-1"
-        comment: "data volume"
-      Spec:
-        size: 100
-        type: qcow2
-        kind: data
-    - Metadata:
-        name: "data-disk-2"
-        comment: "backup volume"
-      Spec:
-        size: 100
-        type: qcow2
-        kind: data
+metadata:
+    name: test-server-2
+    comment: "This is a test server configuration"
+spec:
+    cpu: 2
+    memory: 2048
+    osVariant: ubuntu22.04
+    bootVolume:
+        spec:
+            type: qcow2
+    networkInterface:
+        - networkname: "default"
+    storage:
+        - metadata:
+            name: "data-disk-1"
+            comment: "data volume"
+          spec:
+            size: 100
+            type: qcow2
+            kind: data
+        - metadata:
+            name: "data-disk-2"
+            comment: "backup volume"
+          spec:
+            size: 100
+            type: qcow2
+            kind: data

--- a/cmd/mactl/testdata/test-volume-01-data-qcow2.yaml
+++ b/cmd/mactl/testdata/test-volume-01-data-qcow2.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Volume
-Metadata:
-  name: test-volume1
-Spec:
-  type: qcow2
-  kind: data
-  size: 2
+metadata:
+    name: test-volume1
+spec:
+    type: qcow2
+    kind: data
+    size: 2

--- a/cmd/mactl/testdata/test-volume-02-data-lvm.yaml
+++ b/cmd/mactl/testdata/test-volume-02-data-lvm.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Volume
-Metadata:
-  name: test-volume2
-Spec:
-  type: lvm
-  kind: data
-  size: 2
+metadata:
+    name: test-volume2
+spec:
+    type: lvm
+    kind: data
+    size: 2

--- a/cmd/mactl/testdata/test-volume-03-os-qcow2.yaml
+++ b/cmd/mactl/testdata/test-volume-03-os-qcow2.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Volume
-Metadata:
-  name: test-volume3
-Spec:
-  type: qcow2
-  kind: os
-  osVariant: ubuntu22.04
+metadata:
+    name: test-volume3
+spec:
+    type: qcow2
+    kind: os
+    osVariant: ubuntu22.04

--- a/cmd/mactl/testdata/test-volume-04-os-lvm.yaml
+++ b/cmd/mactl/testdata/test-volume-04-os-lvm.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Volume
-Metadata:
-  name: test-volume4
-Spec:
-  type: lvm
-  kind: os
-  osVariant: ubuntu22.04
+metadata:
+    name: test-volume4
+spec:
+    type: lvm
+    kind: os
+    osVariant: ubuntu22.04

--- a/cmd/mactl/testdata/test-volume-05-rename-source.yaml
+++ b/cmd/mactl/testdata/test-volume-05-rename-source.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Volume
-Metadata:
-  name: test-origine
-Spec:
-  type: lvm
-  kind: data
-  size: 2
+metadata:
+    name: test-origine
+spec:
+    type: lvm
+    kind: data
+    size: 2

--- a/cmd/mactl/testdata/test-volume-06-boot-qcow2.yaml
+++ b/cmd/mactl/testdata/test-volume-06-boot-qcow2.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Volume
-Metadata:
-  name: boot-volume1
-Spec:
-  type: qcow2
-  kind: os
-  osVariant: ubuntu22.04
+metadata:
+    name: boot-volume1
+spec:
+    type: qcow2
+    kind: os
+    osVariant: ubuntu22.04

--- a/cmd/mactl/testdata/test-volume-07-os-lvm-success.yaml
+++ b/cmd/mactl/testdata/test-volume-07-os-lvm-success.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Volume
-Metadata:
-  name: test-volume2
-Spec:
-  type: lvm
-  kind: os
-  osVariant: ubuntu22.04
+metadata:
+    name: test-volume2
+spec:
+    type: lvm
+    kind: os
+    osVariant: ubuntu22.04

--- a/docs/HOWTO-build-package.md
+++ b/docs/HOWTO-build-package.md
@@ -3,7 +3,8 @@
 package 実行時に CGO を有効化して実行
 
 ```
-sudo apt install gcc pkg-config libvirt-dev
+sudo apt update
+sudo apt install gcc pkg-config libvirt-dev make
 pkg-config --modversion libvirt
 CGO_ENABLED=1 make package
 ```

--- a/docs/HOWTO-install-golang.md
+++ b/docs/HOWTO-install-golang.md
@@ -5,8 +5,6 @@
 https://go.dev/dl/
 
 
-1.21 は、現在 libvirtが動かない
-
 ```console
 GOVER=1.21.1
 ```

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,7 +16,7 @@ var _ = Describe("ReadYamlConfig", func() {
 	It("reads a YAML config from a file", func() {
 		tmpDir := GinkgoT().TempDir()
 		configPath := filepath.Join(tmpDir, "server.yaml")
-		content := "Metadata:\n  name: file-server\nSpec:\n  cpu: 2\n"
+		content := "metadata:\n  name: file-server\nspec:\n  cpu: 2\n"
 
 		err := os.WriteFile(configPath, []byte(content), 0o600)
 		Expect(err).NotTo(HaveOccurred())
@@ -38,7 +38,7 @@ var _ = Describe("ReadYamlConfig", func() {
 				http.NotFound(w, r)
 				return
 			}
-			_, _ = w.Write([]byte("Metadata:\n  name: url-server\nSpec:\n  memory: 2048\n"))
+			_, _ = w.Write([]byte("metadata:\n  name: url-server\nspec:\n  memory: 2048\n"))
 		}))
 		defer server.Close()
 
@@ -73,10 +73,10 @@ var _ = Describe("ReadYamlConfig", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("reads Metadata.comment from a YAML config", func() {
+	It("reads metadata.comment from a YAML config", func() {
 		tmpDir := GinkgoT().TempDir()
-		configPath := filepath.Join(tmpDir, "server-Metadata.yaml")
-		content := "Metadata:\n  name: metadata-server\n  comment: created-from-Metadata\n"
+		configPath := filepath.Join(tmpDir, "server-metadata.yaml")
+		content := "metadata:\n  name: metadata-server\n  comment: created-from-metadata\n"
 
 		err := os.WriteFile(configPath, []byte(content), 0o600)
 		Expect(err).NotTo(HaveOccurred())
@@ -86,6 +86,6 @@ var _ = Describe("ReadYamlConfig", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(conf.Metadata).NotTo(BeNil())
 		Expect(conf.Metadata.Comment).NotTo(BeNil())
-		Expect(*conf.Metadata.Comment).To(Equal("created-from-Metadata"))
+		Expect(*conf.Metadata.Comment).To(Equal("created-from-metadata"))
 	})
 })

--- a/pkg/controller/scheduler-controller.go
+++ b/pkg/controller/scheduler-controller.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/db"
 	"github.com/takara9/marmot/pkg/marmotd"
 )
@@ -97,9 +98,19 @@ func (c *schedulerController) schedulerControllerLoop() {
 		if server.Status == nil || server.Status.StatusCode != db.SERVER_PENDING {
 			continue
 		}
-		// NodeName が既に設定済みの場合はスキップ
-		if server.Metadata != nil && server.Metadata.NodeName != nil &&
-			strings.TrimSpace(*server.Metadata.NodeName) != "" {
+
+		assignedNode := ""
+		if server.Metadata != nil && server.Metadata.NodeName != nil {
+			assignedNode = strings.TrimSpace(*server.Metadata.NodeName)
+		}
+
+		// metadata.nodeName が指定済みの場合は存在チェックのみ行い、未知ノードなら ERROR に更新する。
+		if assignedNode != "" {
+			if !clusterHasNode(statuses, assignedNode) {
+				msg := "metadata.nodeName=" + assignedNode + " はクラスタ内に存在しません"
+				slog.Warn("存在しない nodeName が指定されたサーバーを ERROR に更新", "serverId", server.Id, "nodeName", assignedNode)
+				c.marmot.Db.UpdateServerStatus(server.Id, db.SERVER_ERROR, msg)
+			}
 			continue
 		}
 
@@ -117,4 +128,22 @@ func (c *schedulerController) schedulerControllerLoop() {
 		}
 		slog.Info("サーバーにノードを割り当てました", "serverId", server.Id, "targetNode", targetNode)
 	}
+}
+
+func clusterHasNode(statuses []api.HostStatus, nodeName string) bool {
+	target := strings.TrimSpace(nodeName)
+	if target == "" {
+		return false
+	}
+
+	for _, st := range statuses {
+		if st.NodeName == nil {
+			continue
+		}
+		if strings.TrimSpace(*st.NodeName) == target {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/controller/scheduler-controller_test.go
+++ b/pkg/controller/scheduler-controller_test.go
@@ -1,0 +1,37 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestClusterHasNode(t *testing.T) {
+	statuses := []api.HostStatus{
+		{NodeName: util.StringPtr("hvc")},
+		{NodeName: util.StringPtr("ws1")},
+		{},
+	}
+
+	tests := []struct {
+		name     string
+		nodeName string
+		want     bool
+	}{
+		{name: "existing node", nodeName: "hvc", want: true},
+		{name: "existing node with spaces", nodeName: " ws1 ", want: true},
+		{name: "missing node", nodeName: "not-found", want: false},
+		{name: "empty node", nodeName: "", want: false},
+		{name: "spaces only", nodeName: "   ", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clusterHasNode(statuses, tt.nodeName)
+			if got != tt.want {
+				t.Fatalf("clusterHasNode(%q) = %v, want %v", tt.nodeName, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/server-controller.go
+++ b/pkg/controller/server-controller.go
@@ -8,8 +8,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/db"
 	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/util"
 )
 
 const (
@@ -88,6 +90,14 @@ func (c *controller) Stop() {
 func (c *controller) serverControllerLoop() {
 	slog.Debug("サーバーコントローラーの制御ループ実行", "CONTROLLER", time.Now().Format("2006-01-02 15:04:05"))
 
+	clusterHasNodes := true
+	statuses, err := c.marmot.Db.GetAllHostStatus()
+	if err != nil {
+		slog.Warn("GetAllHostStatus() failed; クラスタノード存在確認をスキップ", "err", err)
+	} else {
+		clusterHasNodes = clusterHasAnyNode(statuses)
+	}
+
 	// サーバースペック情報の取得
 	slog.Debug("サーバースペック情報取得", "", "")
 	serverSpec, err := c.marmot.GetServersManage()
@@ -97,8 +107,21 @@ func (c *controller) serverControllerLoop() {
 	}
 
 	for _, spec := range serverSpec {
+		// 削除のタイムスタンプが一定時間以上経過しているかをチェックして、削除処理を実行する
+		if spec.Status != nil && spec.Status.DeletionTimeStamp != nil {
+			deletionTime := *spec.Status.DeletionTimeStamp
+			if time.Since(deletionTime) > c.deletionDelay {
+				slog.Debug("削除のタイムスタンプが一定時間以上経過しているサーバー検出", "SERVER", spec.Id)
+				c.marmot.Db.UpdateServerStatus(spec.Id, db.SERVER_DELETING, "")
+				spec.Status.StatusCode = db.SERVER_DELETING
+				spec.Status.Status = util.StringPtr(db.ServerStatus[db.SERVER_DELETING])
+			}
+		}
+
+		forceDeleteWithoutNode, bypassReason := shouldBypassNodeGateForDeletingServer(spec, statuses)
+
 		// サーバーは必ず nodeName 割当後に処理する。
-		if spec.Metadata == nil || spec.Metadata.NodeName == nil || strings.TrimSpace(*spec.Metadata.NodeName) == "" {
+		if !forceDeleteWithoutNode && (spec.Metadata == nil || spec.Metadata.NodeName == nil || strings.TrimSpace(*spec.Metadata.NodeName) == "") {
 			objectName := ""
 			if spec.Metadata != nil && spec.Metadata.Name != nil {
 				objectName = *spec.Metadata.Name
@@ -107,13 +130,21 @@ func (c *controller) serverControllerLoop() {
 			continue
 		}
 
-		if ok, assignedNode, reason := evaluateNodeAssignment(spec.Metadata, c.marmot.NodeName); !ok {
+		if !forceDeleteWithoutNode {
+			if ok, assignedNode, reason := evaluateNodeAssignment(spec.Metadata, c.marmot.NodeName); !ok {
+				objectName := ""
+				if spec.Metadata != nil && spec.Metadata.Name != nil {
+					objectName = *spec.Metadata.Name
+				}
+				slog.Debug("別ノード割当のサーバーをスキップ", "serverId", spec.Id, "serverName", objectName, "controllerNode", c.marmot.NodeName, "assignedNode", assignedNode, "reason", reason)
+				continue
+			}
+		} else {
 			objectName := ""
 			if spec.Metadata != nil && spec.Metadata.Name != nil {
 				objectName = *spec.Metadata.Name
 			}
-			slog.Debug("別ノード割当のサーバーをスキップ", "serverId", spec.Id, "serverName", objectName, "controllerNode", c.marmot.NodeName, "assignedNode", assignedNode, "reason", reason)
-			continue
+			slog.Warn("nodeName 判定をバイパスして削除を継続", "serverId", spec.Id, "serverName", objectName, "reason", bypassReason)
 		}
 
 		// 取得したサーバースペック情報の表示とプロビジョニング中サーバーの検出
@@ -123,15 +154,6 @@ func (c *controller) serverControllerLoop() {
 		//	continue
 		//}
 		//fmt.Println(string(jsonByte))
-
-		// 削除のタイムスタンプが一定時間以上経過しているかをチェックして、削除処理を実行する
-		if spec.Status != nil && spec.Status.DeletionTimeStamp != nil {
-			deletionTime := *spec.Status.DeletionTimeStamp
-			if time.Since(deletionTime) > c.deletionDelay {
-				slog.Debug("削除のタイムスタンプが一定時間以上経過しているサーバー検出", "SERVER", spec.Id)
-				c.marmot.Db.UpdateServerStatus(spec.Id, db.SERVER_DELETING, "")
-			}
-		}
 
 		// サーバーの状態に応じた処理を実行する
 		switch spec.Status.StatusCode {
@@ -168,11 +190,29 @@ func (c *controller) serverControllerLoop() {
 		case db.SERVER_DELETING:
 			slog.Debug("削除中のサーバー検出", "SERVER", spec.Id)
 
-			// 仮想マシンの削除処理の実行
-			if err := c.marmot.DeleteServerByIdManage(spec.Id); err != nil {
-				slog.Error("DeleteServerById()", "err", err)
-				msg := fmt.Sprintf("サーバーの削除に失敗: %v", err)
-				c.marmot.Db.UpdateServerStatus(spec.Id, db.SERVER_ERROR, msg)
+			if !clusterHasNodes {
+				if spec.Spec != nil && spec.Spec.BootVolume != nil && strings.TrimSpace(spec.Spec.BootVolume.Id) != "" {
+					c.marmot.Db.SetVolumeDeletionTimestamp(spec.Spec.BootVolume.Id)
+				}
+				if spec.Spec != nil && spec.Spec.Storage != nil {
+					for _, vol := range *spec.Spec.Storage {
+						if vol.Spec != nil && vol.Spec.Persistent != nil && *vol.Spec.Persistent {
+							continue
+						}
+						if strings.TrimSpace(vol.Id) == "" {
+							continue
+						}
+						c.marmot.Db.SetVolumeDeletionTimestamp(vol.Id)
+					}
+				}
+				slog.Warn("クラスタノード不在のため VM 実体削除をスキップし、サーバー定義削除を継続", "serverId", spec.Id)
+			} else {
+				// 仮想マシンの削除処理の実行
+				if err := c.marmot.DeleteServerByIdManage(spec.Id); err != nil {
+					slog.Error("DeleteServerById()", "err", err)
+					msg := fmt.Sprintf("サーバーの削除に失敗: %v", err)
+					c.marmot.Db.UpdateServerStatus(spec.Id, db.SERVER_ERROR, msg)
+				}
 			}
 
 			// IPアドレス開放処理の実行
@@ -221,4 +261,42 @@ func (c *controller) serverControllerLoop() {
 
 	// ワークキューから処理を取り出して、処理を実行する
 
+}
+
+func clusterHasAnyNode(statuses []api.HostStatus) bool {
+	for _, st := range statuses {
+		if st.NodeName == nil {
+			continue
+		}
+		if strings.TrimSpace(*st.NodeName) != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func shouldBypassNodeGateForDeletingServer(spec api.Server, statuses []api.HostStatus) (bool, string) {
+	if spec.Status == nil || spec.Status.StatusCode != db.SERVER_DELETING {
+		return false, ""
+	}
+
+	if !clusterHasAnyNode(statuses) {
+		return true, "cluster_nodes_empty"
+	}
+
+	if spec.Metadata == nil || spec.Metadata.NodeName == nil {
+		return true, "assigned_node_missing"
+	}
+
+	assignedNode := strings.TrimSpace(*spec.Metadata.NodeName)
+	if assignedNode == "" {
+		return true, "assigned_node_empty"
+	}
+
+	if !clusterHasNode(statuses, assignedNode) {
+		return true, "assigned_node_not_found"
+	}
+
+	return false, ""
 }

--- a/pkg/controller/server-controller_test.go
+++ b/pkg/controller/server-controller_test.go
@@ -1,0 +1,111 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestClusterHasAnyNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses []api.HostStatus
+		want     bool
+	}{
+		{
+			name: "has valid node",
+			statuses: []api.HostStatus{
+				{NodeName: util.StringPtr("hvc")},
+			},
+			want: true,
+		},
+		{
+			name: "node name with spaces only",
+			statuses: []api.HostStatus{
+				{NodeName: util.StringPtr("   ")},
+				{},
+			},
+			want: false,
+		},
+		{
+			name: "empty statuses",
+			statuses: []api.HostStatus{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clusterHasAnyNode(tt.statuses)
+			if got != tt.want {
+				t.Fatalf("clusterHasAnyNode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldBypassNodeGateForDeletingServer(t *testing.T) {
+	deletingStatus := &api.Status{StatusCode: db.SERVER_DELETING}
+	runningStatus := &api.Status{StatusCode: db.SERVER_RUNNING}
+
+	statusesWithNode := []api.HostStatus{{NodeName: util.StringPtr("hvc")}}
+	emptyStatuses := []api.HostStatus{}
+
+	tests := []struct {
+		name       string
+		spec       api.Server
+		statuses   []api.HostStatus
+		wantBypass bool
+		wantReason string
+	}{
+		{
+			name:       "not deleting",
+			spec:       api.Server{Status: runningStatus},
+			statuses:   statusesWithNode,
+			wantBypass: false,
+			wantReason: "",
+		},
+		{
+			name:       "cluster empty",
+			spec:       api.Server{Status: deletingStatus},
+			statuses:   emptyStatuses,
+			wantBypass: true,
+			wantReason: "cluster_nodes_empty",
+		},
+		{
+			name: "assigned node not found",
+			spec: api.Server{
+				Status: deletingStatus,
+				Metadata: &api.Metadata{
+					NodeName: util.StringPtr("ws1"),
+				},
+			},
+			statuses:   statusesWithNode,
+			wantBypass: true,
+			wantReason: "assigned_node_not_found",
+		},
+		{
+			name: "assigned node found",
+			spec: api.Server{
+				Status: deletingStatus,
+				Metadata: &api.Metadata{
+					NodeName: util.StringPtr("hvc"),
+				},
+			},
+			statuses:   statusesWithNode,
+			wantBypass: false,
+			wantReason: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBypass, gotReason := shouldBypassNodeGateForDeletingServer(tt.spec, tt.statuses)
+			if gotBypass != tt.wantBypass || gotReason != tt.wantReason {
+				t.Fatalf("shouldBypassNodeGateForDeletingServer() = (%v, %q), want (%v, %q)", gotBypass, gotReason, tt.wantBypass, tt.wantReason)
+			}
+		})
+	}
+}

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -805,7 +805,12 @@ func (m *Marmot) DeleteServerByIdManage(id string) error {
 		return err
 	}
 
-	if sv.Metadata.InstanceName != nil {
+	serverName := ""
+	if sv.Metadata != nil && sv.Metadata.Name != nil {
+		serverName = *sv.Metadata.Name
+	}
+
+	if sv.Metadata != nil && sv.Metadata.InstanceName != nil {
 		// サーバーの削除
 		l, err := virt.NewLibVirtEp("qemu:///system")
 		if err != nil {
@@ -823,21 +828,29 @@ func (m *Marmot) DeleteServerByIdManage(id string) error {
 			//	slog.Error("DeleteDomain()", "err", err)
 			//	return err
 			//}
-			slog.Debug("DeleteServerById()", "server is in PROVISIONING state, skipping domain deletion", *sv.Metadata.Name)
+			slog.Debug("DeleteServerById()", "server is in PROVISIONING state, skipping domain deletion", serverName)
 			// return nil 戻さず、削除処理を続行する
 		}
 	}
 
 	// ブートボリュームの削除タイムスタンプのセット
-	m.Db.SetVolumeDeletionTimestamp(sv.Spec.BootVolume.Id)
+	if sv.Spec != nil && sv.Spec.BootVolume != nil && strings.TrimSpace(sv.Spec.BootVolume.Id) != "" {
+		m.Db.SetVolumeDeletionTimestamp(sv.Spec.BootVolume.Id)
+	} else {
+		slog.Warn("DeleteServerByIdManage() boot volume is missing, skipping deletion timestamp", "serverId", id, "serverName", serverName)
+	}
 
 	// データボリュームの削除タイムスタンプのセット
-	if sv.Spec.Storage != nil {
+	if sv.Spec != nil && sv.Spec.Storage != nil {
 		slog.Debug("アタッチされているボリューム削除のため Deletion Timestamp をセット", "ボリューム数", len(*sv.Spec.Storage))
 		for i, vol := range *sv.Spec.Storage {
 			slog.Debug("DeleteServerById()", "index", i, "deleting volume id", vol.Id)
-			if vol.Spec.Persistent != nil && *vol.Spec.Persistent {
+			if vol.Spec != nil && vol.Spec.Persistent != nil && *vol.Spec.Persistent {
 				slog.Debug("DeleteServerById()", "skipping persistent volume", vol.Id)
+				continue
+			}
+			if strings.TrimSpace(vol.Id) == "" {
+				slog.Warn("DeleteServerByIdManage() attached volume id is empty, skipping", "serverId", id, "index", i)
 				continue
 			}
 			m.Db.SetVolumeDeletionTimestamp(vol.Id)

--- a/pkg/marmotd/volume_iscsi_cleanup_test.go
+++ b/pkg/marmotd/volume_iscsi_cleanup_test.go
@@ -97,3 +97,32 @@ func TestCleanupISCSIForVolumeAllowsMissingResources(t *testing.T) {
 		t.Fatalf("cleanupISCSIForVolume() should ignore missing resources, but got error = %v", err)
 	}
 }
+
+func TestCleanupISCSIForVolumeAllowsMissingBackstoreMessage(t *testing.T) {
+	original := targetcliCommandOutput
+	defer func() { targetcliCommandOutput = original }()
+
+	targetcliCommandOutput = func(args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "saveconfig" {
+			return []byte("saved"), nil
+		}
+		if len(args) >= 2 && args[0] == "/backstores/block" && args[1] == "delete" {
+			return []byte("No storage object named disk-abcde."), errors.New("not found")
+		}
+		return []byte("ok"), nil
+	}
+
+	m := &Marmot{}
+	vol := api.Volume{
+		Id: "abcde",
+		Spec: &api.VolSpec{
+			Type:  util.StringPtr("lvm"),
+			Kind:  util.StringPtr("data"),
+			Iscsi: util.BoolPtr(true),
+		},
+	}
+
+	if err := m.cleanupISCSIForVolume(&vol); err != nil {
+		t.Fatalf("cleanupISCSIForVolume() should ignore missing backstore message, but got error = %v", err)
+	}
+}

--- a/pkg/marmotd/volumes.go
+++ b/pkg/marmotd/volumes.go
@@ -46,7 +46,10 @@ func runTargetcliAllowMissing(args ...string) error {
 	}
 
 	message := strings.ToLower(strings.TrimSpace(string(out)))
-	if strings.Contains(message, "not found") || strings.Contains(message, "no such") || strings.Contains(message, "does not exist") {
+	if strings.Contains(message, "not found") ||
+		strings.Contains(message, "no such") ||
+		strings.Contains(message, "does not exist") ||
+		strings.Contains(message, "no storage object named") {
 		return nil
 	}
 

--- a/pkg/networkfabric/ovs.go
+++ b/pkg/networkfabric/ovs.go
@@ -72,16 +72,26 @@ func (o *OVSFabric) EnsureVxlanMesh(vnet *api.VirtualNetwork, peers []string) er
 	if vnet.Spec.UnderlayInterface != nil {
 		underlayIf = strings.TrimSpace(*vnet.Spec.UnderlayInterface)
 	}
-	localIP, err := resolveInterfaceIPv4(underlayIf)
-	if err != nil {
-		return err
-	}
 
+	validPeers := make([]string, 0, len(peers))
 	for _, peerIP := range peers {
 		peerIP = strings.TrimSpace(peerIP)
 		if peerIP == "" {
 			continue
 		}
+		validPeers = append(validPeers, peerIP)
+	}
+	if len(validPeers) == 0 {
+		slog.Debug("no vxlan peers resolved, skipping tunnel ensure", "bridge", bridgeName)
+		return nil
+	}
+
+	localIP, err := resolveInterfaceIPv4(underlayIf)
+	if err != nil {
+		return err
+	}
+
+	for _, peerIP := range validPeers {
 
 		// トンネル名はブリッジ毎に一意化し、別ネットワーク間の名前衝突を避ける。
 		tunnelName := tunnelNameForPeer(bridgeName, peerIP)

--- a/pkg/virt/libvirtXml2.go
+++ b/pkg/virt/libvirtXml2.go
@@ -3,6 +3,8 @@ package virt
 import (
 	"fmt"
 	"log/slog"
+	"os/exec"
+	"strings"
 	"time"
 
 	"libvirt.org/go/libvirt"
@@ -389,6 +391,11 @@ func (l *LibVirtEp) DefineAndStartVM(domain libvirtxml.Domain) error {
 
 	// Start VM
 	err = dom.Create()
+	if err != nil && isOVSPortAttachConflict(err) {
+		slog.Warn("domain start failed due to ovs port conflict, attempting stale-port cleanup and retry", "err", err)
+		cleanupStaleOVSPorts()
+		err = dom.Create()
+	}
 	if err != nil {
 		return err
 	}
@@ -401,6 +408,51 @@ func (l *LibVirtEp) DefineAndStartVM(domain libvirtxml.Domain) error {
 	defer dom.Free()
 
 	return nil
+}
+
+func isOVSPortAttachConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unable to add port") && strings.Contains(msg, "already attached to bridge")
+}
+
+func cleanupStaleOVSPorts() {
+	cmd := exec.Command("ovs-vsctl", "--format=csv", "--data=bare", "--no-headings", "--columns=name,error", "find", "Interface", "error!=\"\"")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Warn("failed to list ovs interfaces with errors", "err", err, "output", strings.TrimSpace(string(out)))
+		return
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ",", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		errText := strings.Trim(strings.TrimSpace(parts[1]), "\"")
+		if name == "" || errText == "" {
+			continue
+		}
+		if !strings.Contains(strings.ToLower(errText), "no such device") {
+			continue
+		}
+
+		delCmd := exec.Command("ovs-vsctl", "--if-exists", "del-port", name)
+		delOut, delErr := delCmd.CombinedOutput()
+		if delErr != nil {
+			slog.Warn("failed to remove stale ovs port", "port", name, "err", delErr, "output", strings.TrimSpace(string(delOut)))
+			continue
+		}
+		slog.Info("removed stale ovs port", "port", name, "reason", errText)
+	}
 }
 
 func (l *LibVirtEp) ListDomains() ([]string, error) {


### PR DESCRIPTION
## 概要

marmot-api-v1.go の JSON/YAML タグ命名規則を整理し、全フィールドをキャメルケース（小文字始まり）に統一しました。  
あわせて、タグ変更に合わせて YAML 入力ファイル側も更新し、互換処理を廃止しています。

## 変更内容

### 1. JSON/YAML タグを小文字始まりキャメルケースに統一（marmot-api-v1.go）

oapi-codegen の生成コードでは、Go の命名規則に由来する大文字始まりのタグキー（例: `Metadata`, `Spec`, `Storage`, `NetworkInterface` など）が生成される場合がありました。  
これらを全て小文字始まりのキャメルケースへ変更しました。

主な変更例:

| 変更前 | 変更後 |
|---|---|
| `json:"Metadata"` | `json:"metadata"` |
| `json:"Spec"` | `json:"spec"` |
| `json:"Storage"` | `json:"storage"` |
| `json:"NetworkInterface"` | `json:"networkInterface"` |
| `json:"BootVolume"` | `json:"bootVolume"` |

### 2. スネークケースタグをキャメルケースに変換（marmot-api-v1.go）

`ImageSpec.SourceUrl` でスネークケースが残っていたため修正しました。

| フィールド | 変更前 | 変更後 |
|---|---|---|
| `ImageSpec.SourceUrl` | `json:"source_url"` / `yaml:"source_url"` | `json:"sourceUrl"` / `yaml:"sourceUrl"` |

### 3. YAML ファイルの更新（testdata, `sample-yamls/`）

タグ変更に伴い互換処理は廃止し、YAML 入力ファイル側のキーを新しいタグ名に合わせて一括修正しました。

### 4. 互換処理の廃止（config.go）

旧キー名を自動変換するノーマライズロジックを削除し、シンプルな `yaml.Unmarshal` のみを使用する構成に戻しています。

## 破壊的変更

- 旧キー名（`Metadata`, `Spec`, `source_url` 等）を使っている既存の YAML/JSON 入力は非互換となります。
- testdata 配下のテストデータは全て新キー名へ移行済みです。

## 動作確認

```
go test ./cmd/mactl/cmd ./pkg/config
```
全テスト成功を確認しました。