### PR TITLE
Ansible 連携機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,35 @@ mactl server create -f https://raw.githubusercontent.com/takara9/marmot/refs/hea
 mactl network create -f https://raw.githubusercontent.com/takara9/marmot/refs/heads/main/cmd/mactl/testdata/test-network-02-test-net-2.yaml
 ```
 
+### Issue #421 サンプル: Server 作成後に ansible-playbook を自動適用
+
+`spec.ansible-playbook` を指定した Server マニフェストのサンプルは以下です。
+
+- `cmd/mactl/testdata/test-server-38-ansible-playbook.yaml`
+
+実行手順:
+
+1. playbook ファイルを `mactl` 実行ディレクトリ配下に配置する（サンプルでは `playbook/setup.yaml`）。
+2. 必要なら秘密鍵パスを環境変数 `MARMOT_ANSIBLE_PRIVATE_KEY` で指定する。
+3. Server を作成する。
+
+```sh
+mkdir -p playbook
+# 例: playbook を配置
+# cp /path/to/setup.yaml playbook/setup.yaml
+
+export MARMOT_ANSIBLE_PRIVATE_KEY="$HOME/.ssh/id_ed25519"
+mactl server create -f cmd/mactl/testdata/test-server-38-ansible-playbook.yaml
+```
+
+補足:
+
+- `spec.ansible-playbook` は `host-bridge` の固定 IP (`spec.networkInterface[].address`) がある場合のみ有効です。
+- `ansible.cfg` がカレントディレクトリに無い場合、`mactl` は次の環境変数を付与して `ansible` / `ansible-playbook` を実行します。
+  - `ANSIBLE_HOST_KEY_CHECKING=False`
+  - `ANSIBLE_DEPRECATION_WARNINGS=False`
+  - `ANSIBLE_SSH_ARGS="-o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes"`
+
 ### 主な `mactl` サブコマンド
 
 ```

