### PR TITLE
モックテストを追加

### DIFF
--- a/api/load_balancer_id.go
+++ b/api/load_balancer_id.go
@@ -1,0 +1,14 @@
+package api
+
+// LoadBalancerID returns the load balancer identifier stored in metadata.id.
+func LoadBalancerID(lb LoadBalancer) string {
+	return lb.Metadata.Id
+}
+
+// SetLoadBalancerID stores the load balancer identifier into metadata.id.
+func SetLoadBalancerID(lb *LoadBalancer, id string) {
+	if lb == nil {
+		return
+	}
+	lb.Metadata.Id = id
+}

--- a/api/marmot-api-v1.go
+++ b/api/marmot-api-v1.go
@@ -84,6 +84,25 @@ type GatewaySpec struct {
 	ServerPorts            []string `json:"serverPorts" yaml:"serverPorts"`
 }
 
+// LoadBalancer defines model for LoadBalancer.
+type LoadBalancer struct {
+	ApiVersion string           `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string           `json:"kind" yaml:"kind"`
+	Metadata   Metadata         `json:"metadata" yaml:"metadata"`
+	Spec       LoadBalancerSpec `json:"spec" yaml:"spec"`
+	Status     *Status          `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+// LoadBalancerSpec defines model for LoadBalancerSpec.
+type LoadBalancerSpec struct {
+	BackendMode            *string  `json:"backendMode,omitempty" yaml:"backendMode,omitempty"`
+	BindPublicIpAddress    *string  `json:"bindPublicIpAddress,omitempty" yaml:"bindPublicIpAddress,omitempty"`
+	InternalServers        []string `json:"internalServers,omitempty" yaml:"internalServers,omitempty"`
+	InternalVirtualNetwork string   `json:"internalVirtualNetwork" yaml:"internalVirtualNetwork"`
+	ServerPorts            []string `json:"serverPorts" yaml:"serverPorts"`
+	VirtualIpAddress       *string  `json:"virtualIpAddress,omitempty" yaml:"virtualIpAddress,omitempty"`
+}
+
 // VpnGateway defines model for VpnGateway.
 type VpnGateway struct {
 	ApiVersion string         `json:"apiVersion" yaml:"apiVersion"`

--- a/cmd/marmotd/marmotd-main.go
+++ b/cmd/marmotd/marmotd-main.go
@@ -127,6 +127,13 @@ func main() {
 		return
 	}
 
+	// ロードバランサーコントローラー
+	_, err = controller.StartLoadBalancerController(cfg.NodeName, cfg.EtcdURL)
+	if err != nil {
+		slog.Error("Failed to start load balancer controller", "err", err)
+		return
+	}
+
 	// DNSサーバーコントローラー
 	_, err = internaldns.StartInternalDNSServer(context.Background(), cfg.NodeName, cfg.EtcdURL, cfg) // DNSサーバーコントローラーの開始
 	if err != nil {

--- a/docs/MEMO-loadbalancer.md
+++ b/docs/MEMO-loadbalancer.md
@@ -1,0 +1,366 @@
+# LoadBalancer の最小設計案
+
+## 目的
+
+issue 369 の LoadBalancer を、Gateway のような専用 VM を起動せずに実装する。
+Marmot はすでに OVN/OVS を制御する経路を持つため、LoadBalancer も controller から OVN の論理オブジェクトを直接操作する。
+
+このメモでは、最小実装として次を成立条件にする。
+
+- 専用 VM を作らない
+- Ansible を使わない
+- バックエンドは既存の Server リソースを使う
+- 内部仮想ネットワーク上の VIP 提供を先に実装する
+- bindPublicIpAddress を使う外部公開は、この設計メモの範囲外とする
+
+## この設計で切り捨てるもの
+
+最小実装では、以下はスコープ外とする。
+
+- host-bridge 上の公開 VIP を使う外部公開
+- bindPublicIpAddress
+- L7 機能
+- ヘルスチェック
+- セッション維持
+- 重み付け
+- backend が Server 以外のオブジェクト
+
+理由は、内部ネットワーク向けの L4 LoadBalancer であれば OVN の論理 load balancer を直接使える一方、host-bridge への公開は localnet、router、NAT、ARP 応答の整理まで必要になり、最小設計から外れるためである。
+
+## API の最小仕様
+
+```yaml
+apiVersion: v1
+kind: LoadBalancer
+metadata:
+  name: lb1
+spec:
+  backendMode: auto
+  internalVirtualNetwork: webs-net
+  serverPorts:
+    - http
+    - https
+    - 1234/tcp
+```
+
+最小実装で有効にする項目:
+
+- metadata.name
+- spec.backendMode
+- spec.internalVirtualNetwork
+- spec.serverPorts
+
+最小実装で optional にする項目:
+
+- spec.virtualIpAddress
+- spec.internalServers (backendMode=manual のときのみ)
+
+最小実装で扱わない項目:
+
+- spec.bindPublicIpAddress
+
+bindPublicIpAddress は、この設計メモでは範囲外とする。
+したがって、このメモに従う実装では spec.bindPublicIpAddress を受け付けない。
+指定された場合は 400 で reject する。
+
+## backendMode の扱い
+
+backendMode は次の 2 値を受け付ける。
+
+- manual
+- auto
+
+デフォルトは auto とする。
+
+### manual
+
+- internalServers の指定を必須とする
+- backend は internalServers で指定された Server のみを対象とする
+
+### auto
+
+- internalServers の指定を禁止する
+- backend は internalVirtualNetwork 上の Server から自動検出する
+
+auto の対象条件は次の 3 点。
+
+1. internalVirtualNetwork に接続していること
+2. status が RUNNING であること
+3. ラベル lb-enabled=true を持つこと
+
+## virtualIpAddress の扱い
+
+issue 369 の記述では bindPublicIpAddress を省略した場合に internalVirtualNetwork 上へ VIP を置く想定になっている。
+この設計では virtualIpAddress は optional とし、指定があればその値を使い、未指定なら controller が internalVirtualNetwork から VIP を自動採番する。
+
+VIP の決定規則は次の通り。
+
+1. spec.virtualIpAddress が指定されていれば、その値を使う
+2. 未指定なら controller が DB の IP 割当ロジックを使って未使用 IP を採番する
+3. 採番した VIP は labels または status に保持し、再 reconcile で再利用する
+
+この方式により、利用者は VIP を明示指定してもよく、省略して自動採番に任せてもよい。
+
+### 自動採番の前提
+
+自動採番は、internalVirtualNetwork に割当対象の IPv4 ネットワークが定義されていることを前提とする。
+採番は既存 Server と同じ IP 管理台帳を使い、backend IP と競合しないことを保証する。
+
+### 明示指定と自動採番のトレードオフ
+
+- 利点: 実装が単純
+- 利点: 期待値が明確
+- 利点: API テストが簡単
+- 利点: 未指定なら利用者が VIP を決めなくてよい
+- 注意点: 自動採番には IP ネットワーク定義と使用中 IP の一元管理が必要
+
+最小実装では、自動採番まで含めて扱う。
+
+## アーキテクチャ
+
+### 責務分離
+
+- API/CLI: LoadBalancer リソースを受け付けて保存する
+- DB: LoadBalancer の spec、status、label を保持する
+- controller: spec を監視し、backend IP を解決し、OVN を同期する
+- networkfabric: OVN load balancer の create/update/delete を隠蔽する
+
+Gateway 方式との違いは、Linux guest OS に iptables を入れるのではなく、OVN Northbound DB 上に load balancer を作成して論理スイッチへ関連付ける点にある。
+
+### データプレーン
+
+最小実装のデータプレーンは OVN の load balancer を使う。
+
+- VIP は spec.virtualIpAddress または自動採番した VIP
+- backend は backendMode に応じて manual 指定または auto 検出で解決した IP 群
+- protocol/port は serverPorts から展開する
+- 対象 logical switch は internalVirtualNetwork に対応するスイッチ
+
+VIP が確定したら、internalVirtualNetwork の内部 DNS に metadata.name を使って A レコードを登録する。
+
+概念上の同期結果は以下。
+
+- LoadBalancer リソース 1 個
+- OVN load balancer 1 個
+- serverPorts の各要素に対応する VIP エントリ
+- internalVirtualNetwork の logical switch への関連付け
+- metadata.name.internalVirtualNetwork に対応する内部 DNS エントリ 1 個
+
+## controller の最小ステート
+
+既存の controller 流儀に合わせ、15 秒ループでよい。
+
+- PENDING: spec のバリデーションと backend 解決を行う
+- PROVISIONING: OVN load balancer を作成または更新する
+- ACTIVE: drift 修復だけ行う
+- DELETING: OVN から切り離して削除する
+- FAILED: 再 apply か更新待ち
+
+最小設計では Gateway のような VM ライフサイクル待ちは存在しないため、PENDING から ACTIVE まで 1 ループで遷移可能である。
+
+## reconcile の流れ
+
+1. LoadBalancer を列挙する
+2. internalVirtualNetwork が存在することを確認する
+3. backendMode を解決する (未指定時は auto)
+4. backendMode=manual の場合は internalServers を検証し、指定された server から backend IP を解決する
+5. backendMode=auto の場合は internalVirtualNetwork 上の server を走査し、対象条件 3 点で backend を自動検出する
+6. backend が 0 台の場合は PROVISIONING を維持する
+7. virtualIpAddress が未指定なら VIP を自動採番し、指定があれば妥当性を検証する
+8. serverPorts を tcp/udp の具体値へ展開する
+9. OVN load balancer の desired state を生成する
+10. desired state を OVN に反映する
+11. VIP を内部 DNS へ登録する
+12. status を ACTIVE に更新する
+
+削除時は逆順で、内部 DNS エントリを削除し、logical switch から関連付けを外し、load balancer を削除し、DB エントリを消す。
+
+## バリデーション仕様
+
+作成時に最低限チェックする内容:
+
+1. metadata.name は internalVirtualNetwork 単位で一意
+2. backendMode は manual または auto のみ許可 (未指定時は auto)
+3. backendMode=manual では internalServers を必須とする
+4. backendMode=manual では internalServers に重複不可
+5. backendMode=auto では internalServers の指定を禁止する
+6. internalVirtualNetwork は存在必須
+7. virtualIpAddress が指定されている場合は internalVirtualNetwork の CIDR 内にあること
+8. virtualIpAddress が指定されている場合は backend IP と重複不可
+9. serverPorts は service 名または n/tcp, n/udp のみ許可
+10. bindPublicIpAddress は範囲外として reject
+11. virtualIpAddress が未指定で自動採番できない場合は reject
+
+更新時の最小仕様:
+
+1. 変更許可は backendMode, internalServers, serverPorts のみ
+2. internalVirtualNetwork は immutable
+3. virtualIpAddress は初回確定後は immutable
+4. bindPublicIpAddress は範囲外のため指定不可
+
+## backend IP 解決
+
+backendMode により解決方法を切り替える。
+
+### manual
+
+internalServers は Server の名前リストとして扱う。
+
+### auto
+
+internalVirtualNetwork 上の Server から backend を自動検出し、対象条件は次の 3 点。
+
+1. internalVirtualNetwork に接続している
+2. status が RUNNING
+3. ラベル lb-enabled=true を持つ
+
+共通で、各 backend は以下の条件を満たす必要がある。
+
+- Server が存在する
+- status が RUNNING である
+- internalVirtualNetwork 上に NIC を持つ
+- その NIC に IP が割り当てられている
+
+1 台でも解決できない server がある場合、最小実装では全体を FAILED にせず、ACTIVE には遷移させないで PROVISIONING を維持する方が運用しやすい。
+
+理由:
+
+- 起動順の前後に耐えやすい
+- backend の復帰時に自動収束しやすい
+
+ただし、manual で存在しない server 名が指定された場合は利用者エラーなので FAILED が妥当である。
+
+auto で条件に一致する backend が 0 台のときは、PROVISIONING を維持する。
+
+## VIP の確定と内部 DNS 登録
+
+VIP は次のいずれかで確定する。
+
+- spec.virtualIpAddress による明示指定
+- controller による自動採番
+
+VIP が確定したら、内部 DNS に metadata.name をホスト名、internalVirtualNetwork をサブドメインとして登録する。
+これにより、同一内部ネットワーク上のクライアントは LoadBalancer を名前で解決できる。
+
+削除時は DNS エントリも必ず削除する。
+
+## networkfabric への追加責務
+
+既存の OVN bridge/switch 制御とは別に、次の抽象を追加する。
+
+- EnsureLoadBalancer
+- DeleteLoadBalancer
+- GetLoadBalancerStatus
+
+入力は次の程度で足りる。
+
+- LoadBalancer ID
+- logical switch 名
+- VIP 一覧
+- backend 一覧
+
+controller は desired state の生成だけ行い、ovn-nbctl の詳細は networkfabric に閉じ込める。
+
+## OVN への反映イメージ
+
+最小実装では、OVN 上で次を冪等に同期する。
+
+1. marmot 管理の load balancer オブジェクトを確保する
+2. 各 serverPort に対応する VIP と backend 群を同期する
+3. internalVirtualNetwork の logical switch に load balancer を関連付ける
+4. delete 時は逆順で切り離す
+
+識別子は external_ids に以下を持たせると追跡しやすい。
+
+- marmot_loadbalancer_id
+- marmot_network_id
+- marmot_managed=true
+
+## status と labels
+
+status の最小構成:
+
+- statusCode
+- message
+- observedGeneration
+- virtualIpAddress
+- resolvedBackends
+
+labels に保持すると有用なもの:
+
+- appliedConfigHash
+- logicalSwitchName
+- ovnLoadBalancerName
+
+appliedConfigHash があれば、spec と backend 解決結果が同じときに無駄な再同期を避けられる。
+
+## テストの最小範囲
+
+VM なしで成立するテストを優先する。
+
+### ユニットテスト
+
+- serverPorts の解決
+- backendMode の既定値が auto になること
+- backendMode=auto で internalServers を reject すること
+- backendMode=manual で internalServers 必須になること
+- virtualIpAddress 指定時の CIDR 検証
+- virtualIpAddress 未指定時の自動採番
+- backend 解決 (manual)
+- backend 自動検出 (auto, 3 条件)
+- VIP の内部 DNS 登録
+- immutable 項目の update reject
+- desired OVN state 生成
+
+### OVN コマンドモックテスト
+
+既存の [pkg/networkfabric/ovn_test.go](pkg/networkfabric/ovn_test.go#L1) と同じ方式で、ovn-nbctl 実行を差し替える。
+
+- lb 作成
+- VIP 更新
+- logical switch への関連付け
+- delete
+
+### 統合テスト
+
+最小設計では必須ではない。
+少なくとも API/DB/controller/networkfabric の大半はモックで検証できる。
+
+## 段階的リリース案
+
+### Phase 1
+
+- API/DB/CLI で LoadBalancer を保存・表示できる
+- bindPublicIpAddress は範囲外として reject
+- controller は未実装
+
+### Phase 2
+
+- controller が backend を解決し、OVN load balancer を内部ネットワークへ作成できる
+- virtualIpAddress は optional とし、未指定時は自動採番する
+- VIP を内部 DNS へ登録する
+
+### Phase 3
+
+- ACTIVE で drift 修復
+- backend の増減を自動反映
+- configHash で不要同期を抑制
+
+### Phase 4
+
+- bindPublicIpAddress を使う外部公開が必要なら、別設計メモとして追加で定義する
+- 必要なら localnet / logical router / NAT の導入を検討
+
+## 実装順序の提案
+
+1. API 型と DB 保存を追加する
+2. serverPorts の正規化関数を切り出す
+3. backend 解決関数を切り出す
+4. networkfabric に OVN load balancer 操作を追加する
+5. controller に reconcile を追加する
+6. モックテストを追加する
+
+## 結論
+
+issue 369 は、専用 VM なしで実装できる。
+最小実装としては、内部仮想ネットワーク向けの OVN ネイティブ L4 LoadBalancer に限定し、bindPublicIpAddress はこの設計メモの範囲外として扱うのが最も小さく、既存の Marmot の controller / networkfabric 構造にも適合する。

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ systemctl status etcd
 - [ネットワークの設定方法](network-setup.md)
 - [データベースの初期化方法](hv-admin/README.md)
 - [VMのmachine-idとhostidの生成規則](MEMO-hostid-generation.md)
+- [LoadBalancer の最小設計案](MEMO-loadbalancer.md)
 
 marmotのインストール
 

--- a/pkg/controller/backend_resolver.go
+++ b/pkg/controller/backend_resolver.go
@@ -1,0 +1,111 @@
+package controller
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+)
+
+func (c *controller) resolveSingleBackendIP(serverName string, networkName string) (string, error) {
+	trimmedServer := strings.TrimSpace(serverName)
+	trimmedNetwork := strings.TrimSpace(networkName)
+	if trimmedServer == "" {
+		return "", fmt.Errorf("spec.internalServerName is required")
+	}
+	if trimmedNetwork == "" {
+		return "", fmt.Errorf("spec.internalVirtualNetwork is required")
+	}
+
+	servers, err := c.db.GetServers()
+	if err != nil {
+		return "", err
+	}
+
+	for _, server := range servers {
+		if strings.TrimSpace(server.Metadata.Name) != trimmedServer {
+			continue
+		}
+		if ip, ok := serverAddressOnNetwork(server, trimmedNetwork); ok {
+			return ip, nil
+		}
+	}
+
+	return "", fmt.Errorf("internal server %q on network %q does not have an assigned IP address", trimmedServer, trimmedNetwork)
+}
+
+func (c *controller) resolveAutoBackendsOnNetwork(networkName string, labelKey string, labelValue string) ([]string, error) {
+	trimmedNetwork := strings.TrimSpace(networkName)
+	if trimmedNetwork == "" {
+		return nil, fmt.Errorf("spec.internalVirtualNetwork is required")
+	}
+
+	servers, err := c.db.GetServers()
+	if err != nil {
+		return nil, err
+	}
+
+	ips := make([]string, 0)
+	seen := map[string]struct{}{}
+
+	for _, server := range servers {
+		if server.Status == nil || server.Status.StatusCode != db.SERVER_RUNNING {
+			continue
+		}
+		if !serverHasLabel(server, labelKey, labelValue) {
+			continue
+		}
+		ip, ok := serverAddressOnNetwork(server, trimmedNetwork)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[ip]; exists {
+			continue
+		}
+		seen[ip] = struct{}{}
+		ips = append(ips, ip)
+	}
+
+	sort.Strings(ips)
+	return ips, nil
+}
+
+func serverAddressOnNetwork(server api.Server, networkName string) (string, bool) {
+	if server.Spec.NetworkInterface == nil {
+		return "", false
+	}
+	trimmedNetwork := strings.TrimSpace(networkName)
+	for _, nic := range *server.Spec.NetworkInterface {
+		if strings.TrimSpace(nic.Networkname) != trimmedNetwork || nic.Address == nil {
+			continue
+		}
+		if ip := strings.TrimSpace(*nic.Address); ip != "" {
+			return ip, true
+		}
+	}
+	return "", false
+}
+
+func serverHasLabel(server api.Server, key string, value string) bool {
+	if server.Metadata.Labels == nil {
+		return false
+	}
+	v, ok := (*server.Metadata.Labels)[key]
+	if !ok {
+		return false
+	}
+	want := strings.TrimSpace(value)
+	switch typed := v.(type) {
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), want)
+	case bool:
+		if typed {
+			return strings.EqualFold(want, "true")
+		}
+		return strings.EqualFold(want, "false")
+	default:
+		return false
+	}
+}

--- a/pkg/controller/backend_resolver_test.go
+++ b/pkg/controller/backend_resolver_test.go
@@ -1,0 +1,111 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestResolveSingleBackendIP(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{db: database, marmot: &marmotd.Marmot{NodeName: "hvc", Db: database}}
+
+	_ = mustCreateVirtualNetwork(t, database, "web-servers")
+	mustCreateInternalServer(t, database, "server-10", "web-servers", "172.16.10.2")
+
+	ip, err := ctrl.resolveSingleBackendIP("server-10", "web-servers")
+	if err != nil {
+		t.Fatalf("resolveSingleBackendIP() failed: %v", err)
+	}
+	if ip != "172.16.10.2" {
+		t.Fatalf("resolveSingleBackendIP() = %q, want %q", ip, "172.16.10.2")
+	}
+}
+
+func TestResolveSingleBackendIP_MissingAddress(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{db: database, marmot: &marmotd.Marmot{NodeName: "hvc", Db: database}}
+
+	_ = mustCreateVirtualNetwork(t, database, "web-servers")
+	_, err := database.MakeServerEntry(api.Server{
+		ApiVersion: "v1",
+		Kind:       "Server",
+		Metadata: api.Metadata{
+			Name:     "server-10",
+			NodeName: util.StringPtr("hvc"),
+		},
+		Spec: api.ServerSpec{
+			NetworkInterface: &[]api.NetworkInterface{{
+				Networkname: "web-servers",
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("MakeServerEntry() failed: %v", err)
+	}
+
+	_, err = ctrl.resolveSingleBackendIP("server-10", "web-servers")
+	if err == nil {
+		t.Fatalf("resolveSingleBackendIP() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not have an assigned IP address") {
+		t.Fatalf("resolveSingleBackendIP() error = %q, want contains %q", err.Error(), "does not have an assigned IP address")
+	}
+}
+
+func TestResolveAutoBackendsOnNetwork(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{db: database, marmot: &marmotd.Marmot{NodeName: "hvc", Db: database}}
+
+	_ = mustCreateVirtualNetwork(t, database, "web-servers")
+
+	mkServer := func(name, ip string, status int, withLabel bool, netName string) {
+		labels := map[string]interface{}{}
+		if withLabel {
+			labels["lb-enabled"] = "true"
+		}
+		server, err := database.MakeServerEntry(api.Server{
+			ApiVersion: "v1",
+			Kind:       "Server",
+			Metadata: api.Metadata{
+				Name:     name,
+				NodeName: util.StringPtr("hvc"),
+				Labels:   &labels,
+			},
+			Spec: api.ServerSpec{
+				NetworkInterface: &[]api.NetworkInterface{{
+					Networkname: netName,
+					Address:     util.StringPtr(ip),
+				}},
+			},
+		})
+		if err != nil {
+			t.Fatalf("MakeServerEntry() failed for %s: %v", name, err)
+		}
+		database.UpdateServerStatus(api.ServerID(server), status, "")
+	}
+
+	mkServer("web-2", "172.16.10.3", db.SERVER_RUNNING, true, "web-servers")
+	mkServer("web-1", "172.16.10.2", db.SERVER_RUNNING, true, "web-servers")
+	mkServer("web-down", "172.16.10.4", db.SERVER_STOPPED, true, "web-servers")
+	mkServer("web-other-net", "172.17.10.5", db.SERVER_RUNNING, true, "db-net")
+	mkServer("web-no-label", "172.16.10.6", db.SERVER_RUNNING, false, "web-servers")
+
+	ips, err := ctrl.resolveAutoBackendsOnNetwork("web-servers", "lb-enabled", "true")
+	if err != nil {
+		t.Fatalf("resolveAutoBackendsOnNetwork() failed: %v", err)
+	}
+	want := []string{"172.16.10.2", "172.16.10.3"}
+	if len(ips) != len(want) {
+		t.Fatalf("resolveAutoBackendsOnNetwork() len = %d, want %d; got=%v", len(ips), len(want), ips)
+	}
+	for i := range ips {
+		if ips[i] != want[i] {
+			t.Fatalf("resolveAutoBackendsOnNetwork()[%d] = %q, want %q; got=%v", i, ips[i], want[i], ips)
+		}
+	}
+}

--- a/pkg/controller/gateway-controller.go
+++ b/pkg/controller/gateway-controller.go
@@ -507,33 +507,7 @@ func (c *controller) findServerByName(name string) (api.Server, error) {
 }
 
 func (c *controller) resolveGatewayInternalServerTarget(gateway api.Gateway) (string, error) {
-	serverName := strings.TrimSpace(gateway.Spec.InternalServerName)
-	internalNetwork := strings.TrimSpace(gateway.Spec.InternalVirtualNetwork)
-	if serverName == "" {
-		return "", fmt.Errorf("spec.internalServerName is required")
-	}
-	if internalNetwork == "" {
-		return "", fmt.Errorf("spec.internalVirtualNetwork is required")
-	}
-
-	servers, err := c.db.GetServers()
-	if err != nil {
-		return "", err
-	}
-	for _, server := range servers {
-		if strings.TrimSpace(server.Metadata.Name) != serverName || server.Spec.NetworkInterface == nil {
-			continue
-		}
-		for _, nic := range *server.Spec.NetworkInterface {
-			if strings.TrimSpace(nic.Networkname) != internalNetwork || nic.Address == nil {
-				continue
-			}
-			if ip := strings.TrimSpace(*nic.Address); ip != "" {
-				return ip, nil
-			}
-		}
-	}
-	return "", fmt.Errorf("internal server %q on network %q does not have an assigned IP address", serverName, internalNetwork)
+	return c.resolveSingleBackendIP(gateway.Spec.InternalServerName, gateway.Spec.InternalVirtualNetwork)
 }
 
 func (c *controller) handleGatewayConfigFailure(gatewayID string, err error) {

--- a/pkg/controller/loadbalancer-controller.go
+++ b/pkg/controller/loadbalancer-controller.go
@@ -1,0 +1,569 @@
+package controller
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/networkfabric"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+const (
+	LOAD_BALANCER_CONTROLLER_INTERVAL = 15 * time.Second
+	loadBalancerBackendModeAuto       = "auto"
+	loadBalancerBackendModeManual     = "manual"
+	loadBalancerAutoBackendLabelKey   = "lb-enabled"
+	loadBalancerAutoBackendLabelValue = "true"
+	loadBalancerLabelLogicalSwitch    = "logicalSwitchName"
+	loadBalancerLabelOVNName          = "ovnLoadBalancerName"
+	loadBalancerLabelResolvedBackends = "resolvedBackends"
+)
+
+var (
+	loadBalancerLogicalSwitchSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+	newLoadBalancerFabric              = func() networkfabric.LoadBalancerFabric { return networkfabric.NewOVNFabric() }
+)
+
+type loadBalancerDesiredState struct {
+	ID                string
+	LogicalSwitchName string
+	ResolvedVIP       string
+	ResolvedBackends  []string
+	NormalizedPorts   []string
+	VIPs              map[string]string
+	ConfigHash        string
+}
+
+type loadBalancerResolveOutcome struct {
+	desired        *loadBalancerDesiredState
+	requeueMessage string
+	fatalErr       error
+}
+
+// StartLoadBalancerController starts controller loop for load balancer resources.
+func StartLoadBalancerController(node string, etcdUrl string) (*controller, error) {
+	var c controller
+	var err error
+
+	c.deletionDelay = 15 * time.Second
+	c.marmot, err = marmotd.NewMarmot(node, etcdUrl)
+	if err != nil {
+		slog.Error("Failed to create marmot instance", "err", err)
+		return nil, err
+	}
+	c.db = c.marmot.Db
+	c.stopChan = make(chan struct{})
+	c.doneChan = make(chan struct{})
+
+	ticker := time.NewTicker(LOAD_BALANCER_CONTROLLER_INTERVAL)
+	go func() {
+		defer ticker.Stop()
+		defer close(c.doneChan)
+		for {
+			select {
+			case <-ticker.C:
+				c.loadBalancerControllerLoop()
+			case <-c.stopChan:
+				slog.Info("ロードバランサーコントローラー停止")
+				return
+			}
+		}
+	}()
+
+	return &c, nil
+}
+
+func (c *controller) loadBalancerControllerLoop() {
+	slog.Debug("ロードバランサーコントローラーの制御ループ実行", "CONTROLLER", time.Now().Format("2006-01-02 15:04:05"))
+
+	items, err := c.db.GetLoadBalancers()
+	if err != nil {
+		slog.Error("GetLoadBalancers() failed", "err", err)
+		return
+	}
+
+	fabric := newLoadBalancerFabric()
+
+	for _, item := range items {
+		id := strings.TrimSpace(api.LoadBalancerID(item))
+		if id == "" {
+			slog.Warn("load balancer id is empty, skip")
+			continue
+		}
+
+		if !loadBalancerHasAssignedNode(item) {
+			if err := c.assignLoadBalancerNode(id); err != nil {
+				slog.Warn("failed to assign node to load balancer", "id", id, "err", err)
+			}
+			continue
+		}
+		if ok, assignedNode, reason := evaluateNodeAssignment(&item.Metadata, c.marmot.NodeName); !ok {
+			slog.Debug("別ノード割当のロードバランサーをスキップ", "id", id, "name", item.Metadata.Name, "controllerNode", c.marmot.NodeName, "assignedNode", assignedNode, "reason", reason)
+			continue
+		}
+
+		if item.Status == nil {
+			_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_PENDING, "")
+			continue
+		}
+
+		if item.Status.DeletionTimeStamp != nil && time.Since(*item.Status.DeletionTimeStamp) > c.deletionDelay {
+			if item.Status.StatusCode != db.LOAD_BALANCER_DELETING {
+				_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_DELETING, "")
+				continue
+			}
+		}
+
+		switch item.Status.StatusCode {
+		case db.LOAD_BALANCER_PENDING:
+			c.reconcileLoadBalancerPending(item)
+		case db.LOAD_BALANCER_PROVISIONING:
+			c.reconcileLoadBalancerProvisioning(item, fabric)
+		case db.LOAD_BALANCER_ACTIVE:
+			c.reconcileLoadBalancerActive(item)
+		case db.LOAD_BALANCER_DELETING:
+			c.reconcileLoadBalancerDeleting(item, fabric)
+		case db.LOAD_BALANCER_FAILED:
+			slog.Debug("FAILED 状態のロードバランサーを検出", "id", id)
+		default:
+			slog.Warn("不明なロードバランサー状態", "id", id, "statusCode", item.Status.StatusCode)
+		}
+	}
+}
+
+func (c *controller) reconcileLoadBalancerPending(lb api.LoadBalancer) {
+	id := api.LoadBalancerID(lb)
+	outcome := c.resolveLoadBalancerDesiredState(lb)
+	if outcome.fatalErr != nil {
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_FAILED, outcome.fatalErr.Error())
+		return
+	}
+	if outcome.requeueMessage != "" {
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_PROVISIONING, outcome.requeueMessage)
+		return
+	}
+	_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_PROVISIONING, "load balancer desired state resolved")
+}
+
+func (c *controller) reconcileLoadBalancerProvisioning(lb api.LoadBalancer, fabric networkfabric.LoadBalancerFabric) {
+	id := api.LoadBalancerID(lb)
+	outcome := c.resolveLoadBalancerDesiredState(lb)
+	if outcome.fatalErr != nil {
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_FAILED, outcome.fatalErr.Error())
+		return
+	}
+	if outcome.requeueMessage != "" {
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_PROVISIONING, outcome.requeueMessage)
+		return
+	}
+	if outcome.desired == nil {
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_PROVISIONING, "load balancer desired state is empty")
+		return
+	}
+	if err := c.applyLoadBalancerDesiredState(lb, *outcome.desired, fabric); err != nil {
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_FAILED, err.Error())
+		return
+	}
+	_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_ACTIVE, "")
+}
+
+func (c *controller) reconcileLoadBalancerActive(lb api.LoadBalancer) {
+	id := api.LoadBalancerID(lb)
+	outcome := c.resolveLoadBalancerDesiredState(lb)
+	if outcome.fatalErr != nil {
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_FAILED, outcome.fatalErr.Error())
+		return
+	}
+	if outcome.requeueMessage != "" {
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_PROVISIONING, outcome.requeueMessage)
+		return
+	}
+	if outcome.desired == nil {
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_PROVISIONING, "load balancer desired state is empty")
+		return
+	}
+	if loadBalancerAppliedConfigHash(lb) != outcome.desired.ConfigHash {
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(id, db.LOAD_BALANCER_PROVISIONING, "load balancer configuration drift detected")
+	}
+}
+
+func (c *controller) reconcileLoadBalancerDeleting(lb api.LoadBalancer, fabric networkfabric.LoadBalancerFabric) {
+	id := api.LoadBalancerID(lb)
+	lsName := loadBalancerLogicalSwitchNameFromLabels(lb)
+	if lsName == "" {
+		if vnet, err := c.db.GetVirtualNetworkByName(strings.TrimSpace(lb.Spec.InternalVirtualNetwork)); err == nil {
+			lsName = loadBalancerLogicalSwitchName(vnet)
+		}
+	}
+	if err := fabric.DeleteLoadBalancer(id, lsName); err != nil {
+		slog.Warn("DeleteLoadBalancer() failed", "id", id, "logicalSwitch", lsName, "err", err)
+	}
+
+	hostname := strings.TrimSpace(lb.Metadata.Name)
+	subdomain := strings.TrimSpace(lb.Spec.InternalVirtualNetwork)
+	if hostname != "" && subdomain != "" {
+		if err := c.db.DeleteDnsEntryByName(hostname, subdomain); err != nil && !errors.Is(err, db.ErrNotFound) {
+			slog.Warn("DeleteDnsEntryByName() failed", "id", id, "hostname", hostname, "subdomain", subdomain, "err", err)
+		}
+	}
+
+	if lb.Spec.VirtualIpAddress == nil || strings.TrimSpace(*lb.Spec.VirtualIpAddress) == "" {
+		_ = c.releaseLoadBalancerAllocatedVIP(lb)
+	}
+
+	if err := c.db.DeleteLoadBalancerById(id); err != nil {
+		slog.Warn("DeleteLoadBalancerById() failed", "id", id, "err", err)
+	}
+}
+
+func (c *controller) resolveLoadBalancerDesiredState(lb api.LoadBalancer) loadBalancerResolveOutcome {
+	id := strings.TrimSpace(api.LoadBalancerID(lb))
+	if id == "" {
+		return loadBalancerResolveOutcome{fatalErr: fmt.Errorf("load balancer id is empty")}
+	}
+	if strings.TrimSpace(lb.Spec.InternalVirtualNetwork) == "" {
+		return loadBalancerResolveOutcome{fatalErr: fmt.Errorf("spec.internalVirtualNetwork is required")}
+	}
+	if lb.Spec.BindPublicIpAddress != nil && strings.TrimSpace(*lb.Spec.BindPublicIpAddress) != "" {
+		return loadBalancerResolveOutcome{fatalErr: fmt.Errorf("spec.bindPublicIpAddress is out of scope for this release")}
+	}
+
+	vnet, err := c.db.GetVirtualNetworkByName(strings.TrimSpace(lb.Spec.InternalVirtualNetwork))
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return loadBalancerResolveOutcome{fatalErr: fmt.Errorf("internalVirtualNetwork %q is not found", strings.TrimSpace(lb.Spec.InternalVirtualNetwork))}
+		}
+		return loadBalancerResolveOutcome{fatalErr: err}
+	}
+
+	normalizedPorts, err := marmotd.NormalizeServerPorts(lb.Spec.ServerPorts)
+	if err != nil {
+		return loadBalancerResolveOutcome{fatalErr: err}
+	}
+	if len(normalizedPorts) == 0 {
+		return loadBalancerResolveOutcome{fatalErr: fmt.Errorf("spec.serverPorts is required")}
+	}
+
+	backendMode := resolveLoadBalancerBackendMode(lb.Spec.BackendMode)
+	if backendMode != loadBalancerBackendModeAuto && backendMode != loadBalancerBackendModeManual {
+		return loadBalancerResolveOutcome{fatalErr: fmt.Errorf("spec.backendMode must be manual or auto")}
+	}
+
+	var backends []string
+	if backendMode == loadBalancerBackendModeManual {
+		resolved, recoverable, resolveErr := c.resolveManualLoadBalancerBackends(lb)
+		if resolveErr != nil {
+			if recoverable {
+				return loadBalancerResolveOutcome{requeueMessage: resolveErr.Error()}
+			}
+			return loadBalancerResolveOutcome{fatalErr: resolveErr}
+		}
+		backends = resolved
+	} else {
+		if len(lb.Spec.InternalServers) > 0 {
+			return loadBalancerResolveOutcome{fatalErr: fmt.Errorf("spec.internalServers is forbidden when backendMode=auto")}
+		}
+		resolved, err := c.resolveAutoBackendsOnNetwork(lb.Spec.InternalVirtualNetwork, loadBalancerAutoBackendLabelKey, loadBalancerAutoBackendLabelValue)
+		if err != nil {
+			return loadBalancerResolveOutcome{fatalErr: err}
+		}
+		backends = resolved
+	}
+
+	if len(backends) == 0 {
+		return loadBalancerResolveOutcome{requeueMessage: "no backend servers resolved"}
+	}
+
+	resolvedVIP, err := c.resolveLoadBalancerVIP(lb, vnet)
+	if err != nil {
+		return loadBalancerResolveOutcome{fatalErr: err}
+	}
+	for _, backend := range backends {
+		if backend == resolvedVIP {
+			return loadBalancerResolveOutcome{fatalErr: fmt.Errorf("resolved virtual IP %q conflicts with backend IP", resolvedVIP)}
+		}
+	}
+
+	logicalSwitchName := loadBalancerLogicalSwitchName(vnet)
+	if logicalSwitchName == "" {
+		return loadBalancerResolveOutcome{fatalErr: fmt.Errorf("failed to determine logical switch name")}
+	}
+
+	vipMap := make(map[string]string, len(normalizedPorts))
+	for _, spec := range normalizedPorts {
+		parts := strings.Split(spec, "/")
+		if len(parts) != 2 {
+			return loadBalancerResolveOutcome{fatalErr: fmt.Errorf("invalid normalized serverPort %q", spec)}
+		}
+		vipMap[fmt.Sprintf("%s:%s", resolvedVIP, parts[0])] = strings.Join(withPort(backends, parts[0]), ",")
+	}
+
+	desired := &loadBalancerDesiredState{
+		ID:                id,
+		LogicalSwitchName: logicalSwitchName,
+		ResolvedVIP:       resolvedVIP,
+		ResolvedBackends:  append([]string(nil), backends...),
+		NormalizedPorts:   append([]string(nil), normalizedPorts...),
+		VIPs:              vipMap,
+		ConfigHash:        desiredLoadBalancerConfigHash(lb, backendMode, resolvedVIP, normalizedPorts, backends),
+	}
+
+	return loadBalancerResolveOutcome{desired: desired}
+}
+
+func (c *controller) applyLoadBalancerDesiredState(lb api.LoadBalancer, desired loadBalancerDesiredState, fabric networkfabric.LoadBalancerFabric) error {
+	externalIDs := map[string]string{}
+	if networkID := strings.TrimSpace(lb.Spec.InternalVirtualNetwork); networkID != "" {
+		externalIDs["marmot_network_name"] = networkID
+	}
+
+	ovnName, err := fabric.EnsureLoadBalancer(networkfabric.OVNLoadBalancerSpec{
+		LoadBalancerID:    desired.ID,
+		LogicalSwitchName: desired.LogicalSwitchName,
+		VIPs:              desired.VIPs,
+		ExternalIDs:       externalIDs,
+	})
+	if err != nil {
+		return err
+	}
+
+	hostname := strings.TrimSpace(lb.Metadata.Name)
+	subdomain := strings.TrimSpace(lb.Spec.InternalVirtualNetwork)
+	if hostname != "" && subdomain != "" {
+		if err := c.db.PutDnsEntry(hostname, subdomain, desired.ResolvedVIP); err != nil {
+			return err
+		}
+	}
+
+	return c.updateLoadBalancerLabels(desired.ID, func(labels map[string]interface{}) {
+		db.SetLoadBalancerResolvedVIP(labels, desired.ResolvedVIP)
+		db.SetLoadBalancerAppliedConfigHash(labels, desired.ConfigHash)
+		labels[loadBalancerLabelLogicalSwitch] = desired.LogicalSwitchName
+		labels[loadBalancerLabelOVNName] = ovnName
+		labels[loadBalancerLabelResolvedBackends] = strings.Join(desired.ResolvedBackends, ",")
+	})
+}
+
+func (c *controller) resolveManualLoadBalancerBackends(lb api.LoadBalancer) ([]string, bool, error) {
+	if len(lb.Spec.InternalServers) == 0 {
+		return nil, false, fmt.Errorf("spec.internalServers is required when backendMode=manual")
+	}
+
+	resolved := make([]string, 0, len(lb.Spec.InternalServers))
+	seen := map[string]struct{}{}
+
+	for _, rawName := range lb.Spec.InternalServers {
+		serverName := strings.TrimSpace(rawName)
+		if serverName == "" {
+			continue
+		}
+		server, err := c.findServerByName(serverName)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				return nil, false, fmt.Errorf("manual backend server %q is not found", serverName)
+			}
+			return nil, false, err
+		}
+		if server.Status == nil || server.Status.StatusCode != db.SERVER_RUNNING {
+			return nil, true, fmt.Errorf("manual backend server %q is not running", serverName)
+		}
+		ip, ok := serverAddressOnNetwork(server, lb.Spec.InternalVirtualNetwork)
+		if !ok {
+			return nil, true, fmt.Errorf("manual backend server %q has no IP on network %q", serverName, strings.TrimSpace(lb.Spec.InternalVirtualNetwork))
+		}
+		if _, exists := seen[ip]; exists {
+			continue
+		}
+		seen[ip] = struct{}{}
+		resolved = append(resolved, ip)
+	}
+
+	if len(resolved) == 0 {
+		return nil, false, fmt.Errorf("spec.internalServers is required when backendMode=manual")
+	}
+	sort.Strings(resolved)
+	return resolved, false, nil
+}
+
+func (c *controller) resolveLoadBalancerVIP(lb api.LoadBalancer, vnet api.VirtualNetwork) (string, error) {
+	if lb.Spec.VirtualIpAddress != nil {
+		explicitVIP := strings.TrimSpace(*lb.Spec.VirtualIpAddress)
+		if explicitVIP != "" {
+			return explicitVIP, nil
+		}
+	}
+
+	if lb.Metadata.Labels != nil {
+		if vip := db.GetLoadBalancerResolvedVIP(*lb.Metadata.Labels); vip != "" {
+			return vip, nil
+		}
+	}
+
+	ipnetID := ""
+	if vnet.Spec.IpNetworkId != nil {
+		ipnetID = strings.TrimSpace(*vnet.Spec.IpNetworkId)
+	}
+	if ipnetID == "" {
+		return "", fmt.Errorf("virtual network %q has no ipNetworkId for VIP auto allocation", strings.TrimSpace(vnet.Metadata.Name))
+	}
+	vnetID := strings.TrimSpace(api.VirtualNetworkID(vnet))
+	if vnetID == "" {
+		return "", fmt.Errorf("virtual network id is empty for %q", strings.TrimSpace(vnet.Metadata.Name))
+	}
+	lbID := strings.TrimSpace(api.LoadBalancerID(lb))
+	if lbID == "" {
+		return "", fmt.Errorf("load balancer id is empty")
+	}
+
+	allocated, _, err := c.db.AllocateIP(vnetID, ipnetID, "loadbalancer-"+lbID)
+	if err != nil {
+		return "", err
+	}
+	if err := c.updateLoadBalancerLabels(lbID, func(labels map[string]interface{}) {
+		db.SetLoadBalancerResolvedVIP(labels, allocated)
+	}); err != nil {
+		return "", err
+	}
+	return allocated, nil
+}
+
+func (c *controller) releaseLoadBalancerAllocatedVIP(lb api.LoadBalancer) error {
+	if lb.Metadata.Labels == nil {
+		return nil
+	}
+	vip := db.GetLoadBalancerResolvedVIP(*lb.Metadata.Labels)
+	if strings.TrimSpace(vip) == "" {
+		return nil
+	}
+	vnet, err := c.db.GetVirtualNetworkByName(strings.TrimSpace(lb.Spec.InternalVirtualNetwork))
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	vnetID := strings.TrimSpace(api.VirtualNetworkID(vnet))
+	if vnetID == "" || vnet.Spec.IpNetworkId == nil || strings.TrimSpace(*vnet.Spec.IpNetworkId) == "" {
+		return nil
+	}
+	if err := c.db.ReleaseIP(vnetID, strings.TrimSpace(*vnet.Spec.IpNetworkId), strings.TrimSpace(vip)); err != nil && !errors.Is(err, db.ErrNotFound) {
+		return err
+	}
+	return nil
+}
+
+func (c *controller) updateLoadBalancerLabels(loadBalancerID string, mutate func(labels map[string]interface{})) error {
+	lb, err := c.db.GetLoadBalancerById(loadBalancerID)
+	if err != nil {
+		return err
+	}
+	if lb.Metadata.Labels == nil {
+		labels := map[string]interface{}{}
+		lb.Metadata.Labels = &labels
+	}
+	labels := *lb.Metadata.Labels
+	mutate(labels)
+	lb.Metadata.Labels = &labels
+	return c.db.UpdateLoadBalancerById(loadBalancerID, lb)
+}
+
+func (c *controller) assignLoadBalancerNode(loadBalancerID string) error {
+	lb, err := c.db.GetLoadBalancerById(loadBalancerID)
+	if err != nil {
+		return err
+	}
+	if lb.Metadata.NodeName != nil && strings.TrimSpace(*lb.Metadata.NodeName) != "" {
+		return nil
+	}
+	if strings.TrimSpace(c.marmot.NodeName) == "" {
+		return fmt.Errorf("controller node name is empty")
+	}
+	lb.Metadata.NodeName = util.StringPtr(strings.TrimSpace(c.marmot.NodeName))
+	return c.db.UpdateLoadBalancerById(loadBalancerID, lb)
+}
+
+func loadBalancerHasAssignedNode(lb api.LoadBalancer) bool {
+	if lb.Metadata.NodeName == nil {
+		return false
+	}
+	return strings.TrimSpace(*lb.Metadata.NodeName) != ""
+}
+
+func loadBalancerAppliedConfigHash(lb api.LoadBalancer) string {
+	if lb.Metadata.Labels == nil {
+		return ""
+	}
+	return db.GetLoadBalancerAppliedConfigHash(*lb.Metadata.Labels)
+}
+
+func loadBalancerLogicalSwitchNameFromLabels(lb api.LoadBalancer) string {
+	if lb.Metadata.Labels == nil {
+		return ""
+	}
+	value, ok := (*lb.Metadata.Labels)[loadBalancerLabelLogicalSwitch]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
+}
+
+func resolveLoadBalancerBackendMode(mode *string) string {
+	if mode == nil {
+		return loadBalancerBackendModeAuto
+	}
+	trimmed := strings.ToLower(strings.TrimSpace(*mode))
+	if trimmed == "" {
+		return loadBalancerBackendModeAuto
+	}
+	return trimmed
+}
+
+func loadBalancerLogicalSwitchName(vnet api.VirtualNetwork) string {
+	id := strings.TrimSpace(api.VirtualNetworkID(vnet))
+	if id == "" {
+		id = strings.TrimSpace(vnet.Metadata.Name)
+	}
+	if id == "" {
+		return ""
+	}
+	return "marmot-net-" + loadBalancerLogicalSwitchSanitizer.ReplaceAllString(id, "-")
+}
+
+func desiredLoadBalancerConfigHash(lb api.LoadBalancer, mode string, vip string, ports []string, backends []string) string {
+	sortedPorts := append([]string(nil), ports...)
+	sortedBackends := append([]string(nil), backends...)
+	sort.Strings(sortedPorts)
+	sort.Strings(sortedBackends)
+
+	payload := strings.Join([]string{
+		strings.TrimSpace(api.LoadBalancerID(lb)),
+		strings.TrimSpace(mode),
+		strings.TrimSpace(lb.Spec.InternalVirtualNetwork),
+		strings.TrimSpace(vip),
+		strings.Join(sortedPorts, ","),
+		strings.Join(sortedBackends, ","),
+	}, "|")
+	sum := sha256.Sum256([]byte(payload))
+	return fmt.Sprintf("%x", sum)
+}
+
+func withPort(ips []string, port string) []string {
+	result := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		result = append(result, fmt.Sprintf("%s:%s", strings.TrimSpace(ip), strings.TrimSpace(port)))
+	}
+	return result
+}

