### PR TITLE
リソルバーの修正方針を修正

### DIFF
--- a/pkg/util/resolver.go
+++ b/pkg/util/resolver.go
@@ -12,8 +12,16 @@ import (
 const marmotResolvConfTemplate = "# generate by marmotd\nnameserver %s\noptions edns0 trust-ad\nsearch host-bridge\n"
 
 // SetupLocalResolver disables systemd-resolved and rewrites /etc/resolv.conf for marmot internal DNS.
+// If /etc/resolv.conf already has a nameserver entry that matches the IP derived from dnsListenAddr,
+// it skips the rewrite entirely.
 func SetupLocalResolver(dnsListenAddr string) error {
 	nameserver := nameserverForDNSListenAddr(dnsListenAddr)
+
+	if current, err := currentNameserverInResolvConf(); err == nil && current == nameserver {
+		slog.Info("resolv.conf nameserver already matches dns_listen_addr; skipping rewrite", "nameserver", nameserver)
+		return nil
+	}
+
 	resolvConfContent := fmt.Sprintf(marmotResolvConfTemplate, nameserver)
 
 	if err := runSystemctlResolved("stop"); err != nil {
@@ -29,6 +37,29 @@ func SetupLocalResolver(dnsListenAddr string) error {
 		return fmt.Errorf("write /etc/resolv.conf: %w", err)
 	}
 	return nil
+}
+
+// currentNameserverInResolvConf returns the first nameserver IP found in /etc/resolv.conf.
+func currentNameserverInResolvConf() (string, error) {
+	data, err := os.ReadFile("/etc/resolv.conf")
+	if err != nil {
+		return "", err
+	}
+	return parseNameserverFromResolvConf(string(data))
+}
+
+// parseNameserverFromResolvConf extracts the first nameserver IP from resolv.conf content.
+func parseNameserverFromResolvConf(content string) (string, error) {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "nameserver") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				return fields[1], nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no nameserver entry found in /etc/resolv.conf")
 }
 
 func nameserverForDNSListenAddr(dnsListenAddr string) string {

--- a/pkg/util/resolver_test.go
+++ b/pkg/util/resolver_test.go
@@ -1,6 +1,69 @@
 package util
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+func TestCurrentNameserverInResolvConf(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantNS  string
+		wantErr bool
+	}{
+		{
+			name:    "single nameserver",
+			content: "# comment\nnameserver 127.0.0.1\noptions edns0\n",
+			wantNS:  "127.0.0.1",
+		},
+		{
+			name:    "multiple nameservers returns first",
+			content: "nameserver 192.168.1.1\nnameserver 8.8.8.8\n",
+			wantNS:  "192.168.1.1",
+		},
+		{
+			name:    "marmotd generated format",
+			content: "# generate by marmotd\nnameserver 192.168.122.10\noptions edns0 trust-ad\nsearch host-bridge\n",
+			wantNS:  "192.168.122.10",
+		},
+		{
+			name:    "no nameserver entry",
+			content: "# only comments\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := os.CreateTemp(t.TempDir(), "resolv.conf")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := f.WriteString(tc.content); err != nil {
+				t.Fatal(err)
+			}
+			f.Close()
+
+			// Temporarily override ReadFile target by writing to a known path and
+			// testing the helper via a wrapper that accepts a path argument.
+			data, _ := os.ReadFile(f.Name())
+			got, gotErr := parseNameserverFromResolvConf(string(data))
+			if tc.wantErr {
+				if gotErr == nil {
+					t.Fatalf("expected error but got nameserver %q", got)
+				}
+				return
+			}
+			if gotErr != nil {
+				t.Fatalf("unexpected error: %v", gotErr)
+			}
+			if got != tc.wantNS {
+				t.Fatalf("got %q, want %q", got, tc.wantNS)
+			}
+		})
+	}
+}
 
 func TestNameserverForDNSListenAddr(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## 概要

marmotd 起動時に `/etc/resolv.conf` の `nameserver` が `dns_listen_addr` と一致している場合、`/etc/resolv.conf` の書き換えをスキップするように変更しました。

## 背景・動機

marmotd を再起動するたびに、すでに正しい設定になっている `/etc/resolv.conf` を毎回書き換えていました。  
これにより systemd-resolved の stop/disable が不必要に実行され、ログへのノイズや一時的な DNS 断が発生する可能性がありました。

## 変更内容

### `pkg/util/resolver.go`

- `SetupLocalResolver` に冒頭チェックを追加
  - `/etc/resolv.conf` の最初の `nameserver` エントリを読み取り、`dns_listen_addr` から導出した IP と比較
  - 一致する場合は systemd-resolved の停止・無効化および `/etc/resolv.conf` の書き換えをすべてスキップ
- `currentNameserverInResolvConf()` を追加（`/etc/resolv.conf` の読み込みとパースを担当）
- `parseNameserverFromResolvConf()` を追加（文字列からの解析ロジックを分離し、テスト容易性を向上）

### `pkg/util/resolver_test.go`

- `TestCurrentNameserverInResolvConf` を追加（4ケース）
  - 単一 nameserver
  - 複数 nameserver（最初の1件を返すことを確認）
  - marmotd 生成フォーマット（`# generate by marmotd` ヘッダーあり）
  - `nameserver` エントリなし（エラーを返すことを確認）

## 動作

```
dns_listen_addr から nameserver IP を導出
        ↓
/etc/resolv.conf の nameserver と比較
        ↓
一致 → スキップ（systemd-resolved の停止・書き換えなし）
不一致 → 従来通り書き換え
```