### PR TITLE
ALB不具合修正

### DIFF
--- a/pkg/controller/gateway-playbooks/load-balancer-haproxy.yaml.tmpl
+++ b/pkg/controller/gateway-playbooks/load-balancer-haproxy.yaml.tmpl
@@ -37,6 +37,7 @@
       ansible.builtin.copy:
         src: /usr/local/marmot/marmot-lb-agent
         dest: /usr/local/bin/marmot-lb-agent
+        remote_src: true
         mode: "0755"
 
     - name: Install marmot-lb-agent service

--- a/pkg/marmotd/package_e2e_test.go
+++ b/pkg/marmotd/package_e2e_test.go
@@ -42,7 +42,10 @@ func TestDebPackageIncludesGatewayAssets(t *testing.T) {
 	}
 	listText := string(listOut)
 	for _, want := range []string{
+		"./usr/local/marmot/marmot-lb-agent",
 		"./usr/local/marmot/gateway-playbooks/gateway-iptables.yaml.tmpl",
+		"./usr/local/marmot/gateway-playbooks/load-balancer-haproxy.yaml.tmpl",
+		"./usr/local/marmot/gateway-playbooks/network-load-balancer-iptables.yaml.tmpl",
 		"./usr/local/marmot/gateway-playbooks/vpn-gateway-openvpn.yaml.tmpl",
 		"./var/lib/marmot/ansible-playbooks/templates/",
 		"./etc/marmot/keys/",

--- a/tools/build-deb.sh
+++ b/tools/build-deb.sh
@@ -6,7 +6,7 @@
 #
 # 前提条件:
 #   - 以下のバイナリが marmot-v<VERSION>/ ディレクトリに存在すること
-#       marmotd, mactl
+#       marmotd, mactl, maadm, marmot-lb-agent
 #   - dpkg-deb コマンドが利用可能であること
 #
 # 使用方法:
@@ -36,7 +36,7 @@ echo "=== marmot v${TAG} dpkgパッケージビルド ==="
 echo ""
 
 # バイナリの存在確認
-for bin in marmotd mactl maadm; do
+for bin in marmotd mactl maadm marmot-lb-agent; do
     if [ ! -f "${BINDIR}/${bin}" ]; then
         echo "エラー: ${BINDIR}/${bin} が見つかりません。"
         echo "先に各コマンドをビルドしてください:"
@@ -71,10 +71,15 @@ mkdir -p "${PKG_DIR}/var/lib/marmot/volumes"
 
 echo "バイナリをコピー中..."
 install -m 0755 "${BINDIR}/marmotd" "${PKG_DIR}/usr/local/marmot/marmotd"
+install -m 0755 "${BINDIR}/marmot-lb-agent" "${PKG_DIR}/usr/local/marmot/marmot-lb-agent"
 install -m 0755 "${BINDIR}/mactl"   "${PKG_DIR}/usr/local/bin/mactl"
 install -m 0755 "${BINDIR}/maadm"   "${PKG_DIR}/usr/local/bin/maadm"
 install -m 0644 "${ROOT_DIR}/pkg/controller/gateway-playbooks/gateway-iptables.yaml.tmpl" \
     "${PKG_DIR}/usr/local/marmot/gateway-playbooks/gateway-iptables.yaml.tmpl"
+install -m 0644 "${ROOT_DIR}/pkg/controller/gateway-playbooks/load-balancer-haproxy.yaml.tmpl" \
+    "${PKG_DIR}/usr/local/marmot/gateway-playbooks/load-balancer-haproxy.yaml.tmpl"
+install -m 0644 "${ROOT_DIR}/pkg/controller/gateway-playbooks/network-load-balancer-iptables.yaml.tmpl" \
+    "${PKG_DIR}/usr/local/marmot/gateway-playbooks/network-load-balancer-iptables.yaml.tmpl"
 install -m 0644 "${ROOT_DIR}/pkg/controller/gateway-playbooks/vpn-gateway-openvpn.yaml.tmpl" \
     "${PKG_DIR}/usr/local/marmot/gateway-playbooks/vpn-gateway-openvpn.yaml.tmpl"
 


### PR DESCRIPTION
## 概要
ALB の設定反映で、marmot-lb-agent 配布タスクが失敗する不具合を修正しました。  
あわせて、deb パッケージに必要な LB 関連ランタイムアセットが不足していた問題を修正し、新規環境での再発を防止しています。

## 背景
ALB の Ansible 実行時に以下の失敗が発生していました。

- Install marmot-lb-agent binary で Source not found エラー
- 結果として status が FAILED になり、ALB が ACTIVE に遷移しない

根本的には、配布元と配布先の参照前提が実運用とずれていたこと、および deb 同梱物の不足が原因でした。

## 変更内容
- ALB の lb-agent 配布タスクを、Controller から LB VM へコピーする前提に統一
- deb ビルドに lb-agent バイナリを同梱
- deb ビルドに ALB/NLB 用プレイブックテンプレートを同梱
- パッケージ同梱内容の E2E テスト期待値を更新

## 期待される効果
- ALB 構成適用時の lb-agent 配布失敗を解消
- 新規インストール環境でも必要アセット不足による ALB/NLB 構成失敗を防止
- パッケージテストで同梱漏れを早期検知できるように改善

## 動作確認
- ALB 関連のコントローラテストを実行し成功
- パッケージ同梱確認テストを実行し成功
- 実機で deb インストール後、配布元バイナリ存在を確認

## 影響範囲
- Application LoadBalancer の Ansible 適用フロー
- Debian パッケージの同梱物
- パッケージ検証テスト

## リスクとロールバック
- リスク: 低  
  既存フローに沿った前提へ戻す修正で、同梱不足も補完済みです。
- ロールバック: 本 PR の差分を revert すれば復旧可能です。