### PR TITLE
NetworkFabric 抽象をVXLAN語彙から中立化

### DIFF
--- a/pkg/controller/network-controller.go
+++ b/pkg/controller/network-controller.go
@@ -557,11 +557,11 @@ func (c *controller) ensureVxlanMeshForNetwork(fabric networkfabric.NetworkFabri
 		return err
 	}
 
-	if err := fabric.EnsureVxlanMesh(&vnet, peers); err != nil {
+	if err := fabric.EnsureOverlayMesh(&vnet, peers); err != nil {
 		return fmt.Errorf("ensure vxlan mesh failed: %w", err)
 	}
 
-	if err := fabric.PruneVxlanMesh(&vnet, peers); err != nil {
+	if err := fabric.PruneOverlayMesh(&vnet, peers); err != nil {
 		return fmt.Errorf("prune vxlan mesh failed: %w", err)
 	}
 

--- a/pkg/controller/network_manual_policy_test.go
+++ b/pkg/controller/network_manual_policy_test.go
@@ -18,12 +18,12 @@ func (m *mockNetworkFabric) EnsureBridge(vnet *api.VirtualNetwork) error {
 	return nil
 }
 
-func (m *mockNetworkFabric) EnsureVxlanMesh(vnet *api.VirtualNetwork, peers []string) error {
+func (m *mockNetworkFabric) EnsureOverlayMesh(vnet *api.VirtualNetwork, peers []string) error {
 	m.ensureMeshCalls++
 	return nil
 }
 
-func (m *mockNetworkFabric) PruneVxlanMesh(vnet *api.VirtualNetwork, remainPeers []string) error {
+func (m *mockNetworkFabric) PruneOverlayMesh(vnet *api.VirtualNetwork, remainPeers []string) error {
 	m.pruneMeshCalls++
 	return nil
 }

--- a/pkg/networkfabric/interface.go
+++ b/pkg/networkfabric/interface.go
@@ -4,7 +4,7 @@ import (
 	"github.com/takara9/marmot/api"
 )
 
-// NetworkFabric は OVS/VXLAN などのオーバーレイネットワーク実体操作を担当する。
+// NetworkFabric は OVS などのオーバーレイネットワーク実体操作を担当する。
 // controller 層がこのインターフェースを通じて、libvirt とは独立に overlay を管理する。
 type NetworkFabric interface {
 	// EnsureBridge はローカルノードで OVS ブリッジを作成・確認する。
@@ -13,15 +13,15 @@ type NetworkFabric interface {
 	// 戻り値: (成功時は nil、既存/失敗はエラー)
 	EnsureBridge(vnet *api.VirtualNetwork) error
 
-	// EnsureVxlanMesh はローカルノード上で、指定ピアへのトンネル群を作成・確認する。
+	// EnsureOverlayMesh はローカルノード上で、指定ピアへのトンネル群を作成・確認する。
 	// 冪等で実行される。
 	// vnet: 対象ネットワーク
 	// peers: 疎通対象のリモートノード IP リスト
-	EnsureVxlanMesh(vnet *api.VirtualNetwork, peers []string) error
+	EnsureOverlayMesh(vnet *api.VirtualNetwork, peers []string) error
 
-	// PruneVxlanMesh は不要なトンネルを削除する。
+	// PruneOverlayMesh は不要なトンネルを削除する。
 	// 例: ノード離脱時に peer リストから外れたノードへのトンネルを削除。
-	PruneVxlanMesh(vnet *api.VirtualNetwork, remainPeers []string) error
+	PruneOverlayMesh(vnet *api.VirtualNetwork, remainPeers []string) error
 
 	// DeleteBridge はブリッジとその配下のトンネルをすべて削除する。
 	// 削除前に必ず libvirt net destroy/undefine が完了していることを前提とする。

--- a/pkg/networkfabric/ovs.go
+++ b/pkg/networkfabric/ovs.go
@@ -147,8 +147,8 @@ func linuxBridgeDeviceExists(bridgeName string) bool {
 	return cmd.Run() == nil
 }
 
-// EnsureVxlanMesh はピアノードへの VXLAN トンネルを作成・確認する。
-func (o *OVSFabric) EnsureVxlanMesh(vnet *api.VirtualNetwork, peers []string) error {
+// EnsureOverlayMesh はピアノードへのオーバーレイトンネルを作成・確認する。
+func (o *OVSFabric) EnsureOverlayMesh(vnet *api.VirtualNetwork, peers []string) error {
 	if vnet == nil || vnet.Spec.BridgeName == nil {
 		return fmt.Errorf("invalid vnet or missing bridge name")
 	}
@@ -294,8 +294,8 @@ func resolveInterfaceIPv4(interfaceName string) (string, error) {
 	return "", fmt.Errorf("no ipv4 address found on underlay interface %s", name)
 }
 
-// PruneVxlanMesh は残すべきピア以外のトンネルを削除する。
-func (o *OVSFabric) PruneVxlanMesh(vnet *api.VirtualNetwork, remainPeers []string) error {
+// PruneOverlayMesh は残すべきピア以外のトンネルを削除する。
+func (o *OVSFabric) PruneOverlayMesh(vnet *api.VirtualNetwork, remainPeers []string) error {
 	if vnet == nil || vnet.Spec.BridgeName == nil {
 		return fmt.Errorf("invalid vnet or missing bridge name")
 	}


### PR DESCRIPTION
**PR3: NetworkFabric 抽象をVXLAN語彙から中立化**
1. 目的
- コントローラーが VXLAN 固有メソッドに依存しない形へ先に整える。

2. 主な変更
- Fabric interface から EnsureVxlanMesh/PruneVxlanMesh などを廃止し、中立 API に変更  
  interface.go
- 呼び出し側のコンパイル修正（まだ中身は旧実装でも可）  
  network-controller.go

3. 完了条件
- Fabric 層の公開インターフェースに VXLAN 用語が残らない。
- コンパイルが通る。