### PR TITLE
Issue #420: OSイメージの export/import 対応と import 後レプリカ生成フローの整備

### DIFF
--- a/cmd/mactl/cmd/image_export.go
+++ b/cmd/mactl/cmd/image_export.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+)
+
+var imageExportCmd = &cobra.Command{
+	Use:   "export [image-name]",
+	Short: "Export an OS image to tgz",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		name := strings.TrimSpace(args[0])
+		if name == "" {
+			return fmt.Errorf("image name is required")
+		}
+
+		m, err := getClientConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get API client config: %w", err)
+		}
+
+		listBody, _, err := m.GetImages()
+		if err != nil {
+			return fmt.Errorf("failed to get images: %w", err)
+		}
+
+		var images []api.Image
+		if err := json.Unmarshal(listBody, &images); err != nil {
+			return fmt.Errorf("failed to parse images: %w", err)
+		}
+
+		image, err := pickExportableImageByName(images, name)
+		if err != nil {
+			return err
+		}
+
+		qcowBytes, err := m.DownloadImageQcow2ById(image.Metadata.Id)
+		if err != nil {
+			return fmt.Errorf("failed to download qcow2 for image %q: %w", image.Metadata.Id, err)
+		}
+
+		outPath := filepath.Join(".", fmt.Sprintf("marmot-machine-image-%s.tgz", sanitizeArchiveName(name)))
+		if err := writeImageArchive(outPath, image.Metadata.Name, qcowBytes); err != nil {
+			return fmt.Errorf("failed to write archive: %w", err)
+		}
+
+		fmt.Println(outPath)
+		return nil
+	},
+}
+
+func init() {
+	imageCmd.AddCommand(imageExportCmd)
+}
+
+func pickExportableImageByName(images []api.Image, name string) (*api.Image, error) {
+	matched := make([]api.Image, 0)
+	for _, image := range images {
+		if strings.TrimSpace(image.Metadata.Name) != name {
+			continue
+		}
+		if image.Metadata.Labels != nil && db.GetFollowerSyncRole(*image.Metadata.Labels) == "follower" {
+			continue
+		}
+		if image.Status == nil || image.Status.StatusCode != db.IMAGE_AVAILABLE {
+			continue
+		}
+		if image.Spec.Qcow2Path == nil || strings.TrimSpace(*image.Spec.Qcow2Path) == "" {
+			continue
+		}
+		matched = append(matched, image)
+	}
+
+	if len(matched) == 0 {
+		return nil, fmt.Errorf("exportable image not found: %s", name)
+	}
+
+	best := matched[0]
+	for _, image := range matched[1:] {
+		if creationTime(image.Status).After(creationTime(best.Status)) {
+			best = image
+		}
+	}
+	return &best, nil
+}
+
+func writeImageArchive(outPath, imageName string, qcow2Bytes []byte) error {
+	f, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz := gzip.NewWriter(f)
+	defer gz.Close()
+
+	tw := tar.NewWriter(gz)
+	defer tw.Close()
+
+	qcowName := fmt.Sprintf("%s.qcow2", sanitizeArchiveName(imageName))
+	hdr := &tar.Header{
+		Name: qcowName,
+		Mode: 0644,
+		Size: int64(len(qcow2Bytes)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	if _, err := tw.Write(qcow2Bytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func sanitizeArchiveName(name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "image"
+	}
+	mapper := func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '-'
+		}
+	}
+	sanitized := strings.Trim(strings.Map(mapper, trimmed), "-")
+	if sanitized == "" {
+		return "image"
+	}
+	return sanitized
+}

--- a/cmd/mactl/cmd/image_export_test.go
+++ b/cmd/mactl/cmd/image_export_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+var _ = Describe("sanitizeArchiveName", func() {
+	It("returns image when sanitized result becomes empty", func() {
+		Expect(sanitizeArchiveName("###")).To(Equal("image"))
+	})
+
+	It("keeps allowed characters", func() {
+		Expect(sanitizeArchiveName("Ubuntu-24.04_LTS")).To(Equal("Ubuntu-24.04_LTS"))
+	})
+})
+
+var _ = Describe("pickExportableImageByName", func() {
+	It("selects latest AVAILABLE image and skips follower images", func() {
+		now := time.Now()
+		earlier := now.Add(-1 * time.Hour)
+		followerLabels := map[string]interface{}{db.ImageLabelSyncRole: "follower"}
+
+		images := []api.Image{
+			{
+				Metadata: api.Metadata{Name: "ubuntu", Id: "img-follower", Labels: &followerLabels},
+				Spec:     api.ImageSpec{Qcow2Path: util.StringPtr("/tmp/follower.qcow2")},
+				Status:   &api.Status{StatusCode: db.IMAGE_AVAILABLE, CreationTimeStamp: &now},
+			},
+			{
+				Metadata: api.Metadata{Name: "ubuntu", Id: "img-old"},
+				Spec:     api.ImageSpec{Qcow2Path: util.StringPtr("/tmp/old.qcow2")},
+				Status:   &api.Status{StatusCode: db.IMAGE_AVAILABLE, CreationTimeStamp: &earlier},
+			},
+			{
+				Metadata: api.Metadata{Name: "ubuntu", Id: "img-new"},
+				Spec:     api.ImageSpec{Qcow2Path: util.StringPtr("/tmp/new.qcow2")},
+				Status:   &api.Status{StatusCode: db.IMAGE_AVAILABLE, CreationTimeStamp: &now},
+			},
+		}
+
+		picked, err := pickExportableImageByName(images, "ubuntu")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(picked.Metadata.Id).To(Equal("img-new"))
+	})
+})

--- a/cmd/mactl/cmd/image_import.go
+++ b/cmd/mactl/cmd/image_import.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var imageImportCmd = &cobra.Command{
+	Use:   "import [filename.tgz]",
+	Short: "Import an OS image archive",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		input := strings.TrimSpace(args[0])
+		if input == "" {
+			return fmt.Errorf("archive filename is required")
+		}
+
+		absPath, err := filepath.Abs(input)
+		if err != nil {
+			return fmt.Errorf("failed to resolve archive path: %w", err)
+		}
+		if _, err := os.Stat(absPath); err != nil {
+			return fmt.Errorf("failed to access archive: %w", err)
+		}
+
+		m, err := getClientConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get API client config: %w", err)
+		}
+
+		body, _, err := m.ImportImageArchive(absPath)
+		if err != nil {
+			return fmt.Errorf("failed to import image archive: %w", err)
+		}
+
+		fmt.Println(string(body))
+		return nil
+	},
+}
+
+func init() {
+	imageCmd.AddCommand(imageImportCmd)
+}

--- a/pkg/client/core.go
+++ b/pkg/client/core.go
@@ -70,7 +70,9 @@ func (m *MarmotEndpoint) httpRequest(req *http.Request) (int, []byte, *url.URL, 
 
 func (m *MarmotEndpoint) httpRequest2(req *http.Request) ([]byte, *url.URL, error) {
 	req.Header.Set("User-Agent", "MarmotdClient/1.0")
-	req.Header.Set("Content-Type", "application/json")
+	if strings.TrimSpace(req.Header.Get("Content-Type")) == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	resp, err := m.Client.Do(req)
 	if err != nil {

--- a/pkg/client/image.go
+++ b/pkg/client/image.go
@@ -3,9 +3,13 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 
 	"github.com/takara9/marmot/api"
 )
@@ -92,5 +96,62 @@ func (m *MarmotEndpoint) UpdateImageById(key string, spec api.Image) ([]byte, *u
 	if err != nil {
 		return nil, nil, err
 	}
+	return m.httpRequest2(req)
+}
+
+// イメージのQCOW2をダウンロードする
+func (m *MarmotEndpoint) DownloadImageQcow2ById(key string) ([]byte, error) {
+	reqURL, err := url.JoinPath(m.Scheme+"://"+m.HostPort, m.BasePath, "/image", key, "qcow2")
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Debug("DownloadImageQcow2ById", "reqURL", reqURL)
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, _, err := m.httpRequest2(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+// tgzファイルをアップロードしてイメージをインポートする
+func (m *MarmotEndpoint) ImportImageArchive(tgzPath string) ([]byte, *url.URL, error) {
+	reqURL, err := url.JoinPath(m.Scheme+"://"+m.HostPort, m.BasePath, "/image/import")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	file, err := os.Open(tgzPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer file.Close()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", filepath.Base(tgzPath))
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		return nil, nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, nil, err
+	}
+
+	req, err := http.NewRequest("POST", reqURL, &body)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
 	return m.httpRequest2(req)
 }

--- a/pkg/controller/image-controller.go
+++ b/pkg/controller/image-controller.go
@@ -104,6 +104,11 @@ func (c *controller) imageControllerLoop() {
 			if err := c.ensureFollowerImagesWaiting(image); err != nil {
 				slog.Error("フォロワー用イメージエントリーの作成に失敗", "headImageId", image.Metadata.Id, "err", err)
 			}
+			if image.Spec.SourceUrl == nil && strings.TrimSpace(util.OrDefault(image.Spec.Qcow2Path, "")) != "" {
+				slog.Debug("インポート済みQCOW2イメージを利用可能に遷移", "image", image.Metadata.Name, "imageId", image.Metadata.Id)
+				c.marmot.Db.UpdateImageStatusMessage(image.Metadata.Id, db.IMAGE_AVAILABLE, "")
+				continue
+			}
 			c.marmot.Db.UpdateImageStatus(image.Metadata.Id, db.IMAGE_CREATING)
 			// ラベルの存在をチェック
 			if image.Metadata.Labels != nil {

--- a/pkg/db/db-image.go
+++ b/pkg/db/db-image.go
@@ -241,7 +241,7 @@ func (d *Database) makeImageEntryFromURLWithNodeAndMeta(name, url, nodeName, api
 		Kind:       kind,
 		Metadata: api.Metadata{
 			Name: name,
-			Id: id,
+			Id:   id,
 			Uuid: util.StringPtr(uuidString),
 		},
 		Spec: api.ImageSpec{
@@ -265,6 +265,57 @@ func (d *Database) makeImageEntryFromURLWithNodeAndMeta(name, url, nodeName, api
 	}
 
 	return id, nil
+}
+
+// MakeImportedImageEntry は既存のqcow2ファイルを参照する利用可能なイメージを登録する。
+func (d *Database) MakeImportedImageEntry(name, nodeName, qcow2Path string) (api.Image, error) {
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return api.Image{}, fmt.Errorf("name is required")
+	}
+	trimmedPath := strings.TrimSpace(qcow2Path)
+	if trimmedPath == "" {
+		return api.Image{}, fmt.Errorf("qcow2Path is required")
+	}
+
+	id, uuidString, err := d.getUniqueImageID()
+	if err != nil {
+		return api.Image{}, err
+	}
+
+	now := time.Now()
+	img := api.Image{
+		ApiVersion: "v1",
+		Kind:       "Image",
+		Metadata: api.Metadata{
+			Name: trimmedName,
+			Id:   id,
+			Uuid: util.StringPtr(uuidString),
+		},
+		Spec: api.ImageSpec{
+			Kind:      util.StringPtr("os"),
+			Type:      util.StringPtr("qcow2"),
+			Qcow2Path: util.StringPtr(trimmedPath),
+		},
+		Status: &api.Status{
+			StatusCode:          IMAGE_PENDING,
+			Status:              util.StringPtr(ImageStatus[IMAGE_PENDING]),
+			CreationTimeStamp:   util.TimePtr(now),
+			LastUpdateTimeStamp: util.TimePtr(now),
+			Message:             util.StringPtr("インポート済みイメージの同期準備中"),
+		},
+	}
+
+	if node := strings.TrimSpace(nodeName); node != "" {
+		img.Metadata.NodeName = util.StringPtr(node)
+	}
+
+	key := ImagePrefix + "/" + id
+	if err := d.PutJSON(key, img); err != nil {
+		return api.Image{}, err
+	}
+
+	return img, nil
 }
 
 // ブートボリュームからイメージを作成する
@@ -332,7 +383,7 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 				Name:     name,
 				Labels:   &labels,
 				NodeName: serverNodeName,
-				Id: id,
+				Id:       id,
 				Uuid:     util.StringPtr(uuidString),
 			},
 			Spec: api.ImageSpec{
@@ -363,7 +414,7 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 				Name:     name,
 				Labels:   &labels,
 				NodeName: serverNodeName,
-				Id: id,
+				Id:       id,
 				Uuid:     util.StringPtr(uuidString),
 			},
 			Spec: api.ImageSpec{
@@ -561,13 +612,16 @@ func (d *Database) updateImage(id string, spec api.Image) error {
 
 // イメージの削除予定日時をセットする
 func (d *Database) SetDeleteTimestampImage(id string) error {
-	image, err := d.GetImage(id)
+	key := ImagePrefix + "/" + id
+	var image api.Image
+	resp, err := d.GetJSON(key, &image)
 	if err != nil {
 		slog.Error("SetDeleteTimestamp() GetImage() failed", "err", err, "imageId", id)
 		return err
 	}
 	image.Status.DeletionTimeStamp = util.TimePtr(time.Now())
-	if err := d.UpdateImage(id, image); err != nil {
+	image.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
+	if err := d.PutJSONCAS(key, resp.Kvs[0].ModRevision, image); err != nil {
 		slog.Error("SetDeleteTimestamp() UpdateImage() failed", "err", err, "imageId", id)
 		return err
 	}
@@ -698,7 +752,7 @@ func (d *Database) MakeFollowerImageEntry(headImage api.Image, followerNodeName 
 			Name:     headImage.Metadata.Name,
 			NodeName: util.StringPtr(followerNodeName),
 			Labels:   &labels,
-			Id: id,
+			Id:       id,
 			Uuid:     util.StringPtr(uuidString),
 		},
 		Spec: api.ImageSpec{

--- a/pkg/db/db-image_test.go
+++ b/pkg/db/db-image_test.go
@@ -167,6 +167,30 @@ var _ = Describe("Image", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
+			It("イメージの削除予定日時を設定できる", func() {
+				localDB, err := db.NewDatabase(url)
+				Expect(err).NotTo(HaveOccurred())
+				defer func() {
+					Expect(localDB.Close()).NotTo(HaveOccurred())
+				}()
+
+				createdID, err := localDB.MakeImageEntryFromURLWithNode("test-image-delete-ts", "http://hmc/delete-ts.qcow2", "hv-test-01")
+				Expect(err).NotTo(HaveOccurred())
+
+				img, err := localDB.GetImage(createdID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(img.Status).NotTo(BeNil())
+				Expect(img.Status.DeletionTimeStamp).To(BeNil())
+
+				err = localDB.SetDeleteTimestampImage(createdID)
+				Expect(err).NotTo(HaveOccurred())
+
+				updated, err := localDB.GetImage(createdID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Status).NotTo(BeNil())
+				Expect(updated.Status.DeletionTimeStamp).NotTo(BeNil())
+			})
+
 			It("すべてのイメージ情報を取得", func() {
 				imgs, err := v.GetImages()
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/marmotd/api-image-import.go
+++ b/pkg/marmotd/api-image-import.go
@@ -1,0 +1,100 @@
+package marmotd
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+// ApiImportImageArchive imports a tgz archive that contains one qcow2 file.
+func (s *Server) ApiImportImageArchive(ctx echo.Context) error {
+	fileHeader, err := ctx.FormFile("file")
+	if err != nil {
+		return ctx.JSON(http.StatusBadRequest, api.Error{Code: 1, Message: "file form field is required"})
+	}
+
+	src, err := fileHeader.Open()
+	if err != nil {
+		return ctx.JSON(http.StatusBadRequest, api.Error{Code: 1, Message: err.Error()})
+	}
+	defer src.Close()
+
+	baseName := strings.TrimSuffix(filepath.Base(fileHeader.Filename), filepath.Ext(fileHeader.Filename))
+	baseName = strings.TrimSuffix(baseName, filepath.Ext(baseName))
+	baseName = strings.TrimPrefix(baseName, "marmot-machine-image-")
+	if strings.TrimSpace(baseName) == "" {
+		baseName = "imported-image"
+	}
+
+	image, err := s.Ma.ImportImageArchiveWithNode(src, baseName, s.Ma.NodeName)
+	if err != nil {
+		slog.Error("ApiImportImageArchive() failed", "err", err)
+		return ctx.JSON(http.StatusBadRequest, api.Error{Code: 1, Message: err.Error()})
+	}
+
+	var resp api.Success
+	resp.Id = image.Metadata.Id
+	resp.Message = util.StringPtr("Image imported successfully")
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+func extractSingleQcow2FromTGZ(src io.Reader, destDir string) (string, error) {
+	gz, err := gzip.NewReader(src)
+	if err != nil {
+		return "", fmt.Errorf("failed to read gzip stream: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var found string
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to read tar stream: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		base := filepath.Base(hdr.Name)
+		if !strings.HasSuffix(strings.ToLower(base), ".qcow2") {
+			continue
+		}
+		if found != "" {
+			return "", fmt.Errorf("archive contains multiple qcow2 files")
+		}
+
+		dstPath := filepath.Join(destDir, base)
+		f, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			return "", err
+		}
+		if _, err := io.Copy(f, tr); err != nil {
+			f.Close()
+			return "", err
+		}
+		if err := f.Close(); err != nil {
+			return "", err
+		}
+		found = dstPath
+	}
+
+	if found == "" {
+		return "", fmt.Errorf("archive does not contain qcow2 file")
+	}
+	return found, nil
+}

--- a/pkg/marmotd/api-routes.go
+++ b/pkg/marmotd/api-routes.go
@@ -9,6 +9,7 @@ import (
 func RegisterRoutes(e *echo.Echo, server *Server, baseURL string) {
 	api.RegisterHandlersWithBaseURL(e, server, baseURL)
 	e.GET(baseURL+"/image/:id/qcow2", server.ApiDownloadImageQcow2ById)
+	e.POST(baseURL+"/image/import", server.ApiImportImageArchive)
 	e.GET(baseURL+"/gateway/:id/cert", func(ctx echo.Context) error {
 		return server.ApiGetGatewayCertById(ctx, ctx.Param("id"))
 	})

--- a/pkg/marmotd/image.go
+++ b/pkg/marmotd/image.go
@@ -192,6 +192,67 @@ func (m *Marmot) GetImageManage(id string) (api.Image, error) {
 	return m.Db.GetImage(id)
 }
 
+// ImportImageArchiveWithNode はtgzアーカイブからqcow2を取り出してイメージ登録する。
+func (m *Marmot) ImportImageArchiveWithNode(src io.Reader, imageName, nodeName string) (api.Image, error) {
+	if src == nil {
+		return api.Image{}, fmt.Errorf("archive stream is nil")
+	}
+	name := strings.TrimSpace(imageName)
+	if name == "" {
+		return api.Image{}, fmt.Errorf("image name is required")
+	}
+
+	if err := os.MkdirAll(IMAGE_POOL, 0755); err != nil {
+		return api.Image{}, err
+	}
+
+	importDir, err := os.MkdirTemp(IMAGE_POOL, "import-")
+	if err != nil {
+		return api.Image{}, err
+	}
+	defer func() {
+		_ = os.RemoveAll(importDir)
+	}()
+
+	importedQcow2, err := extractSingleQcow2FromTGZ(src, importDir)
+	if err != nil {
+		return api.Image{}, err
+	}
+	if err := validateQcowV2Image(importedQcow2); err != nil {
+		return api.Image{}, err
+	}
+
+	image, err := m.Db.MakeImportedImageEntry(name, nodeName, importedQcow2)
+	if err != nil {
+		return api.Image{}, err
+	}
+	cleanupEntry := func() {
+		if err := m.Db.DeleteImage(image.Metadata.Id); err != nil {
+			slog.Warn("ImportImageArchiveWithNode() failed to rollback imported image entry", "imageId", image.Metadata.Id, "err", err)
+		}
+	}
+
+	finalDir := filepath.Join(IMAGE_POOL, image.Metadata.Id)
+	if err := os.MkdirAll(finalDir, 0755); err != nil {
+		cleanupEntry()
+		return api.Image{}, err
+	}
+	finalQcow2Path := filepath.Join(finalDir, fmt.Sprintf("osimage-%s.qcow2", image.Metadata.Id))
+	if err := os.Rename(importedQcow2, finalQcow2Path); err != nil {
+		cleanupEntry()
+		return api.Image{}, err
+	}
+
+	image.Spec.Qcow2Path = util.StringPtr(finalQcow2Path)
+	if err := m.Db.UpdateImage(image.Metadata.Id, image); err != nil {
+		_ = os.Remove(finalQcow2Path)
+		cleanupEntry()
+		return api.Image{}, err
+	}
+
+	return image, nil
+}
+
 // 指定したIDのイメージを削除する関数 （ラップ関数） コントローラーで使用
 func (m *Marmot) DeleteImageManage(id string) error {
 	slog.Debug("Deleting image", "imgId", id)


### PR DESCRIPTION
## 背景
Issue #420 の要望である、OSイメージの外部保存と再利用を実現するため、image export/import 機能を追加しました。  
あわせて、運用中に確認された import 後のレプリカ未生成、削除予約が反映されない問題も修正しました。

Fixes #420

## 変更内容
- mactl image export を追加
- mactl image import を追加
- サーバー側に image QCOW2 ダウンロード API を追加
- サーバー側に image archive import API を追加
- import 失敗時のロールバックを追加
  - 中途失敗時に image エントリや生成済みファイルが残らないように修正
- import 後の状態遷移を調整
  - import 時は PENDING で登録
  - 既存の image controller フローで処理させる
  - import 済み QCOW2 を検知した場合は AVAILABLE へ遷移
- レプリカ生成が既存フローで動くように調整
  - PENDING フローの follower 作成ロジックを活用
- image 削除予約の永続化を修正
  - deletionTimestamp が確実に保存されるよう、更新処理を改善
- export 名のサニタイズ境界ケースを修正
  - 記号のみ入力時でも安全なファイル名を生成

## 挙動のポイント
- import 実行後は、head image が一度 PENDING になり、その後 AVAILABLE へ遷移
- 同時に既存 controller により follower 作成と同期が進む
- 削除要求時は deletionTimestamp が保存され、予約削除フローに入る

## 確認内容
- 単体・コンパイル確認
  - go test ./pkg/controller -run TestShouldBypassNodeGateForDeletingServer -count=1
  - go test ./pkg/marmotd -run ^$ -count=1
  - go test ./pkg/db -run ^$ -count=1
  - go test ./pkg/db -run TestDb -count=1
- import/export の手動確認
  - image export で tgz が生成されること
  - image import で image が登録されること
  - import 後にレプリカが生成されること
- 削除予約の確認
  - image delete 後に deletionTimestamp が保存されること

## 影響範囲
- image import/export の API と CLI
- image controller の PENDING 処理
- image 削除予約のDB更新処理

## 後方互換性
- 既存の image controller ベースの状態遷移を維持
- 新機能追加と不具合修正が中心で、既存コマンド体系との互換性は維持しています

