### PR TITLE
API 型と DB 保存を追加する

### DIFF
--- a/api/load_balancer_id.go
+++ b/api/load_balancer_id.go
@@ -1,0 +1,14 @@
+package api
+
+// LoadBalancerID returns the load balancer identifier stored in metadata.id.
+func LoadBalancerID(lb LoadBalancer) string {
+	return lb.Metadata.Id
+}
+
+// SetLoadBalancerID stores the load balancer identifier into metadata.id.
+func SetLoadBalancerID(lb *LoadBalancer, id string) {
+	if lb == nil {
+		return
+	}
+	lb.Metadata.Id = id
+}

--- a/api/marmot-api-v1.go
+++ b/api/marmot-api-v1.go
@@ -84,6 +84,25 @@ type GatewaySpec struct {
 	ServerPorts            []string `json:"serverPorts" yaml:"serverPorts"`
 }
 
+// LoadBalancer defines model for LoadBalancer.
+type LoadBalancer struct {
+	ApiVersion string           `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string           `json:"kind" yaml:"kind"`
+	Metadata   Metadata         `json:"metadata" yaml:"metadata"`
+	Spec       LoadBalancerSpec `json:"spec" yaml:"spec"`
+	Status     *Status          `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+// LoadBalancerSpec defines model for LoadBalancerSpec.
+type LoadBalancerSpec struct {
+	BackendMode            *string  `json:"backendMode,omitempty" yaml:"backendMode,omitempty"`
+	BindPublicIpAddress    *string  `json:"bindPublicIpAddress,omitempty" yaml:"bindPublicIpAddress,omitempty"`
+	InternalServers        []string `json:"internalServers,omitempty" yaml:"internalServers,omitempty"`
+	InternalVirtualNetwork string   `json:"internalVirtualNetwork" yaml:"internalVirtualNetwork"`
+	ServerPorts            []string `json:"serverPorts" yaml:"serverPorts"`
+	VirtualIpAddress       *string  `json:"virtualIpAddress,omitempty" yaml:"virtualIpAddress,omitempty"`
+}
+
 // VpnGateway defines model for VpnGateway.
 type VpnGateway struct {
 	ApiVersion string         `json:"apiVersion" yaml:"apiVersion"`

--- a/docs/MEMO-loadbalancer.md
+++ b/docs/MEMO-loadbalancer.md
@@ -1,0 +1,366 @@
+# LoadBalancer の最小設計案
+
+## 目的
+
+issue 369 の LoadBalancer を、Gateway のような専用 VM を起動せずに実装する。
+Marmot はすでに OVN/OVS を制御する経路を持つため、LoadBalancer も controller から OVN の論理オブジェクトを直接操作する。
+
+このメモでは、最小実装として次を成立条件にする。
+
+- 専用 VM を作らない
+- Ansible を使わない
+- バックエンドは既存の Server リソースを使う
+- 内部仮想ネットワーク上の VIP 提供を先に実装する
+- bindPublicIpAddress を使う外部公開は、この設計メモの範囲外とする
+
+## この設計で切り捨てるもの
+
+最小実装では、以下はスコープ外とする。
+
+- host-bridge 上の公開 VIP を使う外部公開
+- bindPublicIpAddress
+- L7 機能
+- ヘルスチェック
+- セッション維持
+- 重み付け
+- backend が Server 以外のオブジェクト
+
+理由は、内部ネットワーク向けの L4 LoadBalancer であれば OVN の論理 load balancer を直接使える一方、host-bridge への公開は localnet、router、NAT、ARP 応答の整理まで必要になり、最小設計から外れるためである。
+
+## API の最小仕様
+
+```yaml
+apiVersion: v1
+kind: LoadBalancer
+metadata:
+  name: lb1
+spec:
+  backendMode: auto
+  internalVirtualNetwork: webs-net
+  serverPorts:
+    - http
+    - https
+    - 1234/tcp
+```
+
+最小実装で有効にする項目:
+
+- metadata.name
+- spec.backendMode
+- spec.internalVirtualNetwork
+- spec.serverPorts
+
+最小実装で optional にする項目:
+
+- spec.virtualIpAddress
+- spec.internalServers (backendMode=manual のときのみ)
+
+最小実装で扱わない項目:
+
+- spec.bindPublicIpAddress
+
+bindPublicIpAddress は、この設計メモでは範囲外とする。
+したがって、このメモに従う実装では spec.bindPublicIpAddress を受け付けない。
+指定された場合は 400 で reject する。
+
+## backendMode の扱い
+
+backendMode は次の 2 値を受け付ける。
+
+- manual
+- auto
+
+デフォルトは auto とする。
+
+### manual
+
+- internalServers の指定を必須とする
+- backend は internalServers で指定された Server のみを対象とする
+
+### auto
+
+- internalServers の指定を禁止する
+- backend は internalVirtualNetwork 上の Server から自動検出する
+
+auto の対象条件は次の 3 点。
+
+1. internalVirtualNetwork に接続していること
+2. status が RUNNING であること
+3. ラベル lb-enabled=true を持つこと
+
+## virtualIpAddress の扱い
+
+issue 369 の記述では bindPublicIpAddress を省略した場合に internalVirtualNetwork 上へ VIP を置く想定になっている。
+この設計では virtualIpAddress は optional とし、指定があればその値を使い、未指定なら controller が internalVirtualNetwork から VIP を自動採番する。
+
+VIP の決定規則は次の通り。
+
+1. spec.virtualIpAddress が指定されていれば、その値を使う
+2. 未指定なら controller が DB の IP 割当ロジックを使って未使用 IP を採番する
+3. 採番した VIP は labels または status に保持し、再 reconcile で再利用する
+
+この方式により、利用者は VIP を明示指定してもよく、省略して自動採番に任せてもよい。
+
+### 自動採番の前提
+
+自動採番は、internalVirtualNetwork に割当対象の IPv4 ネットワークが定義されていることを前提とする。
+採番は既存 Server と同じ IP 管理台帳を使い、backend IP と競合しないことを保証する。
+
+### 明示指定と自動採番のトレードオフ
+
+- 利点: 実装が単純
+- 利点: 期待値が明確
+- 利点: API テストが簡単
+- 利点: 未指定なら利用者が VIP を決めなくてよい
+- 注意点: 自動採番には IP ネットワーク定義と使用中 IP の一元管理が必要
+
+最小実装では、自動採番まで含めて扱う。
+
+## アーキテクチャ
+
+### 責務分離
+
+- API/CLI: LoadBalancer リソースを受け付けて保存する
+- DB: LoadBalancer の spec、status、label を保持する
+- controller: spec を監視し、backend IP を解決し、OVN を同期する
+- networkfabric: OVN load balancer の create/update/delete を隠蔽する
+
+Gateway 方式との違いは、Linux guest OS に iptables を入れるのではなく、OVN Northbound DB 上に load balancer を作成して論理スイッチへ関連付ける点にある。
+
+### データプレーン
+
+最小実装のデータプレーンは OVN の load balancer を使う。
+
+- VIP は spec.virtualIpAddress または自動採番した VIP
+- backend は backendMode に応じて manual 指定または auto 検出で解決した IP 群
+- protocol/port は serverPorts から展開する
+- 対象 logical switch は internalVirtualNetwork に対応するスイッチ
+
+VIP が確定したら、internalVirtualNetwork の内部 DNS に metadata.name を使って A レコードを登録する。
+
+概念上の同期結果は以下。
+
+- LoadBalancer リソース 1 個
+- OVN load balancer 1 個
+- serverPorts の各要素に対応する VIP エントリ
+- internalVirtualNetwork の logical switch への関連付け
+- metadata.name.internalVirtualNetwork に対応する内部 DNS エントリ 1 個
+
+## controller の最小ステート
+
+既存の controller 流儀に合わせ、15 秒ループでよい。
+
+- PENDING: spec のバリデーションと backend 解決を行う
+- PROVISIONING: OVN load balancer を作成または更新する
+- ACTIVE: drift 修復だけ行う
+- DELETING: OVN から切り離して削除する
+- FAILED: 再 apply か更新待ち
+
+最小設計では Gateway のような VM ライフサイクル待ちは存在しないため、PENDING から ACTIVE まで 1 ループで遷移可能である。
+
+## reconcile の流れ
+
+1. LoadBalancer を列挙する
+2. internalVirtualNetwork が存在することを確認する
+3. backendMode を解決する (未指定時は auto)
+4. backendMode=manual の場合は internalServers を検証し、指定された server から backend IP を解決する
+5. backendMode=auto の場合は internalVirtualNetwork 上の server を走査し、対象条件 3 点で backend を自動検出する
+6. backend が 0 台の場合は PROVISIONING を維持する
+7. virtualIpAddress が未指定なら VIP を自動採番し、指定があれば妥当性を検証する
+8. serverPorts を tcp/udp の具体値へ展開する
+9. OVN load balancer の desired state を生成する
+10. desired state を OVN に反映する
+11. VIP を内部 DNS へ登録する
+12. status を ACTIVE に更新する
+
+削除時は逆順で、内部 DNS エントリを削除し、logical switch から関連付けを外し、load balancer を削除し、DB エントリを消す。
+
+## バリデーション仕様
+
+作成時に最低限チェックする内容:
+
+1. metadata.name は internalVirtualNetwork 単位で一意
+2. backendMode は manual または auto のみ許可 (未指定時は auto)
+3. backendMode=manual では internalServers を必須とする
+4. backendMode=manual では internalServers に重複不可
+5. backendMode=auto では internalServers の指定を禁止する
+6. internalVirtualNetwork は存在必須
+7. virtualIpAddress が指定されている場合は internalVirtualNetwork の CIDR 内にあること
+8. virtualIpAddress が指定されている場合は backend IP と重複不可
+9. serverPorts は service 名または n/tcp, n/udp のみ許可
+10. bindPublicIpAddress は範囲外として reject
+11. virtualIpAddress が未指定で自動採番できない場合は reject
+
+更新時の最小仕様:
+
+1. 変更許可は backendMode, internalServers, serverPorts のみ
+2. internalVirtualNetwork は immutable
+3. virtualIpAddress は初回確定後は immutable
+4. bindPublicIpAddress は範囲外のため指定不可
+
+## backend IP 解決
+
+backendMode により解決方法を切り替える。
+
+### manual
+
+internalServers は Server の名前リストとして扱う。
+
+### auto
+
+internalVirtualNetwork 上の Server から backend を自動検出し、対象条件は次の 3 点。
+
+1. internalVirtualNetwork に接続している
+2. status が RUNNING
+3. ラベル lb-enabled=true を持つ
+
+共通で、各 backend は以下の条件を満たす必要がある。
+
+- Server が存在する
+- status が RUNNING である
+- internalVirtualNetwork 上に NIC を持つ
+- その NIC に IP が割り当てられている
+
+1 台でも解決できない server がある場合、最小実装では全体を FAILED にせず、ACTIVE には遷移させないで PROVISIONING を維持する方が運用しやすい。
+
+理由:
+
+- 起動順の前後に耐えやすい
+- backend の復帰時に自動収束しやすい
+
+ただし、manual で存在しない server 名が指定された場合は利用者エラーなので FAILED が妥当である。
+
+auto で条件に一致する backend が 0 台のときは、PROVISIONING を維持する。
+
+## VIP の確定と内部 DNS 登録
+
+VIP は次のいずれかで確定する。
+
+- spec.virtualIpAddress による明示指定
+- controller による自動採番
+
+VIP が確定したら、内部 DNS に metadata.name をホスト名、internalVirtualNetwork をサブドメインとして登録する。
+これにより、同一内部ネットワーク上のクライアントは LoadBalancer を名前で解決できる。
+
+削除時は DNS エントリも必ず削除する。
+
+## networkfabric への追加責務
+
+既存の OVN bridge/switch 制御とは別に、次の抽象を追加する。
+
+- EnsureLoadBalancer
+- DeleteLoadBalancer
+- GetLoadBalancerStatus
+
+入力は次の程度で足りる。
+
+- LoadBalancer ID
+- logical switch 名
+- VIP 一覧
+- backend 一覧
+
+controller は desired state の生成だけ行い、ovn-nbctl の詳細は networkfabric に閉じ込める。
+
+## OVN への反映イメージ
+
+最小実装では、OVN 上で次を冪等に同期する。
+
+1. marmot 管理の load balancer オブジェクトを確保する
+2. 各 serverPort に対応する VIP と backend 群を同期する
+3. internalVirtualNetwork の logical switch に load balancer を関連付ける
+4. delete 時は逆順で切り離す
+
+識別子は external_ids に以下を持たせると追跡しやすい。
+
+- marmot_loadbalancer_id
+- marmot_network_id
+- marmot_managed=true
+
+## status と labels
+
+status の最小構成:
+
+- statusCode
+- message
+- observedGeneration
+- virtualIpAddress
+- resolvedBackends
+
+labels に保持すると有用なもの:
+
+- appliedConfigHash
+- logicalSwitchName
+- ovnLoadBalancerName
+
+appliedConfigHash があれば、spec と backend 解決結果が同じときに無駄な再同期を避けられる。
+
+## テストの最小範囲
+
+VM なしで成立するテストを優先する。
+
+### ユニットテスト
+
+- serverPorts の解決
+- backendMode の既定値が auto になること
+- backendMode=auto で internalServers を reject すること
+- backendMode=manual で internalServers 必須になること
+- virtualIpAddress 指定時の CIDR 検証
+- virtualIpAddress 未指定時の自動採番
+- backend 解決 (manual)
+- backend 自動検出 (auto, 3 条件)
+- VIP の内部 DNS 登録
+- immutable 項目の update reject
+- desired OVN state 生成
+
+### OVN コマンドモックテスト
+
+既存の [pkg/networkfabric/ovn_test.go](pkg/networkfabric/ovn_test.go#L1) と同じ方式で、ovn-nbctl 実行を差し替える。
+
+- lb 作成
+- VIP 更新
+- logical switch への関連付け
+- delete
+
+### 統合テスト
+
+最小設計では必須ではない。
+少なくとも API/DB/controller/networkfabric の大半はモックで検証できる。
+
+## 段階的リリース案
+
+### Phase 1
+
+- API/DB/CLI で LoadBalancer を保存・表示できる
+- bindPublicIpAddress は範囲外として reject
+- controller は未実装
+
+### Phase 2
+
+- controller が backend を解決し、OVN load balancer を内部ネットワークへ作成できる
+- virtualIpAddress は optional とし、未指定時は自動採番する
+- VIP を内部 DNS へ登録する
+
+### Phase 3
+
+- ACTIVE で drift 修復
+- backend の増減を自動反映
+- configHash で不要同期を抑制
+
+### Phase 4
+
+- bindPublicIpAddress を使う外部公開が必要なら、別設計メモとして追加で定義する
+- 必要なら localnet / logical router / NAT の導入を検討
+
+## 実装順序の提案
+
+1. API 型と DB 保存を追加する
+2. serverPorts の正規化関数を切り出す
+3. backend 解決関数を切り出す
+4. networkfabric に OVN load balancer 操作を追加する
+5. controller に reconcile を追加する
+6. モックテストを追加する
+
+## 結論
+
+issue 369 は、専用 VM なしで実装できる。
+最小実装としては、内部仮想ネットワーク向けの OVN ネイティブ L4 LoadBalancer に限定し、bindPublicIpAddress はこの設計メモの範囲外として扱うのが最も小さく、既存の Marmot の controller / networkfabric 構造にも適合する。

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ systemctl status etcd
 - [ネットワークの設定方法](network-setup.md)
 - [データベースの初期化方法](hv-admin/README.md)
 - [VMのmachine-idとhostidの生成規則](MEMO-hostid-generation.md)
+- [LoadBalancer の最小設計案](MEMO-loadbalancer.md)
 
 marmotのインストール
 

--- a/pkg/db/db-etcd.go
+++ b/pkg/db/db-etcd.go
@@ -22,6 +22,7 @@ const (
 	ImagePrefix           = "/marmot/image"
 	NetworkPrefix         = "/marmot/network"
 	GatewayPrefix         = "/marmot/gateway"
+	LoadBalancerPrefix    = "/marmot/load-balancer"
 	VpnGatewayPrefix      = "/marmot/vpn-gateway"
 	SeqPrefix             = "/marmot/sequence"
 	VersionKey            = "/marmot/version"

--- a/pkg/db/db-loadbalancer.go
+++ b/pkg/db/db-loadbalancer.go
@@ -1,0 +1,275 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+const (
+	LOAD_BALANCER_PENDING      = 0
+	LOAD_BALANCER_PROVISIONING = 1
+	LOAD_BALANCER_ACTIVE       = 2
+	LOAD_BALANCER_FAILED       = 3
+	LOAD_BALANCER_DELETING     = 4
+
+	LoadBalancerLabelManagedBy      = "managedBy"
+	LoadBalancerLabelManagedByValue = "load-balancer-controller"
+	LoadBalancerLabelAppliedConfig  = "appliedConfigHash"
+	LoadBalancerLabelResolvedVIP    = "resolvedVirtualIpAddress"
+)
+
+var LoadBalancerStatus = map[int]string{
+	LOAD_BALANCER_PENDING:      "PENDING",
+	LOAD_BALANCER_PROVISIONING: "PROVISIONING",
+	LOAD_BALANCER_ACTIVE:       "ACTIVE",
+	LOAD_BALANCER_FAILED:       "FAILED",
+	LOAD_BALANCER_DELETING:     "DELETING",
+}
+
+func SetLoadBalancerAppliedConfigHash(labels map[string]interface{}, hash string) {
+	if labels == nil {
+		return
+	}
+	labels[LoadBalancerLabelAppliedConfig] = strings.TrimSpace(hash)
+}
+
+func GetLoadBalancerAppliedConfigHash(labels map[string]interface{}) string {
+	if labels == nil {
+		return ""
+	}
+	val, ok := labels[LoadBalancerLabelAppliedConfig].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(val)
+}
+
+func SetLoadBalancerResolvedVIP(labels map[string]interface{}, vip string) {
+	if labels == nil {
+		return
+	}
+	labels[LoadBalancerLabelResolvedVIP] = strings.TrimSpace(vip)
+}
+
+func GetLoadBalancerResolvedVIP(labels map[string]interface{}) string {
+	if labels == nil {
+		return ""
+	}
+	val, ok := labels[LoadBalancerLabelResolvedVIP].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(val)
+}
+
+func (d *Database) CreateLoadBalancer(spec api.LoadBalancer) (api.LoadBalancer, error) {
+	mutex, err := d.LockKey("/lock/load-balancer/create")
+	if err != nil {
+		return api.LoadBalancer{}, err
+	}
+	defer d.UnlockKey(mutex)
+
+	current, err := d.GetLoadBalancers()
+	if err != nil && err != ErrNotFound {
+		return api.LoadBalancer{}, err
+	}
+
+	name := strings.TrimSpace(spec.Metadata.Name)
+	vnet := strings.TrimSpace(spec.Spec.InternalVirtualNetwork)
+	for _, item := range current {
+		existingName := strings.TrimSpace(item.Metadata.Name)
+		existingVnet := strings.TrimSpace(item.Spec.InternalVirtualNetwork)
+		if existingName == name && existingVnet == vnet {
+			return api.LoadBalancer{}, fmt.Errorf("load balancer with name %q already exists in internalVirtualNetwork %q", name, vnet)
+		}
+	}
+
+	rec, err := util.DeepCopy(spec)
+	if err != nil {
+		return api.LoadBalancer{}, err
+	}
+
+	if rec.Metadata.Labels == nil {
+		rec.Metadata.Labels = &map[string]interface{}{}
+	}
+	labels := *rec.Metadata.Labels
+	labels[LoadBalancerLabelManagedBy] = LoadBalancerLabelManagedByValue
+	rec.Metadata.Labels = &labels
+
+	var key string
+	for {
+		rec.Metadata.Uuid = util.StringPtr(uuid.New().String())
+		id := (*rec.Metadata.Uuid)[:5]
+		api.SetLoadBalancerID(&rec, id)
+		key = LoadBalancerPrefix + "/" + id
+
+		var existing api.LoadBalancer
+		_, getErr := d.GetJSON(key, &existing)
+		if getErr == ErrNotFound {
+			break
+		}
+		if getErr != nil {
+			return api.LoadBalancer{}, getErr
+		}
+	}
+
+	now := time.Now()
+	rec.Status = &api.Status{
+		StatusCode:          LOAD_BALANCER_PENDING,
+		Status:              util.StringPtr(LoadBalancerStatus[LOAD_BALANCER_PENDING]),
+		CreationTimeStamp:   util.TimePtr(now),
+		LastUpdateTimeStamp: util.TimePtr(now),
+	}
+
+	if err := d.PutJSON(key, rec); err != nil {
+		return api.LoadBalancer{}, err
+	}
+
+	return rec, nil
+}
+
+func (d *Database) GetLoadBalancers() ([]api.LoadBalancer, error) {
+	result := make([]api.LoadBalancer, 0)
+	resp, err := d.GetByPrefix(LoadBalancerPrefix)
+	if err == ErrNotFound {
+		return result, nil
+	}
+	if err != nil {
+		return result, err
+	}
+
+	for _, kv := range resp.Kvs {
+		var rec api.LoadBalancer
+		if err := json.Unmarshal(kv.Value, &rec); err != nil {
+			slog.Error("GetLoadBalancers() unmarshal failed", "err", err, "key", string(kv.Key))
+			continue
+		}
+		result = append(result, rec)
+	}
+
+	return result, nil
+}
+
+func (d *Database) GetLoadBalancerById(id string) (api.LoadBalancer, error) {
+	key := LoadBalancerPrefix + "/" + id
+	var rec api.LoadBalancer
+	_, err := d.GetJSON(key, &rec)
+	if err != nil {
+		return api.LoadBalancer{}, err
+	}
+	return rec, nil
+}
+
+func (d *Database) UpdateLoadBalancerById(id string, spec api.LoadBalancer) error {
+	for {
+		err := d.updateLoadBalancerById(id, spec)
+		if err == ErrUpdateConflict {
+			slog.Warn("UpdateLoadBalancerById() retrying due to update conflict", "loadBalancerId", id)
+			continue
+		}
+		return err
+	}
+}
+
+func (d *Database) updateLoadBalancerById(id string, spec api.LoadBalancer) error {
+	lockKey := "/lock/load-balancer/" + id
+	mutex, err := d.LockKey(lockKey)
+	if err != nil {
+		return err
+	}
+	defer d.UnlockKey(mutex)
+
+	key := LoadBalancerPrefix + "/" + id
+	var rec api.LoadBalancer
+	resp, err := d.GetJSON(key, &rec)
+	if err != nil {
+		return err
+	}
+
+	util.PatchStruct(&rec, spec)
+	api.SetLoadBalancerID(&rec, id)
+
+	return d.PutJSONCAS(key, resp.Kvs[0].ModRevision, &rec)
+}
+
+func (d *Database) DeleteLoadBalancerById(id string) error {
+	lockKey := "/lock/load-balancer/" + id
+	mutex, err := d.LockKey(lockKey)
+	if err != nil {
+		return err
+	}
+	defer d.UnlockKey(mutex)
+
+	key := LoadBalancerPrefix + "/" + id
+	return d.DeleteJSON(key)
+}
+
+func (d *Database) SetDeleteTimestampLoadBalancer(id string) error {
+	rec, err := d.GetLoadBalancerById(id)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	if rec.Status == nil {
+		rec.Status = &api.Status{}
+	}
+	rec.Status.DeletionTimeStamp = util.TimePtr(now)
+	rec.Status.LastUpdateTimeStamp = util.TimePtr(now)
+	rec.Status.StatusCode = LOAD_BALANCER_DELETING
+	rec.Status.Status = util.StringPtr(LoadBalancerStatus[LOAD_BALANCER_DELETING])
+
+	return d.UpdateLoadBalancerById(id, rec)
+}
+
+func (d *Database) UpdateLoadBalancerStatusWithMessage(id string, status int, message string) error {
+	rec, err := d.GetLoadBalancerById(id)
+	if err != nil {
+		return err
+	}
+	if rec.Status == nil {
+		rec.Status = &api.Status{}
+	}
+
+	statusChanged := rec.Status.StatusCode != status
+	rec.Status.StatusCode = status
+	rec.Status.Status = util.StringPtr(LoadBalancerStatus[status])
+	rec.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
+
+	trimmedMessage := strings.TrimSpace(message)
+	if statusChanged {
+		rec.Status.Message = util.StringPtr("")
+	}
+	if trimmedMessage == "" {
+		if rec.Status.Message == nil {
+			rec.Status.Message = util.StringPtr("")
+		}
+	} else {
+		rec.Status.Message = util.StringPtr(trimmedMessage)
+	}
+
+	return d.UpdateLoadBalancerById(id, rec)
+}
+
+func (d *Database) GetLoadBalancerByName(name string) ([]api.LoadBalancer, error) {
+	all, err := d.GetLoadBalancers()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]api.LoadBalancer, 0)
+	target := strings.TrimSpace(name)
+	for _, item := range all {
+		if strings.TrimSpace(item.Metadata.Name) == target {
+			result = append(result, item)
+		}
+	}
+	return result, nil
+}


### PR DESCRIPTION
## 概要
Issue #369 の第一段として、LoadBalancer の API 型と DB 永続化レイヤーを追加しました。  
この PR は「保存できる状態にする」ことに限定し、Controller や API ハンドラの実装は次段で対応します。

## 変更内容
1. LoadBalancer の API 型を追加  
2. LoadBalancer の ID ヘルパーを追加  
3. etcd キープレフィックスに LoadBalancer 用キーを追加  
4. DB レイヤーに LoadBalancer の CRUD と状態更新処理を追加

## DB レイヤーで追加した機能
1. CreateLoadBalancer  
2. GetLoadBalancers  
3. GetLoadBalancerById  
4. UpdateLoadBalancerById（CAS 競合時リトライ）  
5. DeleteLoadBalancerById  
6. SetDeleteTimestampLoadBalancer  
7. UpdateLoadBalancerStatusWithMessage  
8. GetLoadBalancerByName  
9. labels 操作ヘルパー（appliedConfigHash、resolvedVirtualIpAddress）

## この PR でやらないこと
1. HTTP API エンドポイント追加  
2. リクエストバリデーション実装  
3. Controller による reconcile  
4. OVN への反映処理  
5. 内部 DNS 登録処理

## 動作確認
1. api と db パッケージのコンパイル確認を実施  
2. 失敗なし

## 互換性と影響
1. 既存リソースの挙動変更はなし  
2. 追加実装のみで、既存 API への破壊的変更なし

## 関連
Part of #369