--- a/api/marmot-api-v1.go
+++ b/api/marmot-api-v1.go
@@ -337,6 +337,7 @@ type Server struct {
 
 // ServerSpec defines model for ServerSpec.
 type ServerSpec struct {
+	AnsiblePlaybook  *string             `json:"ansible-playbook,omitempty"`
 	Auth             *Auth               `json:"auth,omitempty"`
 	BootVolume       *Volume             `json:"bootVolume,omitempty"`
 	Cpu              *int                `json:"cpu,omitempty"`

--- a/api/marmot-api-v1.yaml
+++ b/api/marmot-api-v1.yaml
@@ -1510,6 +1510,8 @@ components:
     ServerSpec:
       type: object
       properties:
+        ansible-playbook:
+          type: string
         cpu:
           type: integer
           format: int

--- a/cmd/mactl/README.md
+++ b/cmd/mactl/README.md
@@ -18,3 +18,20 @@ mactl server create --configfile https://raw.githubusercontent.com/takara9/marmo
 mactl network create -f https://raw.githubusercontent.com/takara9/marmot/refs/heads/main/cmd/mactl/testdata/test-network-02-test-net-2.yaml
 ```
 
+## Issue #421 サンプル: spec.ansible-playbook
+
+`cmd/mactl/testdata/test-server-38-ansible-playbook.yaml` は、Server 作成後に `ansible-playbook` を自動適用するサンプルです。
+
+```sh
+mkdir -p playbook
+# cp /path/to/setup.yaml playbook/setup.yaml
+
+export MARMOT_ANSIBLE_PRIVATE_KEY="$HOME/.ssh/id_ed25519"
+mactl server create --configfile cmd/mactl/testdata/test-server-38-ansible-playbook.yaml
+```
+
+メモ:
+
+- `spec.ansible-playbook` は `host-bridge` の固定IPが必要です。
+- `ansible.cfg` がカレントディレクトリに無い場合、`mactl` は `ANSIBLE_HOST_KEY_CHECKING=False` などの環境変数を補って実行します。
+

--- a/cmd/mactl/cmd/apply.go
+++ b/cmd/mactl/cmd/apply.go
@@ -131,6 +131,9 @@ func applyServer(manifest map[string]interface{}) error {
 		if err != nil {
 			return fmt.Errorf("failed to create server: %w", err)
 		}
+		if err := maybeApplyServerAnsiblePlaybook(m, *server, byteBody); err != nil {
+			return err
+		}
 	}
 
 	// レスポンス処理

--- a/cmd/mactl/cmd/apply.go
+++ b/cmd/mactl/cmd/apply.go
@@ -131,13 +131,18 @@ func applyServer(manifest map[string]interface{}) error {
 		if err != nil {
 			return fmt.Errorf("failed to create server: %w", err)
 		}
+	}
+
+	// まず API の結果を表示し、その後に必要なら ansible を実行する
+	if err := processApplyResponse(byteBody, exists); err != nil {
+		return err
+	}
+	if !exists {
 		if err := maybeApplyServerAnsiblePlaybook(m, *server, byteBody); err != nil {
 			return err
 		}
 	}
-
-	// レスポンス処理
-	return processApplyResponse(byteBody, exists)
+	return nil
 }
 
 func applyImage(manifest map[string]interface{}) error {

--- a/cmd/mactl/cmd/create.go
+++ b/cmd/mactl/cmd/create.go
@@ -120,6 +120,9 @@ func createServer(manifest map[string]interface{}) error {
 	if err != nil {
 		return fmt.Errorf("failed to create server: %w", err)
 	}
+	if err := maybeApplyServerAnsiblePlaybook(m, *server, byteBody); err != nil {
+		return err
+	}
 
 	// レスポンス処理
 	return processCreateResponse(byteBody)

--- a/cmd/mactl/cmd/create.go
+++ b/cmd/mactl/cmd/create.go
@@ -120,12 +120,15 @@ func createServer(manifest map[string]interface{}) error {
 	if err != nil {
 		return fmt.Errorf("failed to create server: %w", err)
 	}
+
+	// まず API の受理レスポンスを表示し、その後に ansible の実行ログを流す
+	if err := processCreateResponse(byteBody); err != nil {
+		return err
+	}
 	if err := maybeApplyServerAnsiblePlaybook(m, *server, byteBody); err != nil {
 		return err
 	}
-
-	// レスポンス処理
-	return processCreateResponse(byteBody)
+	return nil
 }
 
 func createImage(manifest map[string]interface{}) error {

--- a/cmd/mactl/cmd/server_ansible.go
+++ b/cmd/mactl/cmd/server_ansible.go
@@ -40,6 +40,7 @@ func maybeApplyServerAnsiblePlaybook(m *client.MarmotEndpoint, server api.Server
 		return fmt.Errorf("failed to parse create response id for ansible apply: %w", err)
 	}
 
+	fmt.Fprintln(os.Stderr, "OS起動待機中.....")
 	if err := waitServerRunning(m, serverID, serverAnsibleWaitTimeout, serverAnsibleWaitPollInterval); err != nil {
 		return err
 	}
@@ -57,11 +58,10 @@ func maybeApplyServerAnsiblePlaybook(m *client.MarmotEndpoint, server api.Server
 		return err
 	}
 
+	fmt.Fprintln(os.Stderr, "playbook 適用開始.....")
 	if err := runServerAnsiblePlaybook(playbookPath, targetAddress, privateKeyPath); err != nil {
 		return err
 	}
-
-	fmt.Fprintf(os.Stderr, "ansible-playbook applied successfully: server=%s address=%s playbook=%s\n", serverID, targetAddress, playbookPath)
 	return nil
 }
 
@@ -182,9 +182,6 @@ func waitServerAnsiblePingReady(targetAddress, privateKeyPath string, timeout, i
 			lastErr = err
 		}
 		if time.Now().After(deadline) {
-			if lastErr == nil {
-				lastErr = fmt.Errorf("ansible ping failed")
-			}
 			return fmt.Errorf("timeout waiting for ansible ping to %s: %w", targetAddress, lastErr)
 		}
 		time.Sleep(interval)
@@ -221,13 +218,10 @@ func runServerAnsiblePlaybook(playbookPath, targetAddress, privateKeyPath string
 	}
 	cmd := serverAnsibleExecCommand("ansible-playbook", args...)
 	cmd.Env = serverAnsibleCommandEnv()
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		trimmed := strings.TrimSpace(string(output))
-		if trimmed == "" {
-			return fmt.Errorf("ansible-playbook failed: %w", err)
-		}
-		return fmt.Errorf("ansible-playbook failed: %w: %s", err, trimmed)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("ansible-playbook failed: %w", err)
 	}
 	return nil
 }

--- a/cmd/mactl/cmd/server_ansible.go
+++ b/cmd/mactl/cmd/server_ansible.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/client"
+	"github.com/takara9/marmot/pkg/db"
+)
+
+const (
+	serverAnsibleDefaultUser       = "root"
+	serverAnsibleWaitTimeout       = 10 * time.Minute
+	serverAnsibleWaitPollInterval  = 5 * time.Second
+	serverAnsiblePingTimeout       = 3 * time.Minute
+	serverAnsiblePingPollInterval  = 5 * time.Second
+	serverAnsiblePrivateKeyEnvName = "MARMOT_ANSIBLE_PRIVATE_KEY"
+)
+
+var serverAnsibleExecCommand = exec.Command
+
+func maybeApplyServerAnsiblePlaybook(m *client.MarmotEndpoint, server api.Server, createResponse []byte) error {
+	if server.Spec.AnsiblePlaybook == nil || strings.TrimSpace(*server.Spec.AnsiblePlaybook) == "" {
+		return nil
+	}
+
+	targetAddress, err := validateServerAnsiblePlaybookSpec(server)
+	if err != nil {
+		return err
+	}
+
+	serverID, err := extractSuccessID(createResponse)
+	if err != nil {
+		return fmt.Errorf("failed to parse create response id for ansible apply: %w", err)
+	}
+
+	if err := waitServerRunning(m, serverID, serverAnsibleWaitTimeout, serverAnsibleWaitPollInterval); err != nil {
+		return err
+	}
+
+	playbookPath, err := resolveServerAnsiblePlaybookPath(*server.Spec.AnsiblePlaybook)
+	if err != nil {
+		return err
+	}
+	privateKeyPath, err := resolveServerAnsiblePrivateKeyPath()
+	if err != nil {
+		return err
+	}
+
+	if err := waitServerAnsiblePingReady(targetAddress, privateKeyPath, serverAnsiblePingTimeout, serverAnsiblePingPollInterval); err != nil {
+		return err
+	}
+
+	if err := runServerAnsiblePlaybook(playbookPath, targetAddress, privateKeyPath); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "ansible-playbook applied successfully: server=%s address=%s playbook=%s\n", serverID, targetAddress, playbookPath)
+	return nil
+}
+
+func validateServerAnsiblePlaybookSpec(server api.Server) (string, error) {
+	if server.Spec.AnsiblePlaybook == nil || strings.TrimSpace(*server.Spec.AnsiblePlaybook) == "" {
+		return "", nil
+	}
+	if server.Spec.NetworkInterface == nil || len(*server.Spec.NetworkInterface) == 0 {
+		return "", fmt.Errorf("spec.ansible-playbook requires spec.networkInterface with host-bridge and static address")
+	}
+	for _, nic := range *server.Spec.NetworkInterface {
+		if strings.TrimSpace(nic.Networkname) != "host-bridge" {
+			continue
+		}
+		if nic.Address == nil || strings.TrimSpace(*nic.Address) == "" {
+			return "", fmt.Errorf("spec.ansible-playbook requires host-bridge address to be set")
+		}
+		return strings.TrimSpace(*nic.Address), nil
+	}
+	return "", fmt.Errorf("spec.ansible-playbook can be used only when host-bridge is specified in spec.networkInterface")
+}
+
+func extractSuccessID(body []byte) (string, error) {
+	var data map[string]any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return "", err
+	}
+	id := strings.TrimSpace(fmt.Sprint(data["id"]))
+	if id == "" || id == "<nil>" {
+		return "", fmt.Errorf("id is empty")
+	}
+	return id, nil
+}
+
+func waitServerRunning(m *client.MarmotEndpoint, serverID string, timeout, interval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		body, _, err := m.GetServerById(serverID)
+		if err == nil {
+			var srv api.Server
+			if err := json.Unmarshal(body, &srv); err == nil {
+				if srv.Status != nil {
+					if srv.Status.StatusCode == db.SERVER_RUNNING {
+						return nil
+					}
+					if srv.Status.StatusCode == db.SERVER_ERROR {
+						msg := ""
+						if srv.Status.Message != nil {
+							msg = strings.TrimSpace(*srv.Status.Message)
+						}
+						if msg == "" {
+							msg = "server status became ERROR"
+						}
+						return fmt.Errorf("server %s is ERROR before ansible apply: %s", serverID, msg)
+					}
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for server %s to become RUNNING", serverID)
+		}
+		time.Sleep(interval)
+	}
+}
+
+func resolveServerAnsiblePlaybookPath(path string) (string, error) {
+	p := strings.TrimSpace(path)
+	if p == "" {
+		return "", fmt.Errorf("spec.ansible-playbook is empty")
+	}
+	if !filepath.IsAbs(p) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		p = filepath.Join(cwd, p)
+	}
+	if info, err := os.Stat(p); err != nil {
+		return "", fmt.Errorf("ansible playbook file is not found: %s", p)
+	} else if info.IsDir() {
+		return "", fmt.Errorf("ansible playbook path is a directory: %s", p)
+	}
+	return p, nil
+}
+
+func resolveServerAnsiblePrivateKeyPath() (string, error) {
+	if p := strings.TrimSpace(os.Getenv(serverAnsiblePrivateKeyEnvName)); p != "" {
+		if _, err := os.Stat(p); err != nil {
+			return "", fmt.Errorf("%s points to missing key: %s", serverAnsiblePrivateKeyEnvName, p)
+		}
+		return p, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	candidates := []string{
+		filepath.Join(home, ".ssh", "id_ed25519"),
+		filepath.Join(home, ".ssh", "id_rsa"),
+		filepath.Join(home, ".ssh", "id_ecdsa"),
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("no private key found; set %s or place key under ~/.ssh", serverAnsiblePrivateKeyEnvName)
+}
+
+func waitServerAnsiblePingReady(targetAddress, privateKeyPath string, timeout, interval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		if err := runServerAnsiblePing(targetAddress, privateKeyPath); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			if lastErr == nil {
+				lastErr = fmt.Errorf("ansible ping failed")
+			}
+			return fmt.Errorf("timeout waiting for ansible ping to %s: %w", targetAddress, lastErr)
+		}
+		time.Sleep(interval)
+	}
+}
+
+func runServerAnsiblePing(targetAddress, privateKeyPath string) error {
+	args := []string{
+		"all",
+		"-i", targetAddress + ",",
+		"-m", "ping",
+		"-u", serverAnsibleDefaultUser,
+		"--private-key", privateKeyPath,
+	}
+	cmd := serverAnsibleExecCommand("ansible", args...)
+	cmd.Env = serverAnsibleCommandEnv()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(output))
+		if trimmed == "" {
+			return fmt.Errorf("ansible ping failed: %w", err)
+		}
+		return fmt.Errorf("ansible ping failed: %w: %s", err, trimmed)
+	}
+	return nil
+}
+
+func runServerAnsiblePlaybook(playbookPath, targetAddress, privateKeyPath string) error {
+	args := []string{
+		"-i", targetAddress + ",",
+		playbookPath,
+		"--private-key", privateKeyPath,
+		"-u", serverAnsibleDefaultUser,
+	}
+	cmd := serverAnsibleExecCommand("ansible-playbook", args...)
+	cmd.Env = serverAnsibleCommandEnv()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(output))
+		if trimmed == "" {
+			return fmt.Errorf("ansible-playbook failed: %w", err)
+		}
+		return fmt.Errorf("ansible-playbook failed: %w: %s", err, trimmed)
+	}
+	return nil
+}
+
+func serverAnsibleCommandEnv() []string {
+	env := os.Environ()
+	if _, err := os.Stat("ansible.cfg"); err == nil {
+		return env
+	}
+	return append(env,
+		"ANSIBLE_HOST_KEY_CHECKING=False",
+		"ANSIBLE_DEPRECATION_WARNINGS=False",
+		"ANSIBLE_SSH_ARGS=-o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes",
+	)
+}

--- a/cmd/mactl/cmd/server_ansible_test.go
+++ b/cmd/mactl/cmd/server_ansible_test.go
@@ -1,0 +1,217 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestValidateServerAnsiblePlaybookSpec(t *testing.T) {
+	playbook := "playbook/setup.yaml"
+	ip := "192.168.1.64"
+
+	tests := []struct {
+		name    string
+		server  api.Server
+		wantIP  string
+		wantErr string
+	}{
+		{
+			name:   "playbook not specified",
+			server: api.Server{Spec: api.ServerSpec{}},
+			wantIP: "",
+		},
+		{
+			name: "host-bridge with address",
+			server: api.Server{Spec: api.ServerSpec{
+				AnsiblePlaybook: &playbook,
+				NetworkInterface: &[]api.NetworkInterface{{
+					Networkname: "host-bridge",
+					Address:     &ip,
+				}},
+			}},
+			wantIP: ip,
+		},
+		{
+			name: "missing network interface",
+			server: api.Server{Spec: api.ServerSpec{
+				AnsiblePlaybook: &playbook,
+			}},
+			wantErr: "requires spec.networkInterface",
+		},
+		{
+			name: "host-bridge without address",
+			server: api.Server{Spec: api.ServerSpec{
+				AnsiblePlaybook: &playbook,
+				NetworkInterface: &[]api.NetworkInterface{{
+					Networkname: "host-bridge",
+				}},
+			}},
+			wantErr: "requires host-bridge address",
+		},
+		{
+			name: "host-bridge missing",
+			server: api.Server{Spec: api.ServerSpec{
+				AnsiblePlaybook: &playbook,
+				NetworkInterface: &[]api.NetworkInterface{{
+					Networkname: "default",
+					Address:     &ip,
+				}},
+			}},
+			wantErr: "only when host-bridge is specified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIP, err := validateServerAnsiblePlaybookSpec(tt.server)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateServerAnsiblePlaybookSpec() unexpected err: %v", err)
+				}
+				if gotIP != tt.wantIP {
+					t.Fatalf("validateServerAnsiblePlaybookSpec() ip = %q, want %q", gotIP, tt.wantIP)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateServerAnsiblePlaybookSpec() expected error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateServerAnsiblePlaybookSpec() err = %q, want contains %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestExtractSuccessID(t *testing.T) {
+	id, err := extractSuccessID([]byte(`{"id":"s1234","message":"ok"}`))
+	if err != nil {
+		t.Fatalf("extractSuccessID() unexpected err: %v", err)
+	}
+	if id != "s1234" {
+		t.Fatalf("extractSuccessID() = %q, want s1234", id)
+	}
+
+	if _, err := extractSuccessID([]byte(`{"message":"ok"}`)); err == nil {
+		t.Fatalf("extractSuccessID() expected error for missing id")
+	}
+}
+
+func TestResolveServerAnsiblePrivateKeyPathWithEnv(t *testing.T) {
+	tmp := t.TempDir()
+	keyPath := filepath.Join(tmp, "id_test")
+	if err := os.WriteFile(keyPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("WriteFile() failed: %v", err)
+	}
+
+	old := os.Getenv(serverAnsiblePrivateKeyEnvName)
+	t.Cleanup(func() {
+		_ = os.Setenv(serverAnsiblePrivateKeyEnvName, old)
+	})
+	if err := os.Setenv(serverAnsiblePrivateKeyEnvName, keyPath); err != nil {
+		t.Fatalf("Setenv() failed: %v", err)
+	}
+
+	got, err := resolveServerAnsiblePrivateKeyPath()
+	if err != nil {
+		t.Fatalf("resolveServerAnsiblePrivateKeyPath() unexpected err: %v", err)
+	}
+	if got != keyPath {
+		t.Fatalf("resolveServerAnsiblePrivateKeyPath() = %q, want %q", got, keyPath)
+	}
+}
+
+func TestServerAnsibleCommandEnvWithoutConfig(t *testing.T) {
+	tmp := t.TempDir()
+	cwd, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("Chdir() failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	env := serverAnsibleCommandEnv()
+	if !containsPrefix(env, "ANSIBLE_HOST_KEY_CHECKING=False") {
+		t.Fatalf("serverAnsibleCommandEnv() should include ANSIBLE_HOST_KEY_CHECKING when ansible.cfg is absent")
+	}
+}
+
+func TestServerAnsibleCommandEnvWithConfig(t *testing.T) {
+	tmp := t.TempDir()
+	cwd, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("Chdir() failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	if err := os.WriteFile("ansible.cfg", []byte("[defaults]\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() failed: %v", err)
+	}
+	env := serverAnsibleCommandEnv()
+	if containsPrefix(env, "ANSIBLE_HOST_KEY_CHECKING=False") {
+		t.Fatalf("serverAnsibleCommandEnv() must not inject ansible env vars when ansible.cfg exists")
+	}
+}
+
+func containsPrefix(items []string, prefix string) bool {
+	for _, item := range items {
+		if strings.HasPrefix(item, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestResolveServerAnsiblePlaybookPathRelative(t *testing.T) {
+	tmp := t.TempDir()
+	cwd, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("Chdir() failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	relPath := filepath.Join("playbook", "setup.yaml")
+	if err := os.MkdirAll(filepath.Dir(relPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() failed: %v", err)
+	}
+	if err := os.WriteFile(relPath, []byte("---\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() failed: %v", err)
+	}
+
+	path, err := resolveServerAnsiblePlaybookPath(relPath)
+	if err != nil {
+		t.Fatalf("resolveServerAnsiblePlaybookPath() unexpected err: %v", err)
+	}
+	if path != filepath.Join(tmp, relPath) {
+		t.Fatalf("resolveServerAnsiblePlaybookPath() = %q, want %q", path, filepath.Join(tmp, relPath))
+	}
+}
+
+func TestValidateServerAnsiblePlaybookSpecUsesStringPtr(t *testing.T) {
+	playbook := util.StringPtr("playbook/setup.yaml")
+	ip := util.StringPtr("192.168.1.64")
+	server := api.Server{Spec: api.ServerSpec{
+		AnsiblePlaybook: playbook,
+		NetworkInterface: &[]api.NetworkInterface{{
+			Networkname: "host-bridge",
+			Address:     ip,
+		}},
+	}}
+	got, err := validateServerAnsiblePlaybookSpec(server)
+	if err != nil {
+		t.Fatalf("validateServerAnsiblePlaybookSpec() unexpected err: %v", err)
+	}
+	if got != *ip {
+		t.Fatalf("validateServerAnsiblePlaybookSpec() = %q, want %q", got, *ip)
+	}
+}

--- a/cmd/mactl/cmd/server_create.go
+++ b/cmd/mactl/cmd/server_create.go
@@ -140,6 +140,9 @@ var serverCreateCmd = &cobra.Command{
 			fmt.Println("CreateServer", "err", err)
 			return err
 		}
+		if err := maybeApplyServerAnsiblePlaybook(m, virtualServer, byteBody); err != nil {
+			return err
+		}
 
 		switch outputStyle {
 		case "text":

--- a/cmd/mactl/cmd/server_create.go
+++ b/cmd/mactl/cmd/server_create.go
@@ -140,9 +140,6 @@ var serverCreateCmd = &cobra.Command{
 			fmt.Println("CreateServer", "err", err)
 			return err
 		}
-		if err := maybeApplyServerAnsiblePlaybook(m, virtualServer, byteBody); err != nil {
-			return err
-		}
 
 		switch outputStyle {
 		case "text":
@@ -153,10 +150,16 @@ var serverCreateCmd = &cobra.Command{
 			}
 			serverMap := data.(map[string]interface{})
 			fmt.Printf("サーバーの作成要求が受け入れられました。ID: %v\n", serverMap["id"])
+			if err := maybeApplyServerAnsiblePlaybook(m, virtualServer, byteBody); err != nil {
+				return err
+			}
 			return nil
 
 		case "json":
 			fmt.Println(string(byteBody))
+			if err := maybeApplyServerAnsiblePlaybook(m, virtualServer, byteBody); err != nil {
+				return err
+			}
 			return nil
 
 		case "yaml":
@@ -171,6 +174,9 @@ var serverCreateCmd = &cobra.Command{
 				return err
 			}
 			fmt.Println(string(yamlBytes))
+			if err := maybeApplyServerAnsiblePlaybook(m, virtualServer, byteBody); err != nil {
+				return err
+			}
 			return nil
 
 		default:

--- a/cmd/mactl/testdata/test-server-38-ansible-playbook.yaml
+++ b/cmd/mactl/testdata/test-server-38-ansible-playbook.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Server
+metadata:
+    name: test-server-38
+    comment: "Issue #421 sample: apply ansible-playbook after server boot"
+spec:
+    cpu: 1
+    memory: 1024
+    osVariant: ubuntu24.04
+    auth:
+        url: https://github.com/takara9.keys
+    ansible-playbook: playbook/setup.yaml
+    networkInterface:
+        - networkname: "host-bridge"
+          address: "192.168.1.64"
+          netmasklen: 24
+          routes:
+            - to: "default"
+              via: "192.168.1.1"
+          nameservers:
+            addresses:
+                - 192.168.1.9
+                - 8.8.8.8
+                - 8.8.4.4
+            search:
+                - labo.local
+                - lab.local


### PR DESCRIPTION
## 概要
Issue #421 対応として、Server マニフェストに spec.ansible-playbook を追加し、VM 起動後に mactl から ansible-playbook を自動適用できるようにしました。  
あわせて、利用手順が分かるサンプルマニフェストとドキュメントを追加しました。

## 背景
Server 作成直後に初期設定を自動化したい要望があり、spec.ansible-playbook 指定時に以下を満たす仕組みが必要でした。
- VM が ansible を受け付け可能になるまで待機
- host-bridge の固定 IP を接続先として利用
- mactl 実行ユーザーの秘密鍵を利用
- カレントディレクトリに ansible.cfg が無い場合の安全な実行設定

## 変更内容
- API モデルに spec.ansible-playbook を追加
  - marmot-api-v1.go
  - marmot-api-v1.yaml
- mactl 側に Server 作成後の ansible 自動適用処理を追加
  - server_ansible.go
- Server 作成経路にフックを追加
  - create.go
  - apply.go
  - server_create.go
- ユニットテストを追加
  - server_ansible_test.go
- Issue #421 用サンプルマニフェストを追加
  - test-server-38-ansible-playbook.yaml
- 利用手順ドキュメントを追記
  - README.md
  - README.md

## 実装仕様
- spec.ansible-playbook が未指定の場合は従来動作
- 指定時は以下を実施
- host-bridge と固定 IP の事前バリデーション
- Server が RUNNING になるまでポーリング
- ansible ping で応答確認後に ansible-playbook を実行
- 秘密鍵は次の順で解決
- 環境変数 MARMOT_ANSIBLE_PRIVATE_KEY
- ~/.ssh/id_ed25519
- ~/.ssh/id_rsa
- ~/.ssh/id_ecdsa
- カレントディレクトリに ansible.cfg が無い場合のみ次を自動付与
- ANSIBLE_HOST_KEY_CHECKING=False
- ANSIBLE_DEPRECATION_WARNINGS=False
- ANSIBLE_SSH_ARGS=-o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes

## テスト
- 実施
- go test ./cmd/mactl/cmd/... : 成功
- gofmt 対象ファイルに適用済み
- 補足
- go test ./... は既存の統合テスト環境依存で失敗
- Docker 3379 ポート競合
- root 権限前提の LVM/libvirt テスト
- 今回変更箇所の単体テストは成功

## 互換性と影響範囲
- 既存マニフェストへの破壊的変更なし
- spec.ansible-playbook を使う場合のみ新機能が有効
- mactl の Server 作成系コマンドにのみ追加動作が発生

## 確認手順
- サンプル playbook を配置
- 例: playbook/setup.yaml
- 必要に応じて鍵を指定
- export MARMOT_ANSIBLE_PRIVATE_KEY=$HOME/.ssh/id_ed25519
- サンプルを作成
- mactl server create -f test-server-38-ansible-playbook.yaml
- 期待結果
- Server 作成後、ansible ping 成功を待って ansible-playbook が実行される