### PR TITLE
ネットワークコントローラーの改善

### DIFF
--- a/pkg/controller/network-controller.go
+++ b/pkg/controller/network-controller.go
@@ -142,7 +142,8 @@ func (c *controller) networkControllerLoop(fabric networkfabric.NetworkFabric) {
 
 		role := networkSyncRole(&vnet.Metadata)
 
-		// 削除タイムスタンプが設定されて一定時間経過した仮想ネットワークのステータスを DELETING に更新する。
+		// 削除タイムスタンプが設定されて一定時間経過した仮想ネットワークを削除処理へ進める。
+		// 依存リソースが残っている場合は DEL-PENDING で待機し、依存解消後に DELETING へ遷移する。
 		// ERROR 状態でも削除要求を優先し、削除フローへ進める。
 		if vnet.Status != nil && vnet.Status.DeletionTimeStamp != nil {
 			if err := c.distributeDeleteIntentToSameNameNetworks(vnet); err != nil {
@@ -150,9 +151,18 @@ func (c *controller) networkControllerLoop(fabric networkfabric.NetworkFabric) {
 			}
 			deletionTime := *vnet.Status.DeletionTimeStamp
 			if time.Since(deletionTime) > c.deletionDelay {
-				slog.Debug("削除のタイムスタンプが一定時間以上経過している仮想ネットワーク検出", "networkId", vnetID)
-				c.marmot.Db.UpdateVirtualNetworkStatus(vnetID, db.NETWORK_DELETING)
-				vnet.Status.StatusCode = db.NETWORK_DELETING
+				deps, depErr := c.collectDeleteBlockingDependencies(vnet)
+				if depErr != nil {
+					slog.Warn("依存リソース判定に失敗したためネットワーク削除を保留", "networkId", vnetID, "err", depErr)
+				} else if deps.hasAny() {
+					c.marmot.Db.UpdateVirtualNetworkStatusWithMessage(vnetID, db.NETWORK_DEL_PENDING, deps.statusMessage())
+					vnet.Status.StatusCode = db.NETWORK_DEL_PENDING
+					slog.Debug("依存リソースが残っているためネットワーク削除を待機", "networkId", vnetID, "dependents", deps.statusMessage())
+				} else {
+					slog.Debug("削除のタイムスタンプが一定時間以上経過し依存リソースも存在しないため削除を開始", "networkId", vnetID)
+					c.marmot.Db.UpdateVirtualNetworkStatus(vnetID, db.NETWORK_DELETING)
+					vnet.Status.StatusCode = db.NETWORK_DELETING
+				}
 			}
 		}
 		//fmt.Println("======================================================")
@@ -230,6 +240,8 @@ func (c *controller) networkControllerLoop(fabric networkfabric.NetworkFabric) {
 					slog.Warn("failed to delete bridge on head, continuing", "networkId", vnetID, "err", err)
 				}
 				slog.Debug("仮想ネットワークの削除成功", "networkId", vnetID)
+			case db.NETWORK_DEL_PENDING:
+				slog.Debug("依存リソースの削除待ち状態の仮想ネットワークを処理", "networkId", vnetID)
 			case db.NETWORK_ERROR:
 				slog.Debug("エラー状態の仮想ネットワークを処理", "networkId", vnetID)
 				// ERROR 状態は保持する。削除要求（DeletionTimeStamp）が入った場合のみ削除意図を伝播する。
@@ -709,6 +721,121 @@ func (c *controller) ensureVirtualNetworkAbsent(vnet api.VirtualNetwork) error {
 
 	slog.Debug("フォロワーノードで仮想ネットワーク実体を削除", "networkId", api.VirtualNetworkID(vnet), "networkName", vnet.Metadata.Name, "controllerNode", c.marmot.NodeName)
 	return nil
+}
+
+type networkDeleteDependencies struct {
+	servers       []string
+	loadBalancers []string
+	gateways      []string
+	vpnGateways   []string
+}
+
+func (d networkDeleteDependencies) hasAny() bool {
+	return len(d.servers)+len(d.loadBalancers)+len(d.gateways)+len(d.vpnGateways) > 0
+}
+
+func (d networkDeleteDependencies) statusMessage() string {
+	return fmt.Sprintf(
+		"deletion:blocked-by-dependents servers=%d loadBalancers=%d gateways=%d vpnGateways=%d",
+		len(d.servers),
+		len(d.loadBalancers),
+		len(d.gateways),
+		len(d.vpnGateways),
+	)
+}
+
+func (c *controller) collectDeleteBlockingDependencies(vnet api.VirtualNetwork) (networkDeleteDependencies, error) {
+	networkName := strings.TrimSpace(vnet.Metadata.Name)
+	networkID := strings.TrimSpace(api.VirtualNetworkID(vnet))
+
+	servers, err := c.db.GetServers()
+	if err != nil {
+		return networkDeleteDependencies{}, err
+	}
+	loadBalancers, err := c.db.GetLoadBalancers()
+	if err != nil {
+		return networkDeleteDependencies{}, err
+	}
+	gateways, err := c.db.GetGateways()
+	if err != nil {
+		return networkDeleteDependencies{}, err
+	}
+	vpnGateways, err := c.db.GetVpnGateways()
+	if err != nil {
+		return networkDeleteDependencies{}, err
+	}
+
+	return collectNetworkDeleteDependencies(networkName, networkID, servers, loadBalancers, gateways, vpnGateways), nil
+}
+
+func collectNetworkDeleteDependencies(
+	networkName string,
+	networkID string,
+	servers []api.Server,
+	loadBalancers []api.ApplicationLoadBalancer,
+	gateways []api.Gateway,
+	vpnGateways []api.VpnGateway,
+) networkDeleteDependencies {
+	deps := networkDeleteDependencies{}
+	trimmedName := strings.TrimSpace(networkName)
+	trimmedID := strings.TrimSpace(networkID)
+
+	for _, server := range servers {
+		if server.Spec.NetworkInterface == nil {
+			continue
+		}
+		for _, nic := range *server.Spec.NetworkInterface {
+			if !matchesNetworkRef(trimmedName, trimmedID, nic.Networkname, nic.Networkid) {
+				continue
+			}
+			serverName := strings.TrimSpace(server.Metadata.Name)
+			if serverName == "" {
+				serverName = api.ServerID(server)
+			}
+			deps.servers = append(deps.servers, serverName)
+			break
+		}
+	}
+
+	for _, loadBalancer := range loadBalancers {
+		if !matchesNetworkName(trimmedName, loadBalancer.Spec.InternalVirtualNetwork) {
+			continue
+		}
+		deps.loadBalancers = append(deps.loadBalancers, strings.TrimSpace(loadBalancer.Metadata.Name))
+	}
+
+	for _, gateway := range gateways {
+		if !matchesNetworkName(trimmedName, gateway.Spec.InternalVirtualNetwork) {
+			continue
+		}
+		deps.gateways = append(deps.gateways, strings.TrimSpace(gateway.Metadata.Name))
+	}
+
+	for _, vpnGateway := range vpnGateways {
+		if !matchesNetworkName(trimmedName, vpnGateway.Spec.InternalVirtualNetwork) {
+			continue
+		}
+		deps.vpnGateways = append(deps.vpnGateways, strings.TrimSpace(vpnGateway.Metadata.Name))
+	}
+
+	return deps
+}
+
+func matchesNetworkRef(targetName string, targetID string, candidateName string, candidateID string) bool {
+	if targetID != "" && strings.TrimSpace(candidateID) == targetID {
+		return true
+	}
+	if targetName != "" && strings.TrimSpace(candidateName) == targetName {
+		return true
+	}
+	return false
+}
+
+func matchesNetworkName(targetName string, candidateName string) bool {
+	if targetName == "" {
+		return false
+	}
+	return strings.TrimSpace(candidateName) == targetName
 }
 
 func isVxlanOverlay(vnet api.VirtualNetwork) bool {

--- a/pkg/controller/network_delete_dependency_test.go
+++ b/pkg/controller/network_delete_dependency_test.go
@@ -1,0 +1,69 @@
+package controller
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+)
+
+func TestCollectNetworkDeleteDependencies_MatchesByNameAndID(t *testing.T) {
+	networkName := "app-net"
+	networkID := "n1234"
+
+	servers := []api.Server{
+		{
+			Metadata: api.Metadata{Name: "web-1"},
+			Spec:     api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{{Networkname: "other-net", Networkid: "x1"}}},
+		},
+		{
+			Metadata: api.Metadata{Name: "web-2"},
+			Spec:     api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{{Networkname: "app-net", Networkid: "x2"}}},
+		},
+		{
+			Metadata: api.Metadata{Name: "web-3"},
+			Spec:     api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{{Networkname: "mismatch", Networkid: "n1234"}}},
+		},
+	}
+
+	loadBalancers := []api.ApplicationLoadBalancer{
+		{Metadata: api.Metadata{Name: "alb-app"}, Spec: api.LoadBalancerSpec{InternalVirtualNetwork: "app-net"}},
+		{Metadata: api.Metadata{Name: "alb-other"}, Spec: api.LoadBalancerSpec{InternalVirtualNetwork: "other-net"}},
+	}
+	gateways := []api.Gateway{
+		{Metadata: api.Metadata{Name: "gw-app"}, Spec: api.GatewaySpec{InternalVirtualNetwork: "app-net"}},
+	}
+	vpnGateways := []api.VpnGateway{
+		{Metadata: api.Metadata{Name: "vpngw-app"}, Spec: api.VpnGatewaySpec{InternalVirtualNetwork: "app-net"}},
+	}
+
+	deps := collectNetworkDeleteDependencies(networkName, networkID, servers, loadBalancers, gateways, vpnGateways)
+	if !deps.hasAny() {
+		t.Fatalf("expected dependencies to be detected")
+	}
+
+	sort.Strings(deps.servers)
+	if !reflect.DeepEqual(deps.servers, []string{"web-2", "web-3"}) {
+		t.Fatalf("unexpected servers: got=%v", deps.servers)
+	}
+	if !reflect.DeepEqual(deps.loadBalancers, []string{"alb-app"}) {
+		t.Fatalf("unexpected load balancers: got=%v", deps.loadBalancers)
+	}
+	if !reflect.DeepEqual(deps.gateways, []string{"gw-app"}) {
+		t.Fatalf("unexpected gateways: got=%v", deps.gateways)
+	}
+	if !reflect.DeepEqual(deps.vpnGateways, []string{"vpngw-app"}) {
+		t.Fatalf("unexpected vpn gateways: got=%v", deps.vpnGateways)
+	}
+}
+
+func TestCollectNetworkDeleteDependencies_NoDependents(t *testing.T) {
+	deps := collectNetworkDeleteDependencies("app-net", "n1234", nil, nil, nil, nil)
+	if deps.hasAny() {
+		t.Fatalf("expected no dependencies, got=%+v", deps)
+	}
+	if got, want := deps.statusMessage(), "deletion:blocked-by-dependents servers=0 loadBalancers=0 gateways=0 vpnGateways=0"; got != want {
+		t.Fatalf("unexpected status message: got=%q want=%q", got, want)
+	}
+}