--- a/pkg/controller/loadbalancer-controller_test.go
+++ b/pkg/controller/loadbalancer-controller_test.go
@@ -1,0 +1,137 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/networkfabric"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+type mockLoadBalancerFabric struct {
+	ensureCalls []networkfabric.OVNLoadBalancerSpec
+	deleteCalls []struct {
+		id  string
+		lsw string
+	}
+}
+
+func (m *mockLoadBalancerFabric) EnsureLoadBalancer(spec networkfabric.OVNLoadBalancerSpec) (string, error) {
+	m.ensureCalls = append(m.ensureCalls, spec)
+	return "marmot-lb-" + spec.LoadBalancerID, nil
+}
+
+func (m *mockLoadBalancerFabric) DeleteLoadBalancer(loadBalancerID string, logicalSwitchName string) error {
+	m.deleteCalls = append(m.deleteCalls, struct {
+		id  string
+		lsw string
+	}{id: loadBalancerID, lsw: logicalSwitchName})
+	return nil
+}
+
+func (m *mockLoadBalancerFabric) GetLoadBalancerStatus(loadBalancerID string, logicalSwitchName string) (networkfabric.OVNLoadBalancerStatus, error) {
+	return networkfabric.OVNLoadBalancerStatus{}, nil
+}
+
+func TestLoadBalancerControllerPendingToActive(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{db: database, marmot: &marmotd.Marmot{NodeName: "hvc", Db: database}, deletionDelay: 15}
+
+	_ = mustCreateVirtualNetwork(t, database, "web-servers")
+	mustCreateLoadBalancerBackendServer(t, database, "web-1", "web-servers", "172.16.10.2", true)
+
+	lb, err := database.CreateLoadBalancer(api.LoadBalancer{
+		ApiVersion: "v1",
+		Kind:       "LoadBalancer",
+		Metadata: api.Metadata{
+			Name:     "lb-1",
+			NodeName: util.StringPtr("hvc"),
+		},
+		Spec: api.LoadBalancerSpec{
+			BackendMode:            util.StringPtr("auto"),
+			InternalVirtualNetwork: "web-servers",
+			ServerPorts:            []string{"80/tcp", "443/tcp"},
+			VirtualIpAddress:       util.StringPtr("172.16.10.10"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer() failed: %v", err)
+	}
+	lbID := api.LoadBalancerID(lb)
+
+	mockFabric := &mockLoadBalancerFabric{}
+	origFactory := newLoadBalancerFabric
+	newLoadBalancerFabric = func() networkfabric.LoadBalancerFabric { return mockFabric }
+	t.Cleanup(func() {
+		newLoadBalancerFabric = origFactory
+	})
+
+	ctrl.loadBalancerControllerLoop()
+	afterPending, err := database.GetLoadBalancerById(lbID)
+	if err != nil {
+		t.Fatalf("GetLoadBalancerById() failed after pending loop: %v", err)
+	}
+	if afterPending.Status == nil || afterPending.Status.StatusCode != db.LOAD_BALANCER_PROVISIONING {
+		t.Fatalf("status after first loop = %v, want %d(PROVISIONING)", afterPending.Status, db.LOAD_BALANCER_PROVISIONING)
+	}
+
+	ctrl.loadBalancerControllerLoop()
+	afterProvisioning, err := database.GetLoadBalancerById(lbID)
+	if err != nil {
+		t.Fatalf("GetLoadBalancerById() failed after provisioning loop: %v", err)
+	}
+	if afterProvisioning.Status == nil || afterProvisioning.Status.StatusCode != db.LOAD_BALANCER_ACTIVE {
+		t.Fatalf("status after second loop = %v, want %d(ACTIVE)", afterProvisioning.Status, db.LOAD_BALANCER_ACTIVE)
+	}
+	if len(mockFabric.ensureCalls) == 0 {
+		t.Fatalf("EnsureLoadBalancer() was not called")
+	}
+	lastCall := mockFabric.ensureCalls[len(mockFabric.ensureCalls)-1]
+	if lastCall.LoadBalancerID != lbID {
+		t.Fatalf("EnsureLoadBalancer().LoadBalancerID = %q, want %q", lastCall.LoadBalancerID, lbID)
+	}
+	if lastCall.LogicalSwitchName == "" {
+		t.Fatalf("EnsureLoadBalancer().LogicalSwitchName is empty")
+	}
+	vipMap := lastCall.VIPs
+	if len(vipMap) != 2 {
+		t.Fatalf("EnsureLoadBalancer().VIPs len = %d, want 2; got=%v", len(vipMap), vipMap)
+	}
+	if got := vipMap["172.16.10.10:80"]; strings.TrimSpace(got) != "172.16.10.2:80" {
+		t.Fatalf("vip mapping for 80 = %q, want %q", got, "172.16.10.2:80")
+	}
+	if got := vipMap["172.16.10.10:443"]; strings.TrimSpace(got) != "172.16.10.2:443" {
+		t.Fatalf("vip mapping for 443 = %q, want %q", got, "172.16.10.2:443")
+	}
+}
+
+func mustCreateLoadBalancerBackendServer(t *testing.T, database *db.Database, name, networkName, ipAddress string, enabled bool) api.Server {
+	t.Helper()
+	labels := map[string]interface{}{}
+	if enabled {
+		labels["lb-enabled"] = "true"
+	}
+	server, err := database.MakeServerEntry(api.Server{
+		ApiVersion: "v1",
+		Kind:       "Server",
+		Metadata: api.Metadata{
+			Name:     name,
+			NodeName: util.StringPtr("hvc"),
+			Labels:   &labels,
+		},
+		Spec: api.ServerSpec{
+			NetworkInterface: &[]api.NetworkInterface{{
+				Networkname: networkName,
+				Address:     util.StringPtr(ipAddress),
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("MakeServerEntry() failed for backend server: %v", err)
+	}
+	database.UpdateServerStatus(api.ServerID(server), db.SERVER_RUNNING, "")
+	return server
+}

--- a/pkg/controller/loadbalancer-controller_test.go
+++ b/pkg/controller/loadbalancer-controller_test.go
@@ -1,8 +1,10 @@
 package controller
 
 import (
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/db"
@@ -13,14 +15,19 @@ import (
 
 type mockLoadBalancerFabric struct {
 	ensureCalls []networkfabric.OVNLoadBalancerSpec
+	ensureErr   error
 	deleteCalls []struct {
 		id  string
 		lsw string
 	}
+	deleteErr error
 }
 
 func (m *mockLoadBalancerFabric) EnsureLoadBalancer(spec networkfabric.OVNLoadBalancerSpec) (string, error) {
 	m.ensureCalls = append(m.ensureCalls, spec)
+	if m.ensureErr != nil {
+		return "", m.ensureErr
+	}
 	return "marmot-lb-" + spec.LoadBalancerID, nil
 }
 
@@ -29,6 +36,9 @@ func (m *mockLoadBalancerFabric) DeleteLoadBalancer(loadBalancerID string, logic
 		id  string
 		lsw string
 	}{id: loadBalancerID, lsw: logicalSwitchName})
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
 	return nil
 }
 
@@ -105,6 +115,199 @@ func TestLoadBalancerControllerPendingToActive(t *testing.T) {
 	}
 	if got := vipMap["172.16.10.10:443"]; strings.TrimSpace(got) != "172.16.10.2:443" {
 		t.Fatalf("vip mapping for 443 = %q, want %q", got, "172.16.10.2:443")
+	}
+}
+
+func TestLoadBalancerControllerAutoNoBackendsStaysProvisioning(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{db: database, marmot: &marmotd.Marmot{NodeName: "hvc", Db: database}, deletionDelay: 15}
+
+	_ = mustCreateVirtualNetwork(t, database, "web-servers")
+	// lb-enabled=false 相当: auto 対象が 0 台になる。
+	mustCreateLoadBalancerBackendServer(t, database, "web-1", "web-servers", "172.16.10.2", false)
+
+	lb, err := database.CreateLoadBalancer(api.LoadBalancer{
+		ApiVersion: "v1",
+		Kind:       "LoadBalancer",
+		Metadata: api.Metadata{
+			Name:     "lb-no-backend",
+			NodeName: util.StringPtr("hvc"),
+		},
+		Spec: api.LoadBalancerSpec{
+			BackendMode:            util.StringPtr("auto"),
+			InternalVirtualNetwork: "web-servers",
+			ServerPorts:            []string{"80/tcp"},
+			VirtualIpAddress:       util.StringPtr("172.16.10.20"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer() failed: %v", err)
+	}
+
+	mockFabric := &mockLoadBalancerFabric{}
+	origFactory := newLoadBalancerFabric
+	newLoadBalancerFabric = func() networkfabric.LoadBalancerFabric { return mockFabric }
+	t.Cleanup(func() {
+		newLoadBalancerFabric = origFactory
+	})
+
+	ctrl.loadBalancerControllerLoop()
+	after, err := database.GetLoadBalancerById(api.LoadBalancerID(lb))
+	if err != nil {
+		t.Fatalf("GetLoadBalancerById() failed: %v", err)
+	}
+	if after.Status == nil || after.Status.StatusCode != db.LOAD_BALANCER_PROVISIONING {
+		t.Fatalf("status = %v, want %d(PROVISIONING)", after.Status, db.LOAD_BALANCER_PROVISIONING)
+	}
+	if after.Status.Message == nil || !strings.Contains(*after.Status.Message, "no backend servers resolved") {
+		t.Fatalf("message = %v, want contains %q", after.Status.Message, "no backend servers resolved")
+	}
+	if len(mockFabric.ensureCalls) != 0 {
+		t.Fatalf("EnsureLoadBalancer() should not be called, got=%d", len(mockFabric.ensureCalls))
+	}
+}
+
+func TestLoadBalancerControllerManualMissingServerFails(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{db: database, marmot: &marmotd.Marmot{NodeName: "hvc", Db: database}, deletionDelay: 15}
+
+	_ = mustCreateVirtualNetwork(t, database, "web-servers")
+
+	lb, err := database.CreateLoadBalancer(api.LoadBalancer{
+		ApiVersion: "v1",
+		Kind:       "LoadBalancer",
+		Metadata: api.Metadata{
+			Name:     "lb-manual-missing",
+			NodeName: util.StringPtr("hvc"),
+		},
+		Spec: api.LoadBalancerSpec{
+			BackendMode:            util.StringPtr("manual"),
+			InternalVirtualNetwork: "web-servers",
+			InternalServers:        []string{"server-not-found"},
+			ServerPorts:            []string{"80/tcp"},
+			VirtualIpAddress:       util.StringPtr("172.16.10.30"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer() failed: %v", err)
+	}
+
+	ctrl.loadBalancerControllerLoop()
+	after, err := database.GetLoadBalancerById(api.LoadBalancerID(lb))
+	if err != nil {
+		t.Fatalf("GetLoadBalancerById() failed: %v", err)
+	}
+	if after.Status == nil || after.Status.StatusCode != db.LOAD_BALANCER_FAILED {
+		t.Fatalf("status = %v, want %d(FAILED)", after.Status, db.LOAD_BALANCER_FAILED)
+	}
+	if after.Status.Message == nil || !strings.Contains(*after.Status.Message, "manual backend server") {
+		t.Fatalf("message = %v, want contains %q", after.Status.Message, "manual backend server")
+	}
+}
+
+func TestLoadBalancerControllerDeletingCleansDNSAndEntry(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{db: database, marmot: &marmotd.Marmot{NodeName: "hvc", Db: database}, deletionDelay: 15}
+
+	_ = mustCreateVirtualNetwork(t, database, "web-servers")
+
+	lb, err := database.CreateLoadBalancer(api.LoadBalancer{
+		ApiVersion: "v1",
+		Kind:       "LoadBalancer",
+		Metadata: api.Metadata{
+			Name:     "lb-delete",
+			NodeName: util.StringPtr("hvc"),
+		},
+		Spec: api.LoadBalancerSpec{
+			BackendMode:            util.StringPtr("auto"),
+			InternalVirtualNetwork: "web-servers",
+			ServerPorts:            []string{"80/tcp"},
+			VirtualIpAddress:       util.StringPtr("172.16.10.40"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer() failed: %v", err)
+	}
+	lbID := api.LoadBalancerID(lb)
+
+	if err := database.PutDnsEntry("lb-delete", "web-servers", "172.16.10.40"); err != nil {
+		t.Fatalf("PutDnsEntry() failed: %v", err)
+	}
+	if err := database.UpdateLoadBalancerStatusWithMessage(lbID, db.LOAD_BALANCER_DELETING, ""); err != nil {
+		t.Fatalf("UpdateLoadBalancerStatusWithMessage() failed: %v", err)
+	}
+	if err := database.UpdateLoadBalancerById(lbID, api.LoadBalancer{
+		Metadata: api.Metadata{Labels: &map[string]interface{}{loadBalancerLabelLogicalSwitch: "marmot-net-web-servers"}},
+	}); err != nil {
+		t.Fatalf("UpdateLoadBalancerById() failed: %v", err)
+	}
+
+	mockFabric := &mockLoadBalancerFabric{}
+	origFactory := newLoadBalancerFabric
+	newLoadBalancerFabric = func() networkfabric.LoadBalancerFabric { return mockFabric }
+	t.Cleanup(func() {
+		newLoadBalancerFabric = origFactory
+	})
+
+	ctrl.loadBalancerControllerLoop()
+
+	_, err = database.GetLoadBalancerById(lbID)
+	if !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("GetLoadBalancerById() err = %v, want ErrNotFound", err)
+	}
+	if _, err := database.GetDnsEntry("lb-delete", "web-servers"); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("GetDnsEntry() err = %v, want ErrNotFound", err)
+	}
+	if len(mockFabric.deleteCalls) != 1 {
+		t.Fatalf("DeleteLoadBalancer() call count = %d, want 1", len(mockFabric.deleteCalls))
+	}
+	if mockFabric.deleteCalls[0].id != lbID {
+		t.Fatalf("DeleteLoadBalancer() id = %q, want %q", mockFabric.deleteCalls[0].id, lbID)
+	}
+}
+
+func TestLoadBalancerControllerActiveDriftToProvisioning(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{db: database, marmot: &marmotd.Marmot{NodeName: "hvc", Db: database}, deletionDelay: 15 * time.Second}
+
+	_ = mustCreateVirtualNetwork(t, database, "web-servers")
+	mustCreateLoadBalancerBackendServer(t, database, "web-1", "web-servers", "172.16.10.2", true)
+
+	labels := map[string]interface{}{
+		db.LoadBalancerLabelAppliedConfig: "outdated-hash",
+	}
+	lb, err := database.CreateLoadBalancer(api.LoadBalancer{
+		ApiVersion: "v1",
+		Kind:       "LoadBalancer",
+		Metadata: api.Metadata{
+			Name:     "lb-drift",
+			NodeName: util.StringPtr("hvc"),
+			Labels:   &labels,
+		},
+		Spec: api.LoadBalancerSpec{
+			BackendMode:            util.StringPtr("auto"),
+			InternalVirtualNetwork: "web-servers",
+			ServerPorts:            []string{"80/tcp"},
+			VirtualIpAddress:       util.StringPtr("172.16.10.50"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer() failed: %v", err)
+	}
+	if err := database.UpdateLoadBalancerStatusWithMessage(api.LoadBalancerID(lb), db.LOAD_BALANCER_ACTIVE, ""); err != nil {
+		t.Fatalf("UpdateLoadBalancerStatusWithMessage() failed: %v", err)
+	}
+
+	ctrl.loadBalancerControllerLoop()
+	after, err := database.GetLoadBalancerById(api.LoadBalancerID(lb))
+	if err != nil {
+		t.Fatalf("GetLoadBalancerById() failed: %v", err)
+	}
+	if after.Status == nil || after.Status.StatusCode != db.LOAD_BALANCER_PROVISIONING {
+		t.Fatalf("status = %v, want %d(PROVISIONING)", after.Status, db.LOAD_BALANCER_PROVISIONING)
+	}
+	if after.Status.Message == nil || !strings.Contains(*after.Status.Message, "configuration drift detected") {
+		t.Fatalf("message = %v, want contains %q", after.Status.Message, "configuration drift detected")
 	}
 }
 

--- a/pkg/db/db-etcd.go
+++ b/pkg/db/db-etcd.go
@@ -22,6 +22,7 @@ const (
 	ImagePrefix           = "/marmot/image"
 	NetworkPrefix         = "/marmot/network"
 	GatewayPrefix         = "/marmot/gateway"
+	LoadBalancerPrefix    = "/marmot/load-balancer"
 	VpnGatewayPrefix      = "/marmot/vpn-gateway"
 	SeqPrefix             = "/marmot/sequence"
 	VersionKey            = "/marmot/version"

--- a/pkg/db/db-loadbalancer.go
+++ b/pkg/db/db-loadbalancer.go
@@ -1,0 +1,275 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+const (
+	LOAD_BALANCER_PENDING      = 0
+	LOAD_BALANCER_PROVISIONING = 1
+	LOAD_BALANCER_ACTIVE       = 2
+	LOAD_BALANCER_FAILED       = 3
+	LOAD_BALANCER_DELETING     = 4
+
+	LoadBalancerLabelManagedBy      = "managedBy"
+	LoadBalancerLabelManagedByValue = "load-balancer-controller"
+	LoadBalancerLabelAppliedConfig  = "appliedConfigHash"
+	LoadBalancerLabelResolvedVIP    = "resolvedVirtualIpAddress"
+)
+
+var LoadBalancerStatus = map[int]string{
+	LOAD_BALANCER_PENDING:      "PENDING",
+	LOAD_BALANCER_PROVISIONING: "PROVISIONING",
+	LOAD_BALANCER_ACTIVE:       "ACTIVE",
+	LOAD_BALANCER_FAILED:       "FAILED",
+	LOAD_BALANCER_DELETING:     "DELETING",
+}
+
+func SetLoadBalancerAppliedConfigHash(labels map[string]interface{}, hash string) {
+	if labels == nil {
+		return
+	}
+	labels[LoadBalancerLabelAppliedConfig] = strings.TrimSpace(hash)
+}
+
+func GetLoadBalancerAppliedConfigHash(labels map[string]interface{}) string {
+	if labels == nil {
+		return ""
+	}
+	val, ok := labels[LoadBalancerLabelAppliedConfig].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(val)
+}
+
+func SetLoadBalancerResolvedVIP(labels map[string]interface{}, vip string) {
+	if labels == nil {
+		return
+	}
+	labels[LoadBalancerLabelResolvedVIP] = strings.TrimSpace(vip)
+}
+
+func GetLoadBalancerResolvedVIP(labels map[string]interface{}) string {
+	if labels == nil {
+		return ""
+	}
+	val, ok := labels[LoadBalancerLabelResolvedVIP].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(val)
+}
+
+func (d *Database) CreateLoadBalancer(spec api.LoadBalancer) (api.LoadBalancer, error) {
+	mutex, err := d.LockKey("/lock/load-balancer/create")
+	if err != nil {
+		return api.LoadBalancer{}, err
+	}
+	defer d.UnlockKey(mutex)
+
+	current, err := d.GetLoadBalancers()
+	if err != nil && err != ErrNotFound {
+		return api.LoadBalancer{}, err
+	}
+
+	name := strings.TrimSpace(spec.Metadata.Name)
+	vnet := strings.TrimSpace(spec.Spec.InternalVirtualNetwork)
+	for _, item := range current {
+		existingName := strings.TrimSpace(item.Metadata.Name)
+		existingVnet := strings.TrimSpace(item.Spec.InternalVirtualNetwork)
+		if existingName == name && existingVnet == vnet {
+			return api.LoadBalancer{}, fmt.Errorf("load balancer with name %q already exists in internalVirtualNetwork %q", name, vnet)
+		}
+	}
+
+	rec, err := util.DeepCopy(spec)
+	if err != nil {
+		return api.LoadBalancer{}, err
+	}
+
+	if rec.Metadata.Labels == nil {
+		rec.Metadata.Labels = &map[string]interface{}{}
+	}
+	labels := *rec.Metadata.Labels
+	labels[LoadBalancerLabelManagedBy] = LoadBalancerLabelManagedByValue
+	rec.Metadata.Labels = &labels
+
+	var key string
+	for {
+		rec.Metadata.Uuid = util.StringPtr(uuid.New().String())
+		id := (*rec.Metadata.Uuid)[:5]
+		api.SetLoadBalancerID(&rec, id)
+		key = LoadBalancerPrefix + "/" + id
+
+		var existing api.LoadBalancer
+		_, getErr := d.GetJSON(key, &existing)
+		if getErr == ErrNotFound {
+			break
+		}
+		if getErr != nil {
+			return api.LoadBalancer{}, getErr
+		}
+	}
+
+	now := time.Now()
+	rec.Status = &api.Status{
+		StatusCode:          LOAD_BALANCER_PENDING,
+		Status:              util.StringPtr(LoadBalancerStatus[LOAD_BALANCER_PENDING]),
+		CreationTimeStamp:   util.TimePtr(now),
+		LastUpdateTimeStamp: util.TimePtr(now),
+	}
+
+	if err := d.PutJSON(key, rec); err != nil {
+		return api.LoadBalancer{}, err
+	}
+
+	return rec, nil
+}
+
+func (d *Database) GetLoadBalancers() ([]api.LoadBalancer, error) {
+	result := make([]api.LoadBalancer, 0)
+	resp, err := d.GetByPrefix(LoadBalancerPrefix)
+	if err == ErrNotFound {
+		return result, nil
+	}
+	if err != nil {
+		return result, err
+	}
+
+	for _, kv := range resp.Kvs {
+		var rec api.LoadBalancer
+		if err := json.Unmarshal(kv.Value, &rec); err != nil {
+			slog.Error("GetLoadBalancers() unmarshal failed", "err", err, "key", string(kv.Key))
+			continue
+		}
+		result = append(result, rec)
+	}
+
+	return result, nil
+}
+
+func (d *Database) GetLoadBalancerById(id string) (api.LoadBalancer, error) {
+	key := LoadBalancerPrefix + "/" + id
+	var rec api.LoadBalancer
+	_, err := d.GetJSON(key, &rec)
+	if err != nil {
+		return api.LoadBalancer{}, err
+	}
+	return rec, nil
+}
+
+func (d *Database) UpdateLoadBalancerById(id string, spec api.LoadBalancer) error {
+	for {
+		err := d.updateLoadBalancerById(id, spec)
+		if err == ErrUpdateConflict {
+			slog.Warn("UpdateLoadBalancerById() retrying due to update conflict", "loadBalancerId", id)
+			continue
+		}
+		return err
+	}
+}
+
+func (d *Database) updateLoadBalancerById(id string, spec api.LoadBalancer) error {
+	lockKey := "/lock/load-balancer/" + id
+	mutex, err := d.LockKey(lockKey)
+	if err != nil {
+		return err
+	}
+	defer d.UnlockKey(mutex)
+
+	key := LoadBalancerPrefix + "/" + id
+	var rec api.LoadBalancer
+	resp, err := d.GetJSON(key, &rec)
+	if err != nil {
+		return err
+	}
+
+	util.PatchStruct(&rec, spec)
+	api.SetLoadBalancerID(&rec, id)
+
+	return d.PutJSONCAS(key, resp.Kvs[0].ModRevision, &rec)
+}
+
+func (d *Database) DeleteLoadBalancerById(id string) error {
+	lockKey := "/lock/load-balancer/" + id
+	mutex, err := d.LockKey(lockKey)
+	if err != nil {
+		return err
+	}
+	defer d.UnlockKey(mutex)
+
+	key := LoadBalancerPrefix + "/" + id
+	return d.DeleteJSON(key)
+}
+
+func (d *Database) SetDeleteTimestampLoadBalancer(id string) error {
+	rec, err := d.GetLoadBalancerById(id)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	if rec.Status == nil {
+		rec.Status = &api.Status{}
+	}
+	rec.Status.DeletionTimeStamp = util.TimePtr(now)
+	rec.Status.LastUpdateTimeStamp = util.TimePtr(now)
+	rec.Status.StatusCode = LOAD_BALANCER_DELETING
+	rec.Status.Status = util.StringPtr(LoadBalancerStatus[LOAD_BALANCER_DELETING])
+
+	return d.UpdateLoadBalancerById(id, rec)
+}
+
+func (d *Database) UpdateLoadBalancerStatusWithMessage(id string, status int, message string) error {
+	rec, err := d.GetLoadBalancerById(id)
+	if err != nil {
+		return err
+	}
+	if rec.Status == nil {
+		rec.Status = &api.Status{}
+	}
+
+	statusChanged := rec.Status.StatusCode != status
+	rec.Status.StatusCode = status
+	rec.Status.Status = util.StringPtr(LoadBalancerStatus[status])
+	rec.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
+
+	trimmedMessage := strings.TrimSpace(message)
+	if statusChanged {
+		rec.Status.Message = util.StringPtr("")
+	}
+	if trimmedMessage == "" {
+		if rec.Status.Message == nil {
+			rec.Status.Message = util.StringPtr("")
+		}
+	} else {
+		rec.Status.Message = util.StringPtr(trimmedMessage)
+	}
+
+	return d.UpdateLoadBalancerById(id, rec)
+}
+
+func (d *Database) GetLoadBalancerByName(name string) ([]api.LoadBalancer, error) {
+	all, err := d.GetLoadBalancers()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]api.LoadBalancer, 0)
+	target := strings.TrimSpace(name)
+	for _, item := range all {
+		if strings.TrimSpace(item.Metadata.Name) == target {
+			result = append(result, item)
+		}
+	}
+	return result, nil
+}

--- a/pkg/marmotd/api-gateway.go
+++ b/pkg/marmotd/api-gateway.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -194,7 +193,7 @@ func normalizeGatewaySpec(spec *api.GatewaySpec) error {
 		return err
 	}
 
-	ports, err := normalizeGatewayPorts(spec.ServerPorts)
+	ports, err := NormalizeServerPorts(spec.ServerPorts)
 	if err != nil {
 		return err
 	}
@@ -247,64 +246,3 @@ func normalizeGatewayRemoteCIDRs(spec *api.GatewaySpec) error {
 	return nil
 }
 
-func normalizeGatewayPorts(raw []string) ([]string, error) {
-	if len(raw) == 0 {
-		return nil, fmt.Errorf("spec.serverPorts is required")
-	}
-
-	normalized := make([]string, 0, len(raw))
-	seen := map[string]struct{}{}
-
-	for _, p := range raw {
-		entry := strings.TrimSpace(p)
-		if entry == "" {
-			return nil, fmt.Errorf("spec.serverPorts contains an empty entry")
-		}
-
-		portSpec, err := resolvePortSpec(entry)
-		if err != nil {
-			return nil, err
-		}
-
-		if _, ok := seen[portSpec]; ok {
-			continue
-		}
-		seen[portSpec] = struct{}{}
-		normalized = append(normalized, portSpec)
-	}
-
-	if len(normalized) == 0 {
-		return nil, fmt.Errorf("spec.serverPorts is required")
-	}
-
-	return normalized, nil
-}
-
-func resolvePortSpec(entry string) (string, error) {
-	if strings.Contains(entry, "/") {
-		parts := strings.Split(entry, "/")
-		if len(parts) != 2 {
-			return "", fmt.Errorf("invalid port format %q", entry)
-		}
-		port, err := strconv.Atoi(strings.TrimSpace(parts[0]))
-		if err != nil || port < 1 || port > 65535 {
-			return "", fmt.Errorf("invalid port number in %q", entry)
-		}
-		proto := strings.ToLower(strings.TrimSpace(parts[1]))
-		if proto != "tcp" && proto != "udp" {
-			return "", fmt.Errorf("invalid protocol in %q: must be tcp or udp", entry)
-		}
-		return fmt.Sprintf("%d/%s", port, proto), nil
-	}
-
-	if _, err := strconv.Atoi(entry); err == nil {
-		return "", fmt.Errorf("numeric port %q must include protocol suffix like /tcp or /udp", entry)
-	}
-
-	// service name lookup uses tcp as default protocol by requirement.
-	port, err := net.LookupPort("tcp", strings.ToLower(entry))
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve service name %q with tcp: %w", entry, err)
-	}
-	return fmt.Sprintf("%d/tcp", port), nil
-}

--- a/pkg/marmotd/server_ports.go
+++ b/pkg/marmotd/server_ports.go
@@ -1,0 +1,71 @@
+package marmotd
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// NormalizeServerPorts normalizes spec.serverPorts entries into "<port>/<proto>" format.
+// Service names are resolved with tcp as default protocol.
+func NormalizeServerPorts(raw []string) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("spec.serverPorts is required")
+	}
+
+	normalized := make([]string, 0, len(raw))
+	seen := map[string]struct{}{}
+
+	for _, p := range raw {
+		entry := strings.TrimSpace(p)
+		if entry == "" {
+			return nil, fmt.Errorf("spec.serverPorts contains an empty entry")
+		}
+
+		portSpec, err := resolveServerPortSpec(entry)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, ok := seen[portSpec]; ok {
+			continue
+		}
+		seen[portSpec] = struct{}{}
+		normalized = append(normalized, portSpec)
+	}
+
+	if len(normalized) == 0 {
+		return nil, fmt.Errorf("spec.serverPorts is required")
+	}
+
+	return normalized, nil
+}
+
+func resolveServerPortSpec(entry string) (string, error) {
+	if strings.Contains(entry, "/") {
+		parts := strings.Split(entry, "/")
+		if len(parts) != 2 {
+			return "", fmt.Errorf("invalid port format %q", entry)
+		}
+		port, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil || port < 1 || port > 65535 {
+			return "", fmt.Errorf("invalid port number in %q", entry)
+		}
+		proto := strings.ToLower(strings.TrimSpace(parts[1]))
+		if proto != "tcp" && proto != "udp" {
+			return "", fmt.Errorf("invalid protocol in %q: must be tcp or udp", entry)
+		}
+		return fmt.Sprintf("%d/%s", port, proto), nil
+	}
+
+	if _, err := strconv.Atoi(entry); err == nil {
+		return "", fmt.Errorf("numeric port %q must include protocol suffix like /tcp or /udp", entry)
+	}
+
+	port, err := net.LookupPort("tcp", strings.ToLower(entry))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve service name %q with tcp: %w", entry, err)
+	}
+	return fmt.Sprintf("%d/tcp", port), nil
+}

--- a/pkg/marmotd/server_ports_test.go
+++ b/pkg/marmotd/server_ports_test.go
@@ -1,0 +1,77 @@
+package marmotd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeServerPorts(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []string
+		want    []string
+		wantErr string
+	}{
+		{
+			name:    "empty list",
+			in:      []string{},
+			wantErr: "spec.serverPorts is required",
+		},
+		{
+			name:    "contains empty entry",
+			in:      []string{"http", "  "},
+			wantErr: "spec.serverPorts contains an empty entry",
+		},
+		{
+			name: "service name and explicit ports",
+			in:   []string{"http", "1234/tcp", "5353/UDP"},
+			want: []string{"80/tcp", "1234/tcp", "5353/udp"},
+		},
+		{
+			name: "dedupe while preserving first occurrence order",
+			in:   []string{"https", "443/tcp", "https", "443/tcp"},
+			want: []string{"443/tcp"},
+		},
+		{
+			name:    "numeric port without protocol is rejected",
+			in:      []string{"1234"},
+			wantErr: "must include protocol suffix",
+		},
+		{
+			name:    "invalid protocol rejected",
+			in:      []string{"53/sctp"},
+			wantErr: "must be tcp or udp",
+		},
+		{
+			name:    "unknown service rejected",
+			in:      []string{"service-that-should-not-exist-xyz"},
+			wantErr: "failed to resolve service name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeServerPorts(tt.in)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeServerPorts() returned error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("NormalizeServerPorts() length = %d, want %d; got=%v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("NormalizeServerPorts()[%d] = %q, want %q; got=%v", i, got[i], tt.want[i], got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/networkfabric/interface.go
+++ b/pkg/networkfabric/interface.go
@@ -32,6 +32,31 @@ type NetworkFabric interface {
 	GetBridgeStatus(vnet *api.VirtualNetwork) (exists bool, peerCount int, err error)
 }
 
+// OVNLoadBalancerSpec は OVN load_balancer 同期の最小入力。
+// VIPs は ovn-nbctl の vips マップ形式（"vip:port" -> "backend1:port,backend2:port"）を想定する。
+type OVNLoadBalancerSpec struct {
+	LoadBalancerID   string
+	LogicalSwitchName string
+	VIPs             map[string]string
+	ExternalIDs      map[string]string
+}
+
+// OVNLoadBalancerStatus は OVN 上の load_balancer 状態を表す。
+type OVNLoadBalancerStatus struct {
+	Exists                 bool
+	AttachedToLogicalSwitch bool
+	VIPCount               int
+	OVNLoadBalancerName    string
+}
+
+// LoadBalancerFabric は OVN load balancer の同期を担当する。
+// controller 層は desired state の生成までを担当し、OVN コマンド詳細は本抽象に閉じ込める。
+type LoadBalancerFabric interface {
+	EnsureLoadBalancer(spec OVNLoadBalancerSpec) (string, error)
+	DeleteLoadBalancer(loadBalancerID string, logicalSwitchName string) error
+	GetLoadBalancerStatus(loadBalancerID string, logicalSwitchName string) (OVNLoadBalancerStatus, error)
+}
+
 // PeerNode はメッシュ構成用のピア情報。
 type PeerNode struct {
 	NodeName   string // ノード名

--- a/pkg/networkfabric/ovn_loadbalancer.go
+++ b/pkg/networkfabric/ovn_loadbalancer.go
@@ -1,0 +1,190 @@
+package networkfabric
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var ovnMapPairPattern = regexp.MustCompile(`"([^"]+)"\s*=\s*"([^"]*)"`)
+
+func (o *OVNFabric) EnsureLoadBalancer(spec OVNLoadBalancerSpec) (string, error) {
+	if _, err := ovnNBCTLLookPath("ovn-nbctl"); err != nil {
+		return "", fmt.Errorf("ovn-nbctl is required for load balancer operations")
+	}
+
+	lbName := ovnLoadBalancerName(spec.LoadBalancerID)
+	if lbName == "" {
+		return "", fmt.Errorf("load balancer id is required")
+	}
+	lsName := strings.TrimSpace(spec.LogicalSwitchName)
+	if lsName == "" {
+		return "", fmt.Errorf("logical switch name is required")
+	}
+
+	if _, err := runOVNNBCTLCommand("--may-exist", "lb-add", lbName); err != nil {
+		return "", fmt.Errorf("failed to ensure OVN load balancer %s: %w", lbName, err)
+	}
+
+	externalIDs := map[string]string{
+		"marmot_loadbalancer_id": strings.TrimSpace(spec.LoadBalancerID),
+		"marmot_managed":         "true",
+	}
+	for k, v := range spec.ExternalIDs {
+		tk := strings.TrimSpace(k)
+		if tk == "" {
+			continue
+		}
+		externalIDs[tk] = strings.TrimSpace(v)
+	}
+	keys := sortedMapKeys(externalIDs)
+	for _, key := range keys {
+		val := externalIDs[key]
+		if _, err := runOVNNBCTLCommand("set", "load_balancer", lbName, fmt.Sprintf("external_ids:%s=%s", key, val)); err != nil {
+			return "", fmt.Errorf("failed to set external_id %s on OVN load balancer %s: %w", key, lbName, err)
+		}
+	}
+
+	if _, err := runOVNNBCTLCommand("clear", "load_balancer", lbName, "vips"); err != nil {
+		return "", fmt.Errorf("failed to clear vips on OVN load balancer %s: %w", lbName, err)
+	}
+	if err := setLoadBalancerVIPs(lbName, spec.VIPs); err != nil {
+		return "", err
+	}
+
+	if _, err := runOVNNBCTLCommand("--may-exist", "ls-lb-add", lsName, lbName); err != nil {
+		return "", fmt.Errorf("failed to attach OVN load balancer %s to logical switch %s: %w", lbName, lsName, err)
+	}
+
+	return lbName, nil
+}
+
+func (o *OVNFabric) DeleteLoadBalancer(loadBalancerID string, logicalSwitchName string) error {
+	if _, err := ovnNBCTLLookPath("ovn-nbctl"); err != nil {
+		return fmt.Errorf("ovn-nbctl is required for load balancer operations")
+	}
+
+	lbName := ovnLoadBalancerName(loadBalancerID)
+	if lbName == "" {
+		return fmt.Errorf("load balancer id is required")
+	}
+	lsName := strings.TrimSpace(logicalSwitchName)
+	if lsName != "" {
+		if _, err := runOVNNBCTLCommand("--if-exists", "ls-lb-del", lsName, lbName); err != nil {
+			if !isOVNNoRowError(err) {
+				return fmt.Errorf("failed to detach OVN load balancer %s from logical switch %s: %w", lbName, lsName, err)
+			}
+		}
+	}
+	if _, err := runOVNNBCTLCommand("--if-exists", "lb-del", lbName); err != nil {
+		return fmt.Errorf("failed to delete OVN load balancer %s: %w", lbName, err)
+	}
+	return nil
+}
+
+func (o *OVNFabric) GetLoadBalancerStatus(loadBalancerID string, logicalSwitchName string) (OVNLoadBalancerStatus, error) {
+	if _, err := ovnNBCTLLookPath("ovn-nbctl"); err != nil {
+		return OVNLoadBalancerStatus{}, fmt.Errorf("ovn-nbctl is required for load balancer operations")
+	}
+
+	lbName := ovnLoadBalancerName(loadBalancerID)
+	if lbName == "" {
+		return OVNLoadBalancerStatus{}, fmt.Errorf("load balancer id is required")
+	}
+	status := OVNLoadBalancerStatus{OVNLoadBalancerName: lbName}
+
+	uuidOutput, err := runOVNNBCTLCommand("--columns=_uuid", "--format=csv", "--data=bare", "--no-heading", "find", "load_balancer", "name="+lbName)
+	if err != nil {
+		return status, fmt.Errorf("failed to get OVN load balancer uuid for %s: %w", lbName, err)
+	}
+	uuid := strings.TrimSpace(firstCSVLine(uuidOutput))
+	if uuid == "" {
+		return status, nil
+	}
+	status.Exists = true
+
+	vipsOut, err := runOVNNBCTLCommand("get", "load_balancer", lbName, "vips")
+	if err != nil {
+		return status, fmt.Errorf("failed to get OVN load balancer vips for %s: %w", lbName, err)
+	}
+	status.VIPCount = len(parseOVNMap(vipsOut))
+
+	lsName := strings.TrimSpace(logicalSwitchName)
+	if lsName == "" {
+		return status, nil
+	}
+	attachedOut, err := runOVNNBCTLCommand("get", "logical_switch", lsName, "load_balancer")
+	if err != nil {
+		if isOVNNoRowError(err) {
+			return status, nil
+		}
+		return status, fmt.Errorf("failed to get OVN logical switch load balancer refs for %s: %w", lsName, err)
+	}
+	status.AttachedToLogicalSwitch = strings.Contains(attachedOut, uuid)
+	return status, nil
+}
+
+func setLoadBalancerVIPs(lbName string, vips map[string]string) error {
+	for _, key := range sortedMapKeys(vips) {
+		vipKey := strings.TrimSpace(key)
+		backendValue := strings.TrimSpace(vips[key])
+		if vipKey == "" || backendValue == "" {
+			return fmt.Errorf("vips key and value are required")
+		}
+		if _, err := runOVNNBCTLCommand("set", "load_balancer", lbName, fmt.Sprintf("vips:\"%s\"=\"%s\"", vipKey, backendValue)); err != nil {
+			return fmt.Errorf("failed to set vip mapping %s on OVN load balancer %s: %w", vipKey, lbName, err)
+		}
+	}
+	return nil
+}
+
+func parseOVNMap(raw string) map[string]string {
+	result := map[string]string{}
+	for _, m := range ovnMapPairPattern.FindAllStringSubmatch(strings.TrimSpace(raw), -1) {
+		if len(m) < 3 {
+			continue
+		}
+		result[strings.TrimSpace(m[1])] = strings.TrimSpace(m[2])
+	}
+	return result
+}
+
+func ovnLoadBalancerName(loadBalancerID string) string {
+	id := strings.TrimSpace(loadBalancerID)
+	if id == "" {
+		return ""
+	}
+	safe := ovnLogicalSwitchSanitizer.ReplaceAllString(id, "-")
+	if safe == "" {
+		return ""
+	}
+	return "marmot-lb-" + safe
+}
+
+func sortedMapKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func firstCSVLine(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			return strings.Trim(trimmed, `"`)
+		}
+	}
+	return ""
+}
+
+func isOVNNoRowError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no row") || strings.Contains(msg, "does not exist")
+}

--- a/pkg/networkfabric/ovn_loadbalancer_test.go
+++ b/pkg/networkfabric/ovn_loadbalancer_test.go
@@ -1,0 +1,169 @@
+package networkfabric
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestEnsureLoadBalancer_ProgramsOVNCommands(t *testing.T) {
+	withOVNLookPath(t, true, true)
+	calls := []ovnRunnerCall{}
+	withOVNRunner(t, func(args ...string) (string, error) {
+		calls = append(calls, ovnRunnerCall{args: append([]string{}, args...)})
+		return "", nil
+	})
+
+	of := NewOVNFabric()
+	spec := OVNLoadBalancerSpec{
+		LoadBalancerID:    "lb-1",
+		LogicalSwitchName: "marmot-net-net1",
+		VIPs: map[string]string{
+			"10.0.0.10:443": "10.0.0.21:443,10.0.0.22:443",
+			"10.0.0.10:80":  "10.0.0.21:80,10.0.0.22:80",
+		},
+		ExternalIDs: map[string]string{
+			"marmot_network_id": "net1",
+		},
+	}
+
+	lbName, err := of.EnsureLoadBalancer(spec)
+	if err != nil {
+		t.Fatalf("EnsureLoadBalancer() failed: %v", err)
+	}
+	if lbName != "marmot-lb-lb-1" {
+		t.Fatalf("EnsureLoadBalancer() name = %q, want %q", lbName, "marmot-lb-lb-1")
+	}
+
+	hasLBAdd := false
+	hasClearVIPs := false
+	hasAttach := false
+	setVIPs := []string{}
+	for _, c := range calls {
+		if len(c.args) >= 3 && reflect.DeepEqual(c.args[:2], []string{"--may-exist", "lb-add"}) && c.args[2] == "marmot-lb-lb-1" {
+			hasLBAdd = true
+		}
+		if len(c.args) == 4 && reflect.DeepEqual(c.args[:3], []string{"clear", "load_balancer", "marmot-lb-lb-1"}) && c.args[3] == "vips" {
+			hasClearVIPs = true
+		}
+		if len(c.args) == 4 && reflect.DeepEqual(c.args[:2], []string{"--may-exist", "ls-lb-add"}) {
+			hasAttach = true
+		}
+		if len(c.args) == 4 && reflect.DeepEqual(c.args[:3], []string{"set", "load_balancer", "marmot-lb-lb-1"}) && strings.HasPrefix(c.args[3], "vips:") {
+			setVIPs = append(setVIPs, c.args[3])
+		}
+	}
+
+	if !hasLBAdd {
+		t.Fatalf("lb-add was not called: calls=%v", calls)
+	}
+	if !hasClearVIPs {
+		t.Fatalf("clear vips was not called: calls=%v", calls)
+	}
+	if !hasAttach {
+		t.Fatalf("ls-lb-add was not called: calls=%v", calls)
+	}
+	if len(setVIPs) != 2 {
+		t.Fatalf("set vips call count = %d, want 2; calls=%v", len(setVIPs), setVIPs)
+	}
+	if !(strings.Contains(setVIPs[0], "10.0.0.10:443") || strings.Contains(setVIPs[1], "10.0.0.10:443")) {
+		t.Fatalf("443 vip mapping not found: calls=%v", setVIPs)
+	}
+	if !(strings.Contains(setVIPs[0], "10.0.0.10:80") || strings.Contains(setVIPs[1], "10.0.0.10:80")) {
+		t.Fatalf("80 vip mapping not found: calls=%v", setVIPs)
+	}
+}
+
+func TestDeleteLoadBalancer_CallsDetachAndDelete(t *testing.T) {
+	withOVNLookPath(t, true, true)
+	calls := []ovnRunnerCall{}
+	withOVNRunner(t, func(args ...string) (string, error) {
+		calls = append(calls, ovnRunnerCall{args: append([]string{}, args...)})
+		return "", nil
+	})
+
+	of := NewOVNFabric()
+	if err := of.DeleteLoadBalancer("lb-1", "marmot-net-net1"); err != nil {
+		t.Fatalf("DeleteLoadBalancer() failed: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("command count = %d, want 2; calls=%v", len(calls), calls)
+	}
+	if !reflect.DeepEqual(calls[0].args, []string{"--if-exists", "ls-lb-del", "marmot-net-net1", "marmot-lb-lb-1"}) {
+		t.Fatalf("unexpected detach command: %v", calls[0].args)
+	}
+	if !reflect.DeepEqual(calls[1].args, []string{"--if-exists", "lb-del", "marmot-lb-lb-1"}) {
+		t.Fatalf("unexpected delete command: %v", calls[1].args)
+	}
+}
+
+func TestGetLoadBalancerStatus_ExistsAndAttached(t *testing.T) {
+	withOVNLookPath(t, true, true)
+	withOVNRunner(t, func(args ...string) (string, error) {
+		if len(args) >= 6 && reflect.DeepEqual(args[:5], []string{"--columns=_uuid", "--format=csv", "--data=bare", "--no-heading", "find"}) {
+			return "a3f5f4f9-cf12-48c4-935a-6f5f5e6f4fd8\n", nil
+		}
+		if len(args) == 4 && reflect.DeepEqual(args[:3], []string{"get", "load_balancer", "marmot-lb-lb-1"}) {
+			return "{\"10.0.0.10:80\"=\"10.0.0.21:80,10.0.0.22:80\"}", nil
+		}
+		if len(args) == 4 && reflect.DeepEqual(args[:3], []string{"get", "logical_switch", "marmot-net-net1"}) {
+			return "[a3f5f4f9-cf12-48c4-935a-6f5f5e6f4fd8]", nil
+		}
+		return "", nil
+	})
+
+	of := NewOVNFabric()
+	status, err := of.GetLoadBalancerStatus("lb-1", "marmot-net-net1")
+	if err != nil {
+		t.Fatalf("GetLoadBalancerStatus() failed: %v", err)
+	}
+	if !status.Exists {
+		t.Fatalf("Exists = false, want true")
+	}
+	if !status.AttachedToLogicalSwitch {
+		t.Fatalf("AttachedToLogicalSwitch = false, want true")
+	}
+	if status.VIPCount != 1 {
+		t.Fatalf("VIPCount = %d, want 1", status.VIPCount)
+	}
+	if status.OVNLoadBalancerName != "marmot-lb-lb-1" {
+		t.Fatalf("OVNLoadBalancerName = %q, want %q", status.OVNLoadBalancerName, "marmot-lb-lb-1")
+	}
+}
+
+func TestGetLoadBalancerStatus_NotFound(t *testing.T) {
+	withOVNLookPath(t, true, true)
+	withOVNRunner(t, func(args ...string) (string, error) {
+		if len(args) >= 6 && reflect.DeepEqual(args[:5], []string{"--columns=_uuid", "--format=csv", "--data=bare", "--no-heading", "find"}) {
+			return "\n", nil
+		}
+		return "", nil
+	})
+
+	of := NewOVNFabric()
+	status, err := of.GetLoadBalancerStatus("lb-1", "marmot-net-net1")
+	if err != nil {
+		t.Fatalf("GetLoadBalancerStatus() failed: %v", err)
+	}
+	if status.Exists {
+		t.Fatalf("Exists = true, want false")
+	}
+	if status.AttachedToLogicalSwitch {
+		t.Fatalf("AttachedToLogicalSwitch = true, want false")
+	}
+	if status.VIPCount != 0 {
+		t.Fatalf("VIPCount = %d, want 0", status.VIPCount)
+	}
+}
+
+func TestParseOVNMap(t *testing.T) {
+	raw := "{\"10.0.0.10:80\"=\"10.0.0.21:80,10.0.0.22:80\", \"10.0.0.10:443\"=\"10.0.0.21:443\"}"
+	parsed := parseOVNMap(raw)
+	if len(parsed) != 2 {
+		t.Fatalf("parseOVNMap len = %d, want 2; got=%v", len(parsed), parsed)
+	}
+	if parsed["10.0.0.10:80"] != "10.0.0.21:80,10.0.0.22:80" {
+		t.Fatalf("unexpected parsed value for 80: %v", parsed)
+	}
+}


### PR DESCRIPTION
## 概要
LoadBalancer 実装の最終ステップとして、controller 周辺のモックテストを追加し、主要な状態遷移と異常系の挙動を固定しました。  
既存の reconcile 実装に対して、運用で起こりやすい分岐をテストで担保することが目的です。

## 背景
直前までに以下は実装済みでした。

- API と DB への LoadBalancer 保存
- serverPorts 正規化
- backend 解決関数の切り出し
- networkfabric の OVN LoadBalancer 操作
- controller の reconcile 本体

本 PR では、これらを前提にモックテストを拡充し、回帰を防ぐ範囲を広げています。

## 変更内容
- LoadBalancer controller のモックテストを追加・拡張
- 既存の正常系に加えて、以下を新規カバー
  - auto モードで backend 0 台時に PROVISIONING を維持すること
  - manual モードで存在しない server 指定時に FAILED になること
  - DELETING 時に fabric 削除呼び出し、DNS 削除、DB エントリ削除が行われること
  - ACTIVE 時に config drift 検出で PROVISIONING に戻ること
- テスト用 mock fabric を拡張
  - ensure 側エラー注入
  - delete 側エラー注入
  - 今後の失敗系テストを追加しやすい形に整理

## テスト
実行コマンド:

- go test ./pkg/controller -run LoadBalancerController(PendingToActive|AutoNoBackendsStaysProvisioning|ManualMissingServerFails|DeletingCleansDNSAndEntry|ActiveDriftToProvisioning)
- go test ./cmd/marmotd ./api ./pkg/db ./pkg/marmotd ./pkg/controller ./pkg/networkfabric -run TestDoesNotExist

結果:

- すべて成功

## 影響範囲
- 主に controller テストコード
- 本番動作ロジックの仕様変更はなし
- CI での回帰検知範囲が拡大

## 目的達成
設計メモの実装順序にある「モックテストを追加」を達成し、LoadBalancer の最小実装に対する信頼性を強化しました。