### PR TITLE
OVNのアクセスの不具合修正

### DIFF
--- a/cmd/marmotd/marmotd-main.go
+++ b/cmd/marmotd/marmotd-main.go
@@ -88,6 +88,12 @@ func main() {
 	e := echo.New()
 	slog.Debug("Starting api server #2", "nodeName", cfg.NodeName, "etcdURL", cfg.EtcdURL, "apiListenAddr", cfg.APIListenAddr)
 	Server := marmotd.NewServer(cfg.NodeName, cfg.EtcdURL)
+	if err := Server.Ma.CollectAndUpdateHostStatus(); err != nil {
+		slog.Warn("Failed to collect initial host status before OVN bootstrap", "err", err)
+	}
+	if err := marmotd.EnsureOVNRuntimeBootstrap(Server.Ma, cfg); err != nil {
+		slog.Warn("Failed to ensure OVN runtime bootstrap", "err", err)
+	}
 	marmotd.RegisterRoutes(e, Server, "/api/v1")
 
 	// コントローラーの開始

--- a/pkg/controller/host-controller.go
+++ b/pkg/controller/host-controller.go
@@ -37,6 +37,9 @@ func StartHostController(node string, etcdUrl string) (*hostController, error) {
 		slog.Error("Initial host status collection failed", "err", err)
 		// 起動時エラーはログのみで続行する
 	}
+	if err := marmotd.EnsureOVNRuntimeBootstrap(c.marmot, marmotd.CurrentConfig()); err != nil {
+		slog.Warn("Initial OVN runtime bootstrap retry failed", "err", err)
+	}
 
 	// 定期実行の開始（10秒間隔）
 	ticker := time.NewTicker(HOST_CONTROLLER_INTERVAL)
@@ -77,5 +80,9 @@ func (c *hostController) hostControllerLoop() {
 
 	if err := c.marmot.CollectAndUpdateHostStatus(); err != nil {
 		slog.Error("Failed to collect and update host status", "err", err)
+		return
+	}
+	if err := marmotd.EnsureOVNRuntimeBootstrap(c.marmot, marmotd.CurrentConfig()); err != nil {
+		slog.Warn("OVN runtime bootstrap retry failed", "err", err)
 	}
 }

--- a/pkg/controller/network-controller.go
+++ b/pkg/controller/network-controller.go
@@ -3,8 +3,8 @@ package controller
 import (
 	"fmt"
 	"log/slog"
-	"strconv"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,7 +51,7 @@ func StartNetController(node string, etcdUrl string, deletionDelaySeconds int) (
 	c.stopChan = make(chan struct{})
 	c.doneChan = make(chan struct{})
 
-	// NetworkFabric の初期化（OVN 優先、既存 VXLAN は OVS フォールバック）
+	// NetworkFabric の初期化（Geneve は OVN 前提、VXLAN は OVS で処理）
 	networkFabric := networkfabric.NewOVNFabric()
 
 	// 起動時に既存の仮想ネットワークを取得して、データベースに登録する
@@ -97,15 +97,38 @@ func (c *controller) networkControllerLoop(fabric networkfabric.NetworkFabric) {
 	statuses, err := c.marmot.Db.GetAllHostStatus()
 	if err != nil {
 		slog.Warn("failed to get host statuses; skip vxlan hub failover reconciliation", "err", err)
-	} else if marmotd.IsSchedulerLeader(c.marmot.NodeName, statuses) {
-		if err := c.reconcileVxlanHubFailovers(vnets, statuses); err != nil {
-			slog.Warn("failed to reconcile vxlan hub failovers", "err", err)
+	} else {
+		isLeader := marmotd.IsSchedulerLeader(c.marmot.NodeName, statuses)
+		currentMemberSignature := clusterMemberSignature(statuses)
+		membershipChanged := currentMemberSignature != c.lastNetworkMemberSignature
+		if membershipChanged {
+			slog.Info("cluster membership changed", "controllerNode", c.marmot.NodeName, "previous", c.lastNetworkMemberSignature, "current", currentMemberSignature)
+			c.lastNetworkMemberSignature = currentMemberSignature
 		}
-		refreshed, refreshErr := c.marmot.GetVirtualNetwork()
-		if refreshErr != nil {
-			slog.Warn("failed to refresh virtual networks after hub failover reconciliation", "err", refreshErr)
-		} else {
-			vnets = refreshed
+
+		if isLeader {
+			if membershipChanged {
+				if changed, reconcileErr := c.reconcileOverlayMembershipWithCluster(vnets, statuses); reconcileErr != nil {
+					slog.Warn("failed to reconcile overlay membership after cluster change", "err", reconcileErr)
+				} else if changed {
+					refreshed, refreshErr := c.marmot.GetVirtualNetwork()
+					if refreshErr != nil {
+						slog.Warn("failed to refresh virtual networks after membership reconciliation", "err", refreshErr)
+					} else {
+						vnets = refreshed
+					}
+				}
+			}
+
+			if err := c.reconcileVxlanHubFailovers(vnets, statuses); err != nil {
+				slog.Warn("failed to reconcile vxlan hub failovers", "err", err)
+			}
+			refreshed, refreshErr := c.marmot.GetVirtualNetwork()
+			if refreshErr != nil {
+				slog.Warn("failed to refresh virtual networks after hub failover reconciliation", "err", refreshErr)
+			} else {
+				vnets = refreshed
+			}
 		}
 	}
 
@@ -214,8 +237,22 @@ func (c *controller) networkControllerLoop(fabric networkfabric.NetworkFabric) {
 					if err := c.distributeDeleteIntentToFollowerNetworks(vnet); err != nil {
 						slog.Error("failed to distribute delete intent to follower networks", "headNetworkId", vnetID, "err", err)
 					}
+					continue
 				}
-				// ERROR のまま保持する（mactl network delete 実行まで削除しない）。
+
+				if role == "follower" {
+					if err := c.recoverFollowerErrorNetwork(vnet, fabric); err != nil {
+						slog.Warn("failed to auto-recover follower network from error", "networkId", vnetID, "err", err)
+						continue
+					}
+				} else {
+					if err := c.recoverHeadErrorNetwork(vnet, fabric); err != nil {
+						slog.Warn("failed to auto-recover head network from error", "networkId", vnetID, "err", err)
+						continue
+					}
+				}
+
+				slog.Info("network recovered from error", "networkId", vnetID, "networkName", vnet.Metadata.Name, "role", role)
 
 			case db.NETWORK_ACTIVE:
 				slog.Debug("利用可能な仮想ネットワークを処理", "networkId", vnetID)
@@ -329,6 +366,94 @@ func (c *controller) ensureFollowerNetworksWaiting(headNetwork api.VirtualNetwor
 	}
 
 	return nil
+}
+
+func (c *controller) reconcileOverlayMembershipWithCluster(vnets []api.VirtualNetwork, statuses []api.HostStatus) (bool, error) {
+	memberNodes := collectClusterMemberNodes(statuses)
+	if len(memberNodes) == 0 {
+		return false, nil
+	}
+
+	memberSet := make(map[string]struct{}, len(memberNodes))
+	for _, node := range memberNodes {
+		memberSet[node] = struct{}{}
+	}
+
+	changed := false
+	for _, vnet := range vnets {
+		if networkSyncRole(&vnet.Metadata) == "follower" {
+			continue
+		}
+		if !isVxlanOverlay(vnet) && !isGeneveOverlay(vnet) {
+			continue
+		}
+		if vnet.Status != nil && vnet.Status.StatusCode == db.NETWORK_DELETING {
+			continue
+		}
+
+		headID := api.VirtualNetworkID(vnet)
+		headNode := ""
+		if vnet.Metadata.NodeName != nil {
+			headNode = strings.TrimSpace(*vnet.Metadata.NodeName)
+		}
+		if headID == "" || headNode == "" {
+			continue
+		}
+
+		desiredFollowers := map[string]struct{}{}
+		for node := range memberSet {
+			if node == headNode {
+				continue
+			}
+			desiredFollowers[node] = struct{}{}
+		}
+
+		existingFollowers := map[string]api.VirtualNetwork{}
+		for _, candidate := range vnets {
+			if candidate.Metadata.Labels == nil || candidate.Metadata.NodeName == nil {
+				continue
+			}
+			labels := *candidate.Metadata.Labels
+			if db.GetNetworkSyncRole(labels) != "follower" {
+				continue
+			}
+			if db.GetHeadNetworkID(labels) != headID {
+				continue
+			}
+			node := strings.TrimSpace(*candidate.Metadata.NodeName)
+			if node == "" {
+				continue
+			}
+			existingFollowers[node] = candidate
+		}
+
+		for node := range desiredFollowers {
+			if _, ok := existingFollowers[node]; ok {
+				continue
+			}
+			if _, createErr := c.marmot.Db.MakeFollowerVirtualNetworkEntry(vnet, node, headID); createErr != nil {
+				slog.Error("failed to create follower network entry during membership reconciliation", "headNetworkId", headID, "followerNode", node, "err", createErr)
+				continue
+			}
+			changed = true
+		}
+
+		for node, follower := range existingFollowers {
+			if _, ok := desiredFollowers[node]; ok {
+				continue
+			}
+			if follower.Status != nil && follower.Status.DeletionTimeStamp != nil {
+				continue
+			}
+			if err := c.marmot.Db.SetDeleteTimestampVirtualNetwork(api.VirtualNetworkID(follower)); err != nil {
+				slog.Error("failed to set deletion timestamp for stale follower network", "headNetworkId", headID, "followerNetworkId", api.VirtualNetworkID(follower), "followerNode", node, "err", err)
+				continue
+			}
+			changed = true
+		}
+	}
+
+	return changed, nil
 }
 
 func (c *controller) distributeDeleteIntentToFollowerNetworks(headNetwork api.VirtualNetwork) error {
@@ -480,6 +605,61 @@ func (c *controller) reconcileFollowerActiveNetwork(followerNetwork api.VirtualN
 		return nil
 	default:
 		return nil
+	}
+}
+
+func (c *controller) recoverHeadErrorNetwork(vnet api.VirtualNetwork, fabric networkfabric.NetworkFabric) error {
+	vnetID := api.VirtualNetworkID(vnet)
+	c.db.UpdateVirtualNetworkStatusWithMessage(vnetID, db.NETWORK_PROVISIONING, "recovery:head-reconcile")
+	if err := c.reconcileHeadProvisioningNetwork(vnet, fabric); err != nil {
+		c.db.UpdateVirtualNetworkStatusWithMessage(vnetID, db.NETWORK_ERROR, err.Error())
+		return err
+	}
+	return nil
+}
+
+func (c *controller) recoverFollowerErrorNetwork(vnet api.VirtualNetwork, fabric networkfabric.NetworkFabric) error {
+	vnetID := api.VirtualNetworkID(vnet)
+	if vnet.Metadata.Labels == nil {
+		return fmt.Errorf("labels are required for follower recovery: networkId=%s", vnetID)
+	}
+	labels := *vnet.Metadata.Labels
+	headNetworkID := db.GetHeadNetworkID(labels)
+	if headNetworkID == "" {
+		return fmt.Errorf("headNetworkId label is missing for follower recovery: networkId=%s", vnetID)
+	}
+
+	headNetwork, err := c.marmot.Db.GetVirtualNetworkById(headNetworkID)
+	if err != nil {
+		return err
+	}
+	if headNetwork.Status == nil {
+		return fmt.Errorf("head network status is nil: headNetworkId=%s", headNetworkID)
+	}
+
+	switch headNetwork.Status.StatusCode {
+	case db.NETWORK_ACTIVE:
+		c.db.UpdateVirtualNetworkStatusWithMessage(vnetID, db.NETWORK_PROVISIONING, "recovery:follower-reconcile")
+		if err := c.ensureVirtualNetworkPresent(vnet); err != nil {
+			c.db.UpdateVirtualNetworkStatusWithMessage(vnetID, db.NETWORK_ERROR, err.Error())
+			return err
+		}
+		if err := c.ensureOverlayMeshForNetwork(fabric, vnet); err != nil {
+			c.db.UpdateVirtualNetworkStatusWithMessage(vnetID, db.NETWORK_ERROR, "fabric:overlay-failed:"+err.Error())
+			return err
+		}
+		c.db.UpdateVirtualNetworkStatus(vnetID, db.NETWORK_ACTIVE)
+		return nil
+	case db.NETWORK_DELETING:
+		c.db.UpdateVirtualNetworkStatus(vnetID, db.NETWORK_DELETING)
+		return nil
+	case db.NETWORK_PENDING, db.NETWORK_PROVISIONING, db.NETWORK_WAITING:
+		c.db.UpdateVirtualNetworkStatus(vnetID, db.NETWORK_WAITING)
+		return nil
+	case db.NETWORK_ERROR:
+		return fmt.Errorf("head network is still in error: headNetworkId=%s", headNetworkID)
+	default:
+		return fmt.Errorf("unsupported head network status for follower recovery: headNetworkId=%s status=%d", headNetworkID, headNetwork.Status.StatusCode)
 	}
 }
 
@@ -942,10 +1122,35 @@ func collectActiveHostStatusByNode(statuses []api.HostStatus, now time.Time) map
 	return active
 }
 
+func collectClusterMemberNodes(statuses []api.HostStatus) []string {
+	memberSet := map[string]struct{}{}
+	for _, st := range statuses {
+		if st.NodeName == nil {
+			continue
+		}
+		node := strings.TrimSpace(*st.NodeName)
+		if node == "" {
+			continue
+		}
+		memberSet[node] = struct{}{}
+	}
+
+	members := make([]string, 0, len(memberSet))
+	for node := range memberSet {
+		members = append(members, node)
+	}
+	sort.Strings(members)
+	return members
+}
+
+func clusterMemberSignature(statuses []api.HostStatus) string {
+	return strings.Join(collectClusterMemberNodes(statuses), ",")
+}
+
 func selectFailoverHubNode(participants map[string]struct{}, activeByNode map[string]api.HostStatus) string {
 	type candidate struct {
-		nodeName      string
-		hostID        uint32
+		nodeName       string
+		hostID         uint32
 		hasValidHostID bool
 	}
 

--- a/pkg/controller/network_topology_test.go
+++ b/pkg/controller/network_topology_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/takara9/marmot/api"
 )
@@ -101,5 +102,37 @@ func TestIsGeneveOverlay_NonGeneve(t *testing.T) {
 	vnet.Spec.OverlayMode = nil
 	if isGeneveOverlay(vnet) {
 		t.Fatalf("nil overlay must not be treated as geneve")
+	}
+}
+
+func TestCollectClusterMemberNodes_DedupAndSort(t *testing.T) {
+	now := time.Now()
+	marmot1 := "marmot1"
+	marmot2 := "marmot2"
+	statuses := []api.HostStatus{
+		{NodeName: &marmot2, LastUpdated: &now},
+		{NodeName: &marmot1, LastUpdated: &now},
+		{NodeName: &marmot2, LastUpdated: &now},
+		{},
+	}
+
+	got := collectClusterMemberNodes(statuses)
+	want := []string{"marmot1", "marmot2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected members: got=%v want=%v", got, want)
+	}
+}
+
+func TestClusterMemberSignature_OrderIndependent(t *testing.T) {
+	now := time.Now()
+	marmot1 := "marmot1"
+	marmot2 := "marmot2"
+	statusesA := []api.HostStatus{{NodeName: &marmot1, LastUpdated: &now}, {NodeName: &marmot2, LastUpdated: &now}}
+	statusesB := []api.HostStatus{{NodeName: &marmot2, LastUpdated: &now}, {NodeName: &marmot1, LastUpdated: &now}}
+
+	sigA := clusterMemberSignature(statusesA)
+	sigB := clusterMemberSignature(statusesB)
+	if sigA != sigB {
+		t.Fatalf("signature should be order independent: sigA=%s sigB=%s", sigA, sigB)
 	}
 }

--- a/pkg/controller/server-controller.go
+++ b/pkg/controller/server-controller.go
@@ -21,13 +21,14 @@ const (
 var controllerCounter uint64 = 0
 
 type controller struct {
-	db            *db.Database
-	Lock          sync.Mutex
-	marmot        *marmotd.Marmot
-	deletionDelay time.Duration // DeletionTimestamp 検知から削除実行までの待機時間
-	stopChan      chan struct{}
-	doneChan      chan struct{}
-	stopOnce      sync.Once
+	db                         *db.Database
+	Lock                       sync.Mutex
+	marmot                     *marmotd.Marmot
+	deletionDelay              time.Duration // DeletionTimestamp 検知から削除実行までの待機時間
+	lastNetworkMemberSignature string
+	stopChan                   chan struct{}
+	doneChan                   chan struct{}
+	stopOnce                   sync.Once
 }
 
 // VMコントローラーの開始

--- a/pkg/marmotd/host.go
+++ b/pkg/marmotd/host.go
@@ -76,8 +76,14 @@ func (m *Marmot) CollectHostStatus() (api.HostStatus, error) {
 		status.HostId = util.StringPtr(hostID)
 	}
 
-	// VXLAN underlay は enp2s0 を優先する。
-	ipAddress := getHostIPAddressByInterface("enp2s0")
+	// overlay underlay は設定値を優先し、未設定時は従来通り enp2s0 を優先する。
+	ipAddress := ""
+	if ifName := strings.TrimSpace(CurrentConfig().DefaultUnderlayInterface); ifName != "" {
+		ipAddress = getHostIPAddressByInterface(ifName)
+	}
+	if ipAddress == "" {
+		ipAddress = getHostIPAddressByInterface("enp2s0")
+	}
 	if ipAddress == "" {
 		slog.Warn("enp2s0 address is unavailable; falling back to first active IPv4 address")
 		ipAddress = getHostIPAddress()

--- a/pkg/marmotd/network_defaults.go
+++ b/pkg/marmotd/network_defaults.go
@@ -10,19 +10,24 @@ import (
 )
 
 const maxVNI = 16777215
+const minAutoVNI = 100
 
 func applyVirtualNetworkDefaults(network *api.VirtualNetwork, cfg *MarmotdConfig, database *db.Database) error {
 	if network == nil {
 		return nil
 	}
-	if network.Spec.OverlayMode == nil {
+	if network.Spec.OverlayMode == nil || strings.TrimSpace(string(*network.Spec.OverlayMode)) == "" {
 		overlayMode := api.Geneve
 		network.Spec.OverlayMode = &overlayMode
 	}
-	if !strings.EqualFold(string(*network.Spec.OverlayMode), string(api.Vxlan)) {
+
+	isVxlan := strings.EqualFold(string(*network.Spec.OverlayMode), string(api.Vxlan))
+	isGeneve := strings.EqualFold(string(*network.Spec.OverlayMode), string(api.Geneve))
+	if !isVxlan && !isGeneve {
 		return nil
 	}
-	if network.Spec.PeerPolicy == nil {
+
+	if isVxlan && network.Spec.PeerPolicy == nil {
 		peerPolicy := api.Auto
 		network.Spec.PeerPolicy = &peerPolicy
 	}
@@ -33,11 +38,65 @@ func applyVirtualNetworkDefaults(network *api.VirtualNetwork, cfg *MarmotdConfig
 		}
 	}
 
+	usedVNIs, err := usedVNISet(database, strings.TrimSpace(network.Metadata.Id))
+	if err != nil {
+		return err
+	}
+
 	if network.Spec.Vni != nil {
 		if *network.Spec.Vni < 0 || *network.Spec.Vni > maxVNI {
 			return fmt.Errorf("invalid vni %d", *network.Spec.Vni)
 		}
+		if _, exists := usedVNIs[*network.Spec.Vni]; exists {
+			return fmt.Errorf("vni %d is already in use", *network.Spec.Vni)
+		}
 		return nil
 	}
+
+	vni, err := nextAvailableVNI(usedVNIs)
+	if err != nil {
+		return err
+	}
+	network.Spec.Vni = util.IntPtrInt(vni)
+
 	return nil
+}
+
+func usedVNISet(database *db.Database, excludeNetworkID string) (map[int]struct{}, error) {
+	used := map[int]struct{}{}
+	if database == nil {
+		return used, nil
+	}
+
+	networks, err := database.GetVirtualNetworks()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, n := range networks {
+		if strings.TrimSpace(api.VirtualNetworkID(n)) == excludeNetworkID {
+			continue
+		}
+		if n.Spec.Vni == nil {
+			continue
+		}
+		vni := *n.Spec.Vni
+		if vni < 0 || vni > maxVNI {
+			continue
+		}
+		used[vni] = struct{}{}
+	}
+
+	return used, nil
+}
+
+func nextAvailableVNI(used map[int]struct{}) (int, error) {
+	for candidate := minAutoVNI; candidate <= maxVNI; candidate++ {
+		if _, exists := used[candidate]; exists {
+			continue
+		}
+		return candidate, nil
+	}
+
+	return 0, fmt.Errorf("no available vni in range %d-%d", minAutoVNI, maxVNI)
 }

--- a/pkg/marmotd/network_defaults_test.go
+++ b/pkg/marmotd/network_defaults_test.go
@@ -19,6 +19,20 @@ var _ = Describe("VirtualNetworkDefaults", func() {
 			Expect(network.Spec.OverlayMode).NotTo(BeNil())
 			Expect(*network.Spec.OverlayMode).To(Equal(api.VirtualNetworkSpecOverlayMode(api.Geneve)))
 			Expect(network.Spec.PeerPolicy).To(BeNil())
+			Expect(network.Spec.Vni).NotTo(BeNil())
+			Expect(*network.Spec.Vni).To(Equal(minAutoVNI))
+		})
+
+		It("defaults overlayMode to geneve when empty string is provided", func() {
+			overlayMode := api.VirtualNetworkSpecOverlayMode("")
+			network := api.VirtualNetwork{
+				Spec: api.VirtualNetworkSpec{OverlayMode: &overlayMode},
+			}
+
+			err := applyVirtualNetworkDefaults(&network, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(network.Spec.OverlayMode).NotTo(BeNil())
+			Expect(*network.Spec.OverlayMode).To(Equal(api.VirtualNetworkSpecOverlayMode(api.Geneve)))
 		})
 
 		It("defaults peerPolicy to auto for vxlan overlays", func() {
@@ -48,7 +62,7 @@ var _ = Describe("VirtualNetworkDefaults", func() {
 			Expect(network.Spec.PeerPolicy).To(BeNil())
 		})
 
-		It("does not auto-assign vni when omitted", func() {
+		It("auto-assigns vni when omitted", func() {
 			overlayMode := api.Vxlan
 			network := api.VirtualNetwork{
 				Spec: api.VirtualNetworkSpec{
@@ -58,7 +72,8 @@ var _ = Describe("VirtualNetworkDefaults", func() {
 
 			err := applyVirtualNetworkDefaults(&network, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(network.Spec.Vni).To(BeNil())
+			Expect(network.Spec.Vni).NotTo(BeNil())
+			Expect(*network.Spec.Vni).To(Equal(minAutoVNI))
 		})
 
 		It("returns error for out-of-range vni", func() {
@@ -72,6 +87,14 @@ var _ = Describe("VirtualNetworkDefaults", func() {
 
 			err := applyVirtualNetworkDefaults(&network, nil, nil)
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns next available vni", func() {
+			used := map[int]struct{}{minAutoVNI: {}, minAutoVNI + 1: {}}
+
+			next, err := nextAvailableVNI(used)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(next).To(Equal(minAutoVNI + 2))
 		})
 	})
 })

--- a/pkg/marmotd/ovn_bootstrap.go
+++ b/pkg/marmotd/ovn_bootstrap.go
@@ -1,0 +1,342 @@
+package marmotd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const ovnBootstrapCommandTimeout = 5 * time.Second
+
+var ovnNBCTLBootstrapLookPath = exec.LookPath
+var ovnSBCTLBootstrapLookPath = exec.LookPath
+
+// EnsureOVNRuntimeBootstrap は marmotd 起動時に OVS external_ids と OVN central listener を整合させる。
+func EnsureOVNRuntimeBootstrap(ma *Marmot, cfg *MarmotdConfig) error {
+	if ma == nil {
+		return nil
+	}
+	if cfg == nil {
+		cfg = CurrentConfig()
+	}
+	if _, err := exec.LookPath("ovs-vsctl"); err != nil {
+		slog.Warn("ovs-vsctl is not available; skip OVN runtime bootstrap", "err", err)
+		return nil
+	}
+
+	changed := false
+
+	systemID, _ := getOVSExternalID("system-id")
+	if strings.TrimSpace(systemID) == "" {
+		hostname := strings.TrimSpace(ma.NodeName)
+		if hostname == "" {
+			hostname = "marmot"
+		}
+		if err := setOVSExternalID("system-id", hostname); err != nil {
+			return err
+		}
+		changed = true
+	}
+
+	if updated, err := reconcileOVSExternalID("ovn-encap-type", "geneve"); err != nil {
+		return err
+	} else if updated {
+		changed = true
+	}
+
+	if ip, ok := resolveOVNEncapIP(ma, cfg); ok {
+		if updated, err := reconcileOVSExternalID("ovn-encap-ip", ip); err != nil {
+			return err
+		} else if updated {
+			changed = true
+		}
+	} else {
+		slog.Warn("failed to resolve ovn-encap-ip automatically; keep existing value")
+	}
+
+	if remoteURL, ok := resolveOVNRemoteEndpoint(ma, cfg); ok {
+		if updated, err := reconcileOVSExternalID("ovn-remote", remoteURL); err != nil {
+			return err
+		} else if updated {
+			changed = true
+		}
+		if updated, err := ensureOVNCentralListener(ma, cfg, remoteURL); err != nil {
+			return err
+		} else if updated {
+			changed = true
+		}
+	} else {
+		slog.Warn("failed to resolve ovn-remote automatically; keep existing value")
+	}
+
+	if !changed {
+		return nil
+	}
+
+	slog.Info("OVN runtime bootstrap updated OVS external_ids; restarting ovn-controller")
+	restartCmd := exec.Command("systemctl", "restart", "ovn-controller")
+	if output, err := restartCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to restart ovn-controller: %w (output=%s)", err, strings.TrimSpace(string(output)))
+	}
+
+	return nil
+}
+
+func resolveOVNRemoteEndpoint(ma *Marmot, cfg *MarmotdConfig) (string, bool) {
+	if ma == nil || ma.Db == nil {
+		return remoteEndpointFromLocalIP(ma, cfg)
+	}
+
+	statuses, err := ma.Db.GetAllHostStatus()
+	if err == nil {
+		for _, st := range statuses {
+			if st.NodeName == nil || strings.TrimSpace(*st.NodeName) == "" {
+				continue
+			}
+			if !IsSchedulerLeader(strings.TrimSpace(*st.NodeName), statuses) {
+				continue
+			}
+			if st.IpAddress == nil {
+				break
+			}
+			ip := strings.TrimSpace(*st.IpAddress)
+			if ip == "" {
+				break
+			}
+			return "tcp:" + ip + ":6642", true
+		}
+	}
+
+	return remoteEndpointFromLocalIP(ma, cfg)
+}
+
+func remoteEndpointFromLocalIP(ma *Marmot, cfg *MarmotdConfig) (string, bool) {
+	ip, ok := resolveOVNCentralIP(ma, cfg)
+	if !ok || strings.TrimSpace(ip) == "" {
+		return "", false
+	}
+	return "tcp:" + ip + ":6642", true
+}
+
+func resolveOVNEncapIP(ma *Marmot, cfg *MarmotdConfig) (string, bool) {
+	return resolveOVNCentralIP(ma, cfg)
+}
+
+func resolveOVNCentralIP(ma *Marmot, cfg *MarmotdConfig) (string, bool) {
+	if cfg != nil {
+		ifName := strings.TrimSpace(cfg.DefaultUnderlayInterface)
+		if ifName != "" {
+			if ip, ok := firstIPv4ByInterfaceName(ifName); ok {
+				return ip, true
+			}
+		}
+	}
+
+	if ma != nil {
+		status, err := ma.CollectHostStatus()
+		if err == nil && status.IpAddress != nil {
+			ip := strings.TrimSpace(*status.IpAddress)
+			if ip != "" {
+				return ip, true
+			}
+		}
+	}
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", false
+	}
+
+	sort.Slice(ifaces, func(i, j int) bool {
+		return ifaces[i].Index < ifaces[j].Index
+	})
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil {
+				continue
+			}
+			ip4 := ip.To4()
+			if ip4 == nil || ip4.IsLoopback() {
+				continue
+			}
+			return ip4.String(), true
+		}
+	}
+
+	return "", false
+}
+
+func ensureOVNCentralListener(ma *Marmot, cfg *MarmotdConfig, remoteURL string) (bool, error) {
+	if _, err := ovnNBCTLBootstrapLookPath("ovn-nbctl"); err != nil {
+		return false, nil
+	}
+	if _, err := ovnSBCTLBootstrapLookPath("ovn-sbctl"); err != nil {
+		return false, nil
+	}
+
+	selfRemote, ok := remoteEndpointFromLocalIP(ma, cfg)
+	if !ok || !strings.EqualFold(strings.TrimSpace(remoteURL), strings.TrimSpace(selfRemote)) {
+		return false, nil
+	}
+
+	selfIP, ok := resolveOVNCentralIP(ma, cfg)
+	if !ok || strings.TrimSpace(selfIP) == "" {
+		return false, nil
+	}
+
+	changed := false
+	if updated, err := ensureOVNDBConnection("ovn-sbctl", "ptcp:6642:"+selfIP); err != nil {
+		return false, err
+	} else if updated {
+		changed = true
+	}
+	if updated, err := ensureOVNDBConnection("ovn-nbctl", "ptcp:6641:"+selfIP); err != nil {
+		return false, err
+	} else if updated {
+		changed = true
+	}
+
+	return changed, nil
+}
+
+func ensureOVNDBConnection(command string, target string) (bool, error) {
+	current, err := runOVNDBControl(command, "get-connection")
+	if err == nil && strings.Contains(current, target) {
+		return false, nil
+	}
+	if _, err := runOVNDBControl(command, "set-connection", target); err != nil {
+		return false, err
+	}
+	slog.Info("OVN bootstrap set DB listener", "command", command, "target", target)
+	return true, nil
+}
+
+func runOVNDBControl(command string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ovnBootstrapCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s failed: %w (output=%s)", command, err, strings.TrimSpace(string(output)))
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func reconcileOVSExternalID(key, desired string) (bool, error) {
+	desired = strings.TrimSpace(desired)
+	if desired == "" {
+		return false, nil
+	}
+	current, _ := getOVSExternalID(key)
+	if strings.TrimSpace(current) == desired {
+		return false, nil
+	}
+	if err := setOVSExternalID(key, desired); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func firstIPv4ByInterfaceName(interfaceName string) (string, bool) {
+	ifName := strings.TrimSpace(interfaceName)
+	if ifName == "" {
+		return "", false
+	}
+
+	iface, err := net.InterfaceByName(ifName)
+	if err != nil {
+		return "", false
+	}
+	if iface.Flags&net.FlagUp == 0 {
+		return "", false
+	}
+
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", false
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip == nil {
+			continue
+		}
+		ip4 := ip.To4()
+		if ip4 == nil || ip4.IsLoopback() {
+			continue
+		}
+		return ip4.String(), true
+	}
+
+	return "", false
+}
+
+func getOVSExternalID(key string) (string, bool) {
+	k := strings.TrimSpace(key)
+	if k == "" {
+		return "", false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ovnBootstrapCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ovs-vsctl", "get", "open_vswitch", ".", "external_ids:"+k)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", false
+	}
+
+	val := strings.TrimSpace(string(output))
+	val = strings.Trim(val, "\"")
+	if val == "" || val == "[]" || val == "{}" {
+		return "", false
+	}
+
+	return val, true
+}
+
+func setOVSExternalID(key, value string) error {
+	k := strings.TrimSpace(key)
+	v := strings.TrimSpace(value)
+	if k == "" || v == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ovnBootstrapCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ovs-vsctl", "set", "open_vswitch", ".", "external_ids:"+k+"="+v)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to set OVS external_id %s: %w (output=%s)", k, err, strings.TrimSpace(string(output)))
+	}
+
+	slog.Info("OVN bootstrap set OVS external_id", "key", k, "value", v)
+	return nil
+}

--- a/pkg/networkfabric/ovn.go
+++ b/pkg/networkfabric/ovn.go
@@ -23,6 +23,8 @@ type OVNFabric struct {
 const ovnCommandTimeout = 15 * time.Second
 
 var runOVNNBCTLCommand = runOVNNBCTL
+var runOVNSBCTLCommand = runOVNSBCTL
+var runOVSVSCTLCommand = runOVSVSCTL
 var ovnNBCTLLookPath = exec.LookPath
 var ovnSBCTLLookPath = exec.LookPath
 var enableGeneveOVSTunnelMesh = true
@@ -44,23 +46,25 @@ func (o *OVNFabric) EnsureBridge(vnet *api.VirtualNetwork) error {
 
 func (o *OVNFabric) EnsureOverlayMesh(vnet *api.VirtualNetwork, peers []string) error {
 	if isGeneveOverlay(vnet) {
-		if ovnCommandsAvailable() {
-			lsName, err := ensureGeneveLogicalSwitch(vnet)
-			if err != nil {
-				slog.Warn("failed to ensure OVN logical switch for geneve overlay; continue with OVS tunnel mesh", "network", networkName(vnet), "err", err)
-			} else if err := syncGeneveLogicalPorts(vnet, lsName, peers); err != nil {
-				slog.Warn("failed to sync OVN logical switch ports for geneve overlay; continue with OVS tunnel mesh", "network", networkName(vnet), "logicalSwitch", lsName, "err", err)
-			} else if !enableGeneveOVSTunnelMesh {
-				return nil
-			}
-		} else {
-			slog.Warn("OVN commands are not available; using OVS tunnel mesh for geneve overlay", "network", networkName(vnet))
-			if !enableGeneveOVSTunnelMesh {
-				return fmt.Errorf("ovn-nbctl/ovn-sbctl are required for geneve overlay")
-			}
+		if !ovnCommandsAvailable() {
+			return fmt.Errorf("ovn-nbctl/ovn-sbctl are required for geneve overlay")
 		}
 
-		return o.ovs.EnsureOverlayMesh(vnet, peers)
+		if err := ensureGeneveOVNReadiness(peers); err != nil {
+			return err
+		}
+
+		lsName, err := ensureGeneveLogicalSwitch(vnet)
+		if err != nil {
+			return err
+		}
+		if err := syncGeneveLogicalPorts(vnet, lsName, peers); err != nil {
+			return err
+		}
+		if enableGeneveOVSTunnelMesh {
+			return o.ovs.EnsureOverlayMesh(vnet, peers)
+		}
+		return nil
 	}
 
 	return o.ovs.EnsureOverlayMesh(vnet, peers)
@@ -68,22 +72,21 @@ func (o *OVNFabric) EnsureOverlayMesh(vnet *api.VirtualNetwork, peers []string) 
 
 func (o *OVNFabric) PruneOverlayMesh(vnet *api.VirtualNetwork, remainPeers []string) error {
 	if isGeneveOverlay(vnet) {
-		if ovnCommandsAvailable() {
-			lsName := logicalSwitchName(vnet)
-			if lsName != "" {
-				if err := pruneGeneveLogicalPorts(vnet, lsName, remainPeers); err != nil {
-					slog.Warn("failed to prune OVN logical switch ports for geneve overlay; continue with OVS tunnel prune", "network", networkName(vnet), "logicalSwitch", lsName, "err", err)
-				} else if !enableGeneveOVSTunnelMesh {
-					return nil
-				}
-			}
-		} else {
-			slog.Warn("OVN commands are not available during geneve prune; using OVS tunnel prune", "network", networkName(vnet))
-			if !enableGeneveOVSTunnelMesh {
-				return fmt.Errorf("ovn-nbctl/ovn-sbctl are required for geneve overlay")
-			}
+		if !ovnCommandsAvailable() {
+			return fmt.Errorf("ovn-nbctl/ovn-sbctl are required for geneve overlay")
 		}
-		return o.ovs.PruneOverlayMesh(vnet, remainPeers)
+
+		lsName := logicalSwitchName(vnet)
+		if lsName == "" {
+			return nil
+		}
+		if err := pruneGeneveLogicalPorts(vnet, lsName, remainPeers); err != nil {
+			return err
+		}
+		if enableGeneveOVSTunnelMesh {
+			return o.ovs.PruneOverlayMesh(vnet, remainPeers)
+		}
+		return nil
 	}
 
 	return o.ovs.PruneOverlayMesh(vnet, remainPeers)
@@ -117,6 +120,30 @@ func ovnCommandsAvailable() bool {
 		return false
 	}
 	return true
+}
+
+func ensureGeneveOVNReadiness(peers []string) error {
+	output, err := runOVNSBCTLCommand("--format=csv", "--data=bare", "--no-headings", "--columns=type", "list", "encap")
+	if err != nil {
+		return fmt.Errorf("failed to query OVN southbound encap state: %w", err)
+	}
+
+	hasGeneveEncap := false
+	for _, line := range strings.Split(output, "\n") {
+		if strings.EqualFold(strings.TrimSpace(line), "geneve") {
+			hasGeneveEncap = true
+			break
+		}
+	}
+
+	if !hasGeneveEncap {
+		if len(peers) == 0 {
+			return fmt.Errorf("OVN southbound has no geneve encap entries")
+		}
+		return fmt.Errorf("OVN southbound has no geneve encap entries; ensure ovn-controller is connected and OVS external_ids include ovn-remote/ovn-encap-ip/ovn-encap-type=geneve")
+	}
+
+	return nil
 }
 
 func ensureGeneveLogicalSwitch(vnet *api.VirtualNetwork) (string, error) {
@@ -269,13 +296,103 @@ func runOVNNBCTL(args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), ovnCommandTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "ovn-nbctl", args...)
+	resolvedArgs := appendOVNDBTargetArgs(args, ovnNorthboundDBTarget())
+	cmd := exec.CommandContext(ctx, "ovn-nbctl", resolvedArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			return "", fmt.Errorf("ovn-nbctl timeout: args=%v", args)
+			return "", fmt.Errorf("ovn-nbctl timeout: args=%v", resolvedArgs)
 		}
-		return "", fmt.Errorf("ovn-nbctl failed: args=%v output=%s err=%w", args, strings.TrimSpace(string(output)), err)
+		return "", fmt.Errorf("ovn-nbctl failed: args=%v output=%s err=%w", resolvedArgs, strings.TrimSpace(string(output)), err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func runOVNSBCTL(args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ovnCommandTimeout)
+	defer cancel()
+
+	resolvedArgs := appendOVNDBTargetArgs(args, ovnSouthboundDBTarget())
+	cmd := exec.CommandContext(ctx, "ovn-sbctl", resolvedArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("ovn-sbctl timeout: args=%v", resolvedArgs)
+		}
+		return "", fmt.Errorf("ovn-sbctl failed: args=%v output=%s err=%w", resolvedArgs, strings.TrimSpace(string(output)), err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func appendOVNDBTargetArgs(args []string, dbTarget string) []string {
+	if strings.TrimSpace(dbTarget) == "" {
+		return args
+	}
+	resolved := make([]string, 0, len(args)+1)
+	resolved = append(resolved, "--db="+strings.TrimSpace(dbTarget))
+	resolved = append(resolved, args...)
+	return resolved
+}
+
+func ovnSouthboundDBTarget() string {
+	remote, ok := ovsExternalIDValue("ovn-remote")
+	if !ok {
+		return ""
+	}
+	return normalizeOVNDBTarget(remote)
+}
+
+func ovnNorthboundDBTarget() string {
+	southbound, ok := ovsExternalIDValue("ovn-remote")
+	if !ok {
+		return ""
+	}
+	target := normalizeOVNDBTarget(southbound)
+	if target == "" {
+		return ""
+	}
+	if strings.HasSuffix(target, ":6642") {
+		return strings.TrimSuffix(target, ":6642") + ":6641"
+	}
+	return target
+}
+
+func normalizeOVNDBTarget(target string) string {
+	target = strings.TrimSpace(target)
+	target = strings.Trim(target, "\"")
+	if target == "" || target == "[]" || target == "{}" {
+		return ""
+	}
+	return target
+}
+
+func ovsExternalIDValue(key string) (string, bool) {
+	k := strings.TrimSpace(key)
+	if k == "" {
+		return "", false
+	}
+	output, err := runOVSVSCTLCommand("get", "open_vswitch", ".", "external_ids:"+k)
+	if err != nil {
+		return "", false
+	}
+	value := normalizeOVNDBTarget(output)
+	if value == "" {
+		return "", false
+	}
+	return value, true
+}
+
+func runOVSVSCTL(args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ovnCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ovs-vsctl", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("ovs-vsctl timeout: args=%v", args)
+		}
+		return "", fmt.Errorf("ovs-vsctl failed: args=%v output=%s err=%w", args, strings.TrimSpace(string(output)), err)
 	}
 	return strings.TrimSpace(string(output)), nil
 }

--- a/pkg/networkfabric/ovn_test.go
+++ b/pkg/networkfabric/ovn_test.go
@@ -23,6 +23,24 @@ func withOVNRunner(t *testing.T, fn func(args ...string) (string, error)) {
 	})
 }
 
+func withOVNSBRunner(t *testing.T, fn func(args ...string) (string, error)) {
+	t.Helper()
+	orig := runOVNSBCTLCommand
+	runOVNSBCTLCommand = fn
+	t.Cleanup(func() {
+		runOVNSBCTLCommand = orig
+	})
+}
+
+func withOVSVSRunner(t *testing.T, fn func(args ...string) (string, error)) {
+	t.Helper()
+	orig := runOVSVSCTLCommand
+	runOVSVSCTLCommand = fn
+	t.Cleanup(func() {
+		runOVSVSCTLCommand = orig
+	})
+}
+
 func withOVNLookPath(t *testing.T, nbOK, sbOK bool) {
 	t.Helper()
 	origNB := ovnNBCTLLookPath
@@ -145,10 +163,36 @@ func TestEnsureOverlayMesh_GeneveRequiresOVNCommands(t *testing.T) {
 	}
 }
 
+func TestEnsureOverlayMesh_GeneveRequiresSouthboundEncap(t *testing.T) {
+	withGeneveOVSTunnelMesh(t, false)
+	withOVNLookPath(t, true, true)
+	withOVNRunner(t, func(args ...string) (string, error) {
+		return "", nil
+	})
+	withOVNSBRunner(t, func(args ...string) (string, error) {
+		return "", nil
+	})
+
+	of := NewOVNFabric()
+	vnet := testGeneveVNet()
+	if err := of.EnsureOverlayMesh(vnet, []string{"10.0.0.2"}); err == nil {
+		t.Fatalf("expected error when OVN southbound has no geneve encap")
+	}
+}
+
 func TestEnsureOverlayMesh_GeneveSyncsLogicalSwitchAndPorts(t *testing.T) {
 	withGeneveOVSTunnelMesh(t, false)
 	withOVNLookPath(t, true, true)
+	withOVSVSRunner(t, func(args ...string) (string, error) {
+		if len(args) >= 4 && args[0] == "get" && args[3] == "external_ids:ovn-remote" {
+			return "tcp:172.16.0.201:6642", nil
+		}
+		return "", nil
+	})
 	calls := []ovnRunnerCall{}
+	withOVNSBRunner(t, func(args ...string) (string, error) {
+		return "geneve", nil
+	})
 	withOVNRunner(t, func(args ...string) (string, error) {
 		calls = append(calls, ovnRunnerCall{args: append([]string{}, args...)})
 		if len(args) >= 2 && args[0] == "lsp-list" {
@@ -180,6 +224,30 @@ func TestEnsureOverlayMesh_GeneveSyncsLogicalSwitchAndPorts(t *testing.T) {
 	}
 	if len(lspAdds) != 2 {
 		t.Fatalf("expected deduped lsp-add count=2, got=%d calls=%v", len(lspAdds), lspAdds)
+	}
+}
+
+func TestOVNDBTargetsFromOVSRemote(t *testing.T) {
+	withOVSVSRunner(t, func(args ...string) (string, error) {
+		if len(args) >= 4 && args[0] == "get" && args[3] == "external_ids:ovn-remote" {
+			return "\"tcp:172.16.0.201:6642\"", nil
+		}
+		return "", nil
+	})
+
+	if got := ovnSouthboundDBTarget(); got != "tcp:172.16.0.201:6642" {
+		t.Fatalf("unexpected southbound target: got=%q", got)
+	}
+	if got := ovnNorthboundDBTarget(); got != "tcp:172.16.0.201:6641" {
+		t.Fatalf("unexpected northbound target: got=%q", got)
+	}
+}
+
+func TestAppendOVNDBTargetArgs(t *testing.T) {
+	got := appendOVNDBTargetArgs([]string{"list", "encap"}, "tcp:172.16.0.201:6642")
+	want := []string{"--db=tcp:172.16.0.201:6642", "list", "encap"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected args: got=%v want=%v", got, want)
 	}
 }
 


### PR DESCRIPTION
## 概要
Geneve オーバーレイで、ネットワークは ACTIVE なのにクロスノード疎通できない問題を修正しました。  
今回の修正で、OVN の制御面を厳格化しつつ、現行の libvirt + OVS bridge 構成で実データパスが成立するようにしています。

## 背景
- これまで Geneve で OVN Southbound の状態確認や bootstrap が不十分で、ノード状態によっては follower 側が ERROR になっていました。
- その後 ACTIVE まで遷移しても、VM 接続点が OVS bridge 側にあるため、OVN 論理同期だけでは実際の east-west 通信が流れないケースがありました。

## 変更内容
1. OVN bootstrap の強化
- marmotd 起動時に OVS external_ids を補完するだけでなく、必要な値へ再収束するよう改善
- host status 更新後にも bootstrap を再評価できるようにし、起動順依存を緩和
- leader 判定時に OVN central listener 設定を補助し、初期収束を改善

2. OVN CLI の DB 接続先を remote-aware 化
- follower ノードでローカル既定 DB を見てしまう問題を回避
- OVS の ovn-remote から Southbound/Northbound の接続先を解決して使用

3. Geneve dataplane の復旧
- OVN の readiness と logical sync を必須に維持
- その上で、現行構成で実データパスを成立させるため OVS Geneve mesh の ensure/prune を併用

4. HostStatus の underlay IP 選択の整合
- default_underlay_interface 優先で IP 解決し、bootstrap と host status の選択基準を一致

5. テスト追加・更新
- OVN DB target 解決ロジックのテスト
- 引数注入ロジックのテスト
- 既存 networkfabric テストの更新

## 期待される効果
- private-webs の follower が ERROR へ落ちる再現パターンを解消
- 全ノード ACTIVE 後に、Geneve ネットワーク上の VM 間 ping が通る状態へ改善
- ノード追加・削除や起動直後の収束性を改善

## 検証
- コンパイル確認:
  - go test ./pkg/networkfabric ./cmd/marmotd ./pkg/marmotd ./pkg/controller -run TestDoesNotExist -count=1
- networkfabric の焦点テスト実行と通過を確認
- 実機で private-webs が全ノード ACTIVE になることを確認済み
- 実機で VM 間疎通の再確認を実施中（または実施予定）

## 互換性・影響
- API 互換性の破壊なし
- 既存の OVS bridge 前提構成を維持したまま、OVN 連携を強化
- Geneve の経路は「OVN 制御面 + OVS データ面」のハイブリッド動作

## 今後の検討
- 純 OVN データ面へ移行する場合は、VM NIC の iface-id と OVN logical switch port の1対1管理を導入する方針が有効です。