--- a/pkg/db/db-virtual_network.go
+++ b/pkg/db/db-virtual_network.go
@@ -21,6 +21,7 @@ const (
 	NETWORK_ERROR        = 4 // エラー状態
 	NETWORK_DELETING     = 5 // 削除中
 	NETWORK_WAITING      = 6 // ヘッドノードの作成完了待ち
+	NETWORK_DEL_PENDING  = 7 // 依存リソース削除待ち
 
 	// Network label keys for distributed sync
 	NetworkLabelSyncRole      = "syncRole"
@@ -36,6 +37,7 @@ var NetworkStatus = map[int]string{
 	4: "ERROR",
 	5: "DELETING",
 	6: "WAITING",
+	7: "DEL-PENDING",
 }
 
 // SetNetworkSyncLabels sets distributed sync metadata labels for networks.
@@ -398,6 +400,8 @@ func defaultMessageForStatus(status int) string {
 		return "error:unknown"
 	case NETWORK_DELETING:
 		return "deletion:in-progress"
+	case NETWORK_DEL_PENDING:
+		return "deletion:blocked-by-dependents"
 	case NETWORK_INACTIVE:
 		return "inactive"
 	default:


### PR DESCRIPTION
## 概要
Issue #411 の対策として、利用中リソースが残っている仮想ネットワークを即時削除しないように、ネットワーク削除フローを改善しました。  
削除要求後は依存関係を確認し、依存がある間は DEL-PENDING で待機、依存がなくなったら DELETING に遷移して削除を進めます。

Closes #411

## 背景
現状は、Server や ALB などが対象ネットワークを使用中でも削除処理が進み、最終的にネットワークが ERROR に落ちるケースがありました。  
本PRでは、削除前の依存チェックを導入し、削除の安全性と状態遷移の明確性を高めています。

## 変更内容
- ネットワーク状態に DEL-PENDING を追加
- ネットワーク削除遷移時に依存リソースを検査するロジックを追加
- 依存ありの場合は DEL-PENDING に遷移し、ステータスメッセージに依存件数を出力
- 依存なしの場合のみ DELETING に遷移して既存削除処理を実行
- 依存判定対象
  - Server の networkname / networkid
  - Application Load Balancer の internalVirtualNetwork
  - Gateway の internalVirtualNetwork
  - VpnGateway の internalVirtualNetwork
- 依存判定ロジックのユニットテストを追加
  - Name/ID の両方で一致判定できること
  - 依存なしケースのステータスメッセージ検証

## 影響範囲
- ネットワーク削除時の状態遷移
- ネットワークステータス定義（DEL-PENDING 追加）
- 既存の作成・通常運用フローへの影響はなし

## 動作イメージ
- 削除要求を受けたネットワークに対して削除遅延経過後に依存チェックを実施
- 依存が残っている間は DEL-PENDING を維持
- 利用中リソースが解消されたタイミングで DELETING に遷移し削除処理を継続

## テスト
実行コマンド:
go test ./pkg/controller -run 'TestCollectNetworkDeleteDependencies|TestEnsureOverlayMeshForNetwork_ManualSkipsAutomaticTunnelOps|TestBuildVxlanHubSpokePeerIPs'

結果:
ok github.com/takara9/marmot/pkg/controller (cached)