### PR TITLE
VPN-GWデグレ対応

### DIFF
--- a/pkg/controller/vpn-gateway-ansible.go
+++ b/pkg/controller/vpn-gateway-ansible.go
@@ -88,7 +88,7 @@ func renderVpnGatewayPlaybook(playbookPath string, targetIP string, vpnGateway a
 	if err != nil {
 		return err
 	}
-	if override, readErr := os.ReadFile(marmotd.GatewayPlaybookTemplatePath()); readErr == nil && strings.TrimSpace(string(override)) != "" {
+	if override, readErr := os.ReadFile(marmotd.VpnGatewayPlaybookTemplatePath()); readErr == nil && strings.TrimSpace(string(override)) != "" {
 		tmpl, err = template.New("vpn-gateway-playbook").Parse(string(override))
 		if err != nil {
 			return err

--- a/pkg/marmotd/gateway_runtime_assets.go
+++ b/pkg/marmotd/gateway_runtime_assets.go
@@ -130,6 +130,10 @@ func GatewayPlaybookTemplatePath() string {
 	return filepath.Join(gatewayPlaybookInstallDir, "gateway-iptables.yaml.tmpl")
 }
 
+func VpnGatewayPlaybookTemplatePath() string {
+	return filepath.Join(gatewayPlaybookInstallDir, "vpn-gateway-openvpn.yaml.tmpl")
+}
+
 func LoadBalancerPlaybookTemplatePath() string {
 	return filepath.Join(gatewayPlaybookInstallDir, "load-balancer-haproxy.yaml.tmpl")
 }

--- a/pkg/marmotd/gateway_runtime_assets_test.go
+++ b/pkg/marmotd/gateway_runtime_assets_test.go
@@ -7,6 +7,20 @@ import (
 	"testing"
 )
 
+func TestVpnGatewayPlaybookTemplatePath(t *testing.T) {
+	oldInstallDir := gatewayPlaybookInstallDir
+	t.Cleanup(func() {
+		gatewayPlaybookInstallDir = oldInstallDir
+	})
+
+	gatewayPlaybookInstallDir = "/tmp/marmot-playbooks"
+	got := VpnGatewayPlaybookTemplatePath()
+	want := filepath.Join("/tmp/marmot-playbooks", "vpn-gateway-openvpn.yaml.tmpl")
+	if got != want {
+		t.Fatalf("VpnGatewayPlaybookTemplatePath() = %q, want %q", got, want)
+	}
+}
+
 func TestEnsureGatewayRuntimeAssets_CreatesKeysAndSyncsPlaybooks(t *testing.T) {
 	oldKeyDir := gatewayKeyDir
 	oldSourceDir := gatewayPlaybookSourceDir


### PR DESCRIPTION
## 概要
VPN Gateway の Ansible 適用時に、`can't evaluate field Ports in type controller.vpnGatewayPlaybookData` で失敗するデグレを修正しました。

## 背景 / 原因
VPN Gateway の playbook レンダリングで、VPN 用ではなく Gateway 用のテンプレート上書きパスを参照していました。  
その結果、Gateway テンプレートが読み込まれ、VPN 側データ構造に存在しない `.Ports` を評価して失敗していました。

## 変更内容
- VPN 用のテンプレートパス accessor を追加
- VPN Gateway のレンダラが VPN 専用テンプレートパスを参照するよう修正
- パス解決の単体テストを追加（回帰防止）

## 動作確認
- `go test ./pkg/marmotd -run "Test(EnsureGatewayRuntimeAssets|VpnGatewayPlaybookTemplatePath)"`
- `go test ./pkg/controller -run "Test.*Vpn|Test.*Gateway"`

いずれも成功。

## 影響範囲
- 影響対象: VPN Gateway の playbook テンプレート解決ロジック
- 非影響: Gateway / LB / NLB の既存テンプレート解決ロジック

## 期待される効果
- `mactl get vpngw ...` で FAILED になっていた `.Ports` エラーが解消され、VPN Gateway の構成適用が正常に進むようになります。