### PR TITLE
host-bridgeの自動設定

### DIFF
--- a/cmd/marmotd/marmotd-main.go
+++ b/cmd/marmotd/marmotd-main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/takara9/marmot/pkg/controller"
 	internaldns "github.com/takara9/marmot/pkg/internal-dns"
 	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/util"
 )
 
 var controllerCounter uint64 = 0
@@ -72,6 +73,9 @@ func main() {
 		"image_download_timeout_seconds", cfg.ImageDownloadTimeoutSeconds,
 		"image_resize_timeout_seconds", cfg.ImageResizeTimeoutSeconds,
 		"image_delete_timeout_seconds", cfg.ImageDeleteTimeoutSeconds)
+
+	// Setup host-bridge for libvirt
+	util.SetupHostBridge()
 
 	// REST-APIサーバーの処理
 	slog.Info("Starting api server", "nodeName", cfg.NodeName, "etcdURL", cfg.EtcdURL, "apiListenAddr", cfg.APIListenAddr)

--- a/pkg/util/hostbridge.go
+++ b/pkg/util/hostbridge.go
@@ -1,0 +1,379 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// SetupHostBridge checks and configures host bridge for marmot
+// Returns true if bridge was successfully set up, false otherwise
+func SetupHostBridge() bool {
+	slog.Info("Starting host-bridge setup")
+
+	// Check if bridge br0 already exists
+	if bridgeExists("br0") {
+		slog.Info("Bridge br0 already exists, skipping setup")
+		return configureVirshBridge()
+	}
+
+	// Find primary NIC (exclude loopback and WiFi)
+	primaryNIC := findPrimaryNIC()
+	if primaryNIC == "" {
+		slog.Warn("No suitable physical NIC found for bridge setup")
+		return false
+	}
+
+	slog.Info("Found primary NIC", "nic", primaryNIC)
+
+	// Get DHCP information from current interface
+	bridgeConfig := getBridgeConfig(primaryNIC)
+
+	// Backup existing netplan files
+	if err := backupNetplanFiles(); err != nil {
+		slog.Warn("Failed to backup netplan files", "err", err)
+		// Continue even if backup fails
+	}
+
+	// Create netplan configuration
+	netplanFile := "/etc/netplan/00-host-bridge.yaml"
+	if err := createNetplanConfig(netplanFile, primaryNIC, bridgeConfig); err != nil {
+		slog.Error("Failed to create netplan config", "file", netplanFile, "err", err)
+		return false
+	}
+
+	// Apply netplan configuration
+	if err := applyNetplan(); err != nil {
+		slog.Error("Failed to apply netplan", "err", err)
+		return false
+	}
+
+	// Wait for bridge to be created
+	time.Sleep(2 * time.Second)
+
+	// Configure virsh bridge
+	if !configureVirshBridge() {
+		slog.Warn("Failed to configure virsh bridge, but netplan configuration is applied")
+		return true // Bridge might still work without virsh configuration
+	}
+
+	slog.Info("Host-bridge setup completed successfully")
+	return true
+}
+
+// bridgeExists checks if a bridge with given name exists
+func bridgeExists(bridgeName string) bool {
+	// Check using ip link show
+	cmd := exec.Command("ip", "link", "show", bridgeName)
+	err := cmd.Run()
+	return err == nil
+}
+
+// findPrimaryNIC finds the first physical NIC (excluding loopback and WiFi)
+func findPrimaryNIC() string {
+	// Get all network interfaces
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		slog.Error("Failed to get network interfaces", "err", err)
+		return ""
+	}
+
+	for _, iface := range interfaces {
+		// Skip loopback
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+
+		// Skip WiFi interfaces (starting with 'w')
+		if strings.HasPrefix(iface.Name, "w") {
+			continue
+		}
+
+		// Check if interface is up and has broadcast capability
+		if iface.Flags&net.FlagBroadcast != 0 {
+			return iface.Name
+		}
+	}
+
+	return ""
+}
+
+// bridgeConfigInfo holds bridge configuration details
+type bridgeConfigInfo struct {
+	IPAddress  string
+	Gateway    string
+	Nameserver string
+	Domain     string
+}
+
+// getBridgeConfig extracts DHCP configuration from interface
+func getBridgeConfig(nicName string) bridgeConfigInfo {
+	config := bridgeConfigInfo{}
+
+	// Get IP address
+	cmd := exec.Command("ip", "-o", "addr", "show", nicName)
+	output, err := cmd.Output()
+	if err == nil {
+		// Parse output: 2: enp1s0    inet 192.168.1.100/24 brd 192.168.1.255 scope global dynamic enp1s0
+		parts := strings.Fields(string(output))
+		for i, part := range parts {
+			if part == "inet" && i+1 < len(parts) {
+				config.IPAddress = parts[i+1]
+				break
+			}
+		}
+	}
+
+	// Get gateway
+	cmd = exec.Command("ip", "route", "show")
+	output, err = cmd.Output()
+	if err == nil {
+		lines := strings.Split(string(output), "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "via") && strings.Contains(line, "default") {
+				// Parse: default via 192.168.1.1 dev enp1s0 proto dhcp src 192.168.1.100 metric 100
+				parts := strings.Fields(line)
+				for i, part := range parts {
+					if part == "via" && i+1 < len(parts) {
+						config.Gateway = parts[i+1]
+						break
+					}
+				}
+			}
+		}
+	}
+
+	// Get DNS from /etc/resolv.conf
+	resolveConf, err := ioutil.ReadFile("/etc/resolv.conf")
+	if err == nil {
+		lines := strings.Split(string(resolveConf), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "nameserver") {
+				parts := strings.Fields(line)
+				if len(parts) > 1 {
+					config.Nameserver = parts[1]
+					break
+				}
+			}
+			if strings.HasPrefix(line, "domain ") {
+				parts := strings.Fields(line)
+				if len(parts) > 1 {
+					config.Domain = parts[1]
+				}
+			}
+		}
+	}
+
+	slog.Debug("Bridge config extracted", "nic", nicName, "ip", config.IPAddress, "gateway", config.Gateway, "nameserver", config.Nameserver)
+	return config
+}
+
+// backupNetplanFiles backs up existing netplan configuration files
+func backupNetplanFiles() error {
+	netplanDir := "/etc/netplan"
+	files, err := ioutil.ReadDir(netplanDir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		if file.Name()[0] == '_' {
+			continue // Already backed up
+		}
+		if !strings.HasSuffix(file.Name(), ".yaml") && !strings.HasSuffix(file.Name(), ".yml") {
+			continue
+		}
+
+		originalPath := filepath.Join(netplanDir, file.Name())
+		backupPath := filepath.Join(netplanDir, "_"+file.Name())
+
+		input, err := ioutil.ReadFile(originalPath)
+		if err != nil {
+			slog.Warn("Failed to read netplan file for backup", "file", originalPath, "err", err)
+			continue
+		}
+
+		if err := ioutil.WriteFile(backupPath, input, 0644); err != nil {
+			slog.Warn("Failed to backup netplan file", "file", originalPath, "backup", backupPath, "err", err)
+			continue
+		}
+
+		slog.Info("Backed up netplan file", "original", originalPath, "backup", backupPath)
+
+		// Remove original file after successful backup
+		if err := os.Remove(originalPath); err != nil {
+			slog.Warn("Failed to remove original netplan file", "file", originalPath, "err", err)
+		} else {
+			slog.Info("Removed original netplan file", "file", originalPath)
+		}
+	}
+
+	return nil
+}
+
+// createNetplanConfig creates netplan configuration for bridge
+func createNetplanConfig(filePath string, nicName string, config bridgeConfigInfo) error {
+	yaml := fmt.Sprintf(`network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    %s:
+      dhcp4: false
+      dhcp6: false
+  bridges:
+    br0:
+      interfaces: [%s]
+`, nicName, nicName)
+
+	// Add IP address if available
+	if config.IPAddress != "" {
+		yaml += fmt.Sprintf(`      addresses:
+        - %s
+`, config.IPAddress)
+	}
+
+	// Add routes if gateway available
+	if config.Gateway != "" {
+		yaml += fmt.Sprintf(`      routes:
+        - to: default
+          via: %s
+`, config.Gateway)
+	}
+
+	// Add nameservers if available
+	if config.Nameserver != "" {
+		yaml += `      nameservers:
+`
+		yaml += `        addresses:
+`
+		yaml += fmt.Sprintf(`          - %s
+`, config.Nameserver)
+
+		if config.Domain != "" {
+			yaml += `        search:
+`
+			yaml += fmt.Sprintf(`          - %s
+`, config.Domain)
+		}
+	}
+
+	// Add bridge parameters
+	yaml += `      parameters:
+        stp: false
+      dhcp4: no
+      dhcp6: no
+`
+
+	if err := ioutil.WriteFile(filePath, []byte(yaml), 0644); err != nil {
+		return err
+	}
+
+	slog.Info("Created netplan config", "file", filePath)
+	return nil
+}
+
+// applyNetplan applies netplan configuration
+func applyNetplan() error {
+	cmd := exec.Command("netplan", "apply")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Error("netplan apply failed", "err", err, "output", string(output))
+		return err
+	}
+
+	slog.Info("netplan applied successfully")
+	return nil
+}
+
+// configureVirshBridge configures virsh network for bridge
+func configureVirshBridge() bool {
+	// Check if virsh is available
+	cmd := exec.Command("which", "virsh")
+	if err := cmd.Run(); err != nil {
+		slog.Warn("virsh command not found, skipping virsh bridge configuration")
+		return false
+	}
+
+	// Check if host-bridge network already defined
+	cmd = exec.Command("virsh", "net-info", "host-bridge")
+	if err := cmd.Run(); err == nil {
+		slog.Info("host-bridge network already defined in virsh")
+		// Try to start it if not running
+		startVirshBridge()
+		return true
+	}
+
+	// Define the host-bridge network
+	hostBridgeXML := `<network>
+  <name>host-bridge</name>
+  <forward mode='bridge'/>
+  <bridge name='br0'/>
+</network>
+`
+
+	// Write temporary XML file for virsh
+	tmpFile, err := ioutil.TempFile("", "hostbridge-*.xml")
+	if err != nil {
+		slog.Error("Failed to create temp file for virsh XML", "err", err)
+		return false
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write([]byte(hostBridgeXML)); err != nil {
+		slog.Error("Failed to write virsh XML", "err", err)
+		tmpFile.Close()
+		return false
+	}
+	tmpFile.Close()
+
+	// Define network
+	cmd = exec.Command("virsh", "net-define", tmpFile.Name())
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Error("Failed to define host-bridge network", "err", err, "output", string(output))
+		return false
+	}
+
+	slog.Info("Defined host-bridge network in virsh")
+
+	// Start and autostart the network
+	if !startVirshBridge() {
+		return false
+	}
+
+	return true
+}
+
+// startVirshBridge starts and autostarts the host-bridge network
+func startVirshBridge() bool {
+	// Start network
+	cmd := exec.Command("virsh", "net-start", "host-bridge")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Ignore error if network is already started
+		if !strings.Contains(string(output), "already active") {
+			slog.Warn("Failed to start host-bridge network", "err", err, "output", string(output))
+		}
+	}
+
+	// Set autostart
+	cmd = exec.Command("virsh", "net-autostart", "host-bridge")
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		slog.Warn("Failed to autostart host-bridge network", "err", err, "output", string(output))
+		return false
+	}
+
+	slog.Info("Started and autostated host-bridge network in virsh")
+	return true
+}


### PR DESCRIPTION
## 概要

Issue #348 に対応し、marmotd 起動時に host-bridge を自動設定する機能を実装しました。

## 説明

Ubuntu にインストール直後のシステムで、marmotd サービス起動時に自動的に以下を実行します：

1. **ブリッジ検出** - 既存の `br0` ブリッジの有無を確認
2. **物理NIC検出** - ループバック・WiFi を除外した最初の物理インターフェースを自動選択
3. **DHCP情報抽出** - 現在割り当てられているIPアドレス・ゲートウェイ・DNSを抽出
4. **netplan設定バックアップ** - 既存の netplan 設定ファイルを `_` prefix 付きでバックアップしてから削除
5. **netplan設定生成** - `/etc/netplan/00-host-bridge.yaml` を生成し、DHCP情報を固定化
6. **netplan 適用** - `netplan apply` を実行してネットワーク設定を反映
7. **virsh 統合** - libvirt で `host-bridge` ネットワークを定義・起動

これにより、インストール直後からブリッジを利用した仮想マシンのネットワーク構成が可能になります。

## 変更内容

### 新規ファイル
- **hostbridge.go** - ホストブリッジ自動設定機能の実装
  - `SetupHostBridge()` - メイン処理
  - `bridgeExists()` - ブリッジ存在確認
  - `findPrimaryNIC()` - 物理NIC自動検出
  - `getBridgeConfig()` - DHCP情報抽出
  - `backupNetplanFiles()` - netplan設定バックアップ
  - `createNetplanConfig()` - netplan YAML生成
  - `applyNetplan()` - netplan適用
  - `configureVirshBridge()` - virsh ネットワーク定義
  - `startVirshBridge()` - virsh ネットワーク起動

### 既存ファイル修正
- **marmotd-main.go**
  - util パッケージをインポート
  - 設定ロード後、REST-APIサーバー起動前に `util.SetupHostBridge()` を呼び出し

## 動作フロー

```
marmotd 起動
  ↓
コンフィグ読み込み
  ↓
SetupHostBridge() 実行
  ├─ br0 が存在する? YES → virsh 連携のみ実行
  └─ NO → 以下を実行
     ├─ 最初の物理NIC検出（enp1s0など）
     ├─ DHCP割当情報を抽出
     ├─ 既存netplan設定をバックアップ・削除
     ├─ 新しい netplan 設定を生成
     ├─ netplan apply 実行
     ├─ br0 作成を待機（2秒）
     └─ virsh で host-bridge ネットワークを定義・起動
  ↓
REST-APIサーバー起動
```

## 使用例

```bash
# Ubuntu に marmot をインストール
sudo apt install ./marmot_v0.15.0_amd64.deb

# marmot サービス自動起動（初回起動時にhost-bridgeを自動設定）
sudo systemctl start marmot

# ブリッジが作成されたか確認
ip link show br0
brctl show br0

# virsh で定義されているか確認
virsh net-list
virsh net-info host-bridge
```

## 備考

- 既存 netplan 設定は自動的にバックアップ（`_` prefix）されてから削除されます
- ブリッジ作成に失敗した場合でも、marmotd は引き続き起動します（ログに警告が記録されます）
- virsh が利用不可な環境では、netplan 設定のみ適用されます
- 既に `br0` ブリッジが存在する場合は、再度の設定処理をスキップします

