### PR TITLE
デフォルト値と入力検証の切替

### DIFF
--- a/pkg/marmotd/network_defaults.go
+++ b/pkg/marmotd/network_defaults.go
@@ -9,7 +9,6 @@ import (
 	"github.com/takara9/marmot/pkg/util"
 )
 
-const autoVNIStart = 100
 const maxVNI = 16777215
 
 func applyVirtualNetworkDefaults(network *api.VirtualNetwork, cfg *MarmotdConfig, database *db.Database) error {
@@ -17,7 +16,7 @@ func applyVirtualNetworkDefaults(network *api.VirtualNetwork, cfg *MarmotdConfig
 		return nil
 	}
 	if network.Spec.OverlayMode == nil {
-		overlayMode := api.Vxlan
+		overlayMode := api.Geneve
 		network.Spec.OverlayMode = &overlayMode
 	}
 	if !strings.EqualFold(string(*network.Spec.OverlayMode), string(api.Vxlan)) {
@@ -40,40 +39,5 @@ func applyVirtualNetworkDefaults(network *api.VirtualNetwork, cfg *MarmotdConfig
 		}
 		return nil
 	}
-	if database == nil {
-		return fmt.Errorf("database is required to auto-assign vni")
-	}
-
-	networks, err := database.GetVirtualNetworks()
-	if err != nil {
-		return err
-	}
-	vni, err := nextAvailableVNI(networks)
-	if err != nil {
-		return err
-	}
-	network.Spec.Vni = util.IntPtrInt(vni)
 	return nil
-}
-
-func nextAvailableVNI(networks []api.VirtualNetwork) (int, error) {
-	used := make(map[int]struct{}, len(networks))
-	for _, network := range networks {
-		if network.Spec.Vni == nil {
-			continue
-		}
-		vni := *network.Spec.Vni
-		if vni < 0 || vni > maxVNI {
-			continue
-		}
-		used[vni] = struct{}{}
-	}
-
-	for candidate := autoVNIStart; candidate <= maxVNI; candidate++ {
-		if _, exists := used[candidate]; !exists {
-			return candidate, nil
-		}
-	}
-
-	return 0, fmt.Errorf("no available vni")
 }

--- a/pkg/marmotd/network_defaults_test.go
+++ b/pkg/marmotd/network_defaults_test.go
@@ -9,17 +9,28 @@ import (
 
 var _ = Describe("VirtualNetworkDefaults", func() {
 	Describe("applyVirtualNetworkDefaults", func() {
-		It("defaults overlayMode to vxlan and peerPolicy to auto when omitted", func() {
+		It("defaults overlayMode to geneve when omitted", func() {
 			network := api.VirtualNetwork{
-				Spec: api.VirtualNetworkSpec{
-					Vni: util.IntPtrInt(100),
-				},
+				Spec: api.VirtualNetworkSpec{},
 			}
 
 			err := applyVirtualNetworkDefaults(&network, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(network.Spec.OverlayMode).NotTo(BeNil())
-			Expect(*network.Spec.OverlayMode).To(Equal(api.VirtualNetworkSpecOverlayMode(api.Vxlan)))
+			Expect(*network.Spec.OverlayMode).To(Equal(api.VirtualNetworkSpecOverlayMode(api.Geneve)))
+			Expect(network.Spec.PeerPolicy).To(BeNil())
+		})
+
+		It("defaults peerPolicy to auto for vxlan overlays", func() {
+			overlayMode := api.Vxlan
+			network := api.VirtualNetwork{
+				Spec: api.VirtualNetworkSpec{
+					OverlayMode: &overlayMode,
+				},
+			}
+
+			err := applyVirtualNetworkDefaults(&network, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(network.Spec.PeerPolicy).NotTo(BeNil())
 			Expect(*network.Spec.PeerPolicy).To(Equal(api.VirtualNetworkSpecPeerPolicy(api.Auto)))
 		})
@@ -36,30 +47,31 @@ var _ = Describe("VirtualNetworkDefaults", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(network.Spec.PeerPolicy).To(BeNil())
 		})
-	})
 
-	Describe("nextAvailableVNI", func() {
-		It("uses the first free VNI from 100", func() {
-			networks := []api.VirtualNetwork{
-				{Spec: api.VirtualNetworkSpec{Vni: util.IntPtrInt(100)}},
-				{Spec: api.VirtualNetworkSpec{Vni: util.IntPtrInt(101)}},
-				{Spec: api.VirtualNetworkSpec{Vni: util.IntPtrInt(103)}},
+		It("does not auto-assign vni when omitted", func() {
+			overlayMode := api.Vxlan
+			network := api.VirtualNetwork{
+				Spec: api.VirtualNetworkSpec{
+					OverlayMode: &overlayMode,
+				},
 			}
 
-			vni, err := nextAvailableVNI(networks)
+			err := applyVirtualNetworkDefaults(&network, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vni).To(Equal(102))
+			Expect(network.Spec.Vni).To(BeNil())
 		})
 
-		It("ignores invalid existing VNI values", func() {
-			networks := []api.VirtualNetwork{
-				{Spec: api.VirtualNetworkSpec{Vni: util.IntPtrInt(-1)}},
-				{Spec: api.VirtualNetworkSpec{Vni: util.IntPtrInt(0)}},
+		It("returns error for out-of-range vni", func() {
+			overlayMode := api.Vxlan
+			network := api.VirtualNetwork{
+				Spec: api.VirtualNetworkSpec{
+					OverlayMode: &overlayMode,
+					Vni:         util.IntPtrInt(maxVNI + 1),
+				},
 			}
 
-			vni, err := nextAvailableVNI(networks)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(vni).To(Equal(100))
+			err := applyVirtualNetworkDefaults(&network, nil, nil)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
1. 目的
- ネットワーク作成時の既定動作を新方式へ変更する。

2. 主な変更
- デフォルト overlayMode を新仕様へ変更  
  network_defaults.go
- VNI 自動採番の削除または Geneve 向け識別子へ置換  
  network_defaults.go
- 関連テスト修正  
  network_defaults_test.go

3. 完了条件
- 新規 network 作成時の defaults が仕様通り。
- defaults 系テストが全通過。
