### PR TITLE
認証鍵設定対象の変更

### DIFF
--- a/api/marmot-api-v1.go
+++ b/api/marmot-api-v1.go
@@ -105,10 +105,11 @@ type ApplicationLoadBalancerSpec struct {
 
 // Auth defines model for Auth.
 type Auth struct {
-	PublicKey    *string `json:"publicKey,omitempty"`
-	RootPassword *string `json:"rootPassword,omitempty"`
-	Url          *string `json:"url,omitempty"`
-	User         *string `json:"user,omitempty"`
+	PublicKey    *string   `json:"publicKey,omitempty"`
+	RootPassword *string   `json:"rootPassword,omitempty"`
+	Url          *string   `json:"url,omitempty"`
+	User         *string   `json:"user,omitempty"`
+	Users        *[]string `json:"users,omitempty"`
 }
 
 // Error defines model for Error.

--- a/api/marmot-api-v1.yaml
+++ b/api/marmot-api-v1.yaml
@@ -1980,6 +1980,10 @@ components:
           type: string
         user:
           type: string
+        users:
+          type: array
+          items:
+            type: string
         rootPassword:
           type: string
     HostStatus:

--- a/pkg/marmotd/cloud-init.go
+++ b/pkg/marmotd/cloud-init.go
@@ -10,8 +10,8 @@ import (
 )
 
 // GenerateCloudInitISO generates a cloud-init ISO with password and SSH key settings.
-// username が空の場合はデフォルトユーザーに設定し、指定がある場合は新規ユーザーを作成します。
-func GenerateCloudInitISO(path, password, sshKey, username string) (string, error) {
+// usernames が空の場合はデフォルトユーザーに設定し、指定がある場合は各ユーザーを作成します。
+func GenerateCloudInitISO(path, password, sshKey string, usernames []string) (string, error) {
 	// Create temporary directory for cloud-init files
 	tempDir, err := os.MkdirTemp("", "cloud-init-")
 	if err != nil {
@@ -20,28 +20,7 @@ func GenerateCloudInitISO(path, password, sshKey, username string) (string, erro
 	defer os.RemoveAll(tempDir)
 
 	// Generate user-data
-	var userData string
-	if username != "" {
-		userData = fmt.Sprintf(`#cloud-config
-users:
-  - name: %s
-    shell: /bin/bash
-    sudo: ALL=(ALL) NOPASSWD:ALL
-    ssh_authorized_keys:
-%s
-chpasswd:
-  list:
-    - %s:%s
-  expire: False
-`, username, formatSSHKeys(sshKey, "      "), username, password)
-	} else {
-		userData = fmt.Sprintf(`#cloud-config
-password: %s
-chpasswd: { expire: False }
-ssh_authorized_keys:
-%s
-`, password, formatSSHKeys(sshKey, "  "))
-	}
+	userData := buildCloudInitUserData(password, sshKey, usernames)
 
 	userDataPath := filepath.Join(tempDir, "user-data")
 	if err := os.WriteFile(userDataPath, []byte(userData), 0644); err != nil {
@@ -96,4 +75,47 @@ func formatSSHKeys(sshKey, indent string) string {
 		}
 	}
 	return strings.Join(result, "\n")
+}
+
+func buildCloudInitUserData(password, sshKey string, usernames []string) string {
+	users := normalizeUsernames(usernames)
+	if len(users) == 0 {
+		return fmt.Sprintf(`#cloud-config
+password: %s
+chpasswd: { expire: False }
+ssh_authorized_keys:
+%s
+`, password, formatSSHKeys(sshKey, "  "))
+	}
+
+	var builder strings.Builder
+	builder.WriteString("#cloud-config\n")
+	builder.WriteString("users:\n")
+	for _, username := range users {
+		builder.WriteString(fmt.Sprintf("  - name: %s\n", username))
+		builder.WriteString("    shell: /bin/bash\n")
+		builder.WriteString("    sudo: ALL=(ALL) NOPASSWD:ALL\n")
+		builder.WriteString("    ssh_authorized_keys:\n")
+		builder.WriteString(formatSSHKeys(sshKey, "      "))
+		builder.WriteString("\n")
+	}
+	if password != "" {
+		builder.WriteString("chpasswd:\n")
+		builder.WriteString("  list:\n")
+		for _, username := range users {
+			builder.WriteString(fmt.Sprintf("    - %s:%s\n", username, password))
+		}
+		builder.WriteString("  expire: False\n")
+	}
+	return builder.String()
+}
+
+func normalizeUsernames(usernames []string) []string {
+	normalized := make([]string, 0, len(usernames))
+	for _, username := range usernames {
+		if trimmed := strings.TrimSpace(username); trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	return normalized
 }

--- a/pkg/marmotd/cloud-init_test.go
+++ b/pkg/marmotd/cloud-init_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Cloud-InitISO作成テスト", Ordered, func() {
 		path := "/var/lib/marmot/isos/test-server"
 
 		It("モックサーバー用etcdの起動", func() {
-			isoFile, err = marmotd.GenerateCloudInitISO(path, password, sshKey, "")
+			isoFile, err = marmotd.GenerateCloudInitISO(path, password, sshKey, nil)
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println("ISO FILE=", isoFile)
 		})

--- a/pkg/marmotd/cloud-init_userdata_test.go
+++ b/pkg/marmotd/cloud-init_userdata_test.go
@@ -1,0 +1,30 @@
+package marmotd
+
+import "testing"
+
+func TestBuildCloudInitUserDataMultipleUsers(t *testing.T) {
+	got := buildCloudInitUserData("12345", "ssh-rsa AAAA\nssh-ed25519 BBBB", []string{"root", "ubuntu"})
+	want := `#cloud-config
+users:
+  - name: root
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ssh-rsa AAAA
+      - ssh-ed25519 BBBB
+  - name: ubuntu
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ssh-rsa AAAA
+      - ssh-ed25519 BBBB
+chpasswd:
+  list:
+    - root:12345
+    - ubuntu:12345
+  expire: False
+`
+	if got != want {
+		t.Fatalf("buildCloudInitUserData() = %q, want %q", got, want)
+	}
+}

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -157,6 +157,9 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 		slog.Error("GetServerById()", "err", err)
 		return "", err
 	}
+	if err := validateServerAuthSpec(serverConfig.Spec.Auth); err != nil {
+		return "", err
+	}
 
 	assignedNodeName := strings.TrimSpace(m.NodeName)
 	if serverConfig.Metadata.NodeName != nil {
@@ -593,14 +596,17 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 
 	var password string
 	var sshKey string
-	var username string
+	var usernames []string
 
 	if serverConfig.Spec.Auth != nil {
 		if serverConfig.Spec.Auth.RootPassword != nil {
 			password = *serverConfig.Spec.Auth.RootPassword
 		}
 		if serverConfig.Spec.Auth.User != nil {
-			username = *serverConfig.Spec.Auth.User
+			usernames = append(usernames, *serverConfig.Spec.Auth.User)
+		}
+		if serverConfig.Spec.Auth.Users != nil {
+			usernames = append(usernames, (*serverConfig.Spec.Auth.Users)...)
 		}
 		if serverConfig.Spec.Auth.Url != nil {
 			keys, err := FetchPublicKeys(*serverConfig.Spec.Auth.Url)
@@ -614,7 +620,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 		}
 	}
 
-	isoPath, err := GenerateCloudInitISO(path, password, sshKey, username)
+	isoPath, err := GenerateCloudInitISO(path, password, sshKey, usernames)
 	if err != nil {
 		slog.Error("GenerateCloudInitISO()", "err", err)
 		return "", err
@@ -813,6 +819,26 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 	}
 
 	return id, nil
+}
+
+func validateServerAuthSpec(auth *api.Auth) error {
+	if auth == nil {
+		return nil
+	}
+	if auth.User != nil && auth.Users != nil && len(*auth.Users) > 0 {
+		return fmt.Errorf("spec.auth.user and spec.auth.users cannot be used together")
+	}
+	if auth.User != nil && strings.TrimSpace(*auth.User) == "" {
+		return fmt.Errorf("spec.auth.user must not be empty")
+	}
+	if auth.Users != nil {
+		for _, username := range *auth.Users {
+			if strings.TrimSpace(username) == "" {
+				return fmt.Errorf("spec.auth.users must not contain empty values")
+			}
+		}
+	}
+	return nil
 }
 
 func appendVPNRouteIfEnabled(nic *api.NetworkInterface, vnet *api.VirtualNetwork) {

--- a/pkg/marmotd/server_auth_test.go
+++ b/pkg/marmotd/server_auth_test.go
@@ -1,0 +1,30 @@
+package marmotd
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestValidateServerAuthSpecRejectsUserAndUsersTogether(t *testing.T) {
+	user := util.StringPtr("root")
+	users := &[]string{"root", "ubuntu"}
+	auth := &api.Auth{User: user, Users: users}
+
+	if err := validateServerAuthSpec(auth); err == nil {
+		t.Fatalf("validateServerAuthSpec() expected error for user/users combination")
+	}
+}
+
+func TestValidateServerAuthSpecRejectsEmptyUsernames(t *testing.T) {
+	user := util.StringPtr("   ")
+	users := &[]string{"root", ""}
+
+	if err := validateServerAuthSpec(&api.Auth{User: user}); err == nil {
+		t.Fatalf("validateServerAuthSpec() expected error for empty user")
+	}
+	if err := validateServerAuthSpec(&api.Auth{Users: users}); err == nil {
+		t.Fatalf("validateServerAuthSpec() expected error for empty users entry")
+	}
+}


### PR DESCRIPTION
# Support Multiple Users in SSH Key Configuration

## Overview
このPRは issue #431 に対応し、Server マニフェストで複数のユーザーに対して公開鍵を配置できるようにします。

従来の `spec.auth.user` (単一ユーザー) に加えて、新たに `spec.auth.users` (複数ユーザー配列) をサポートします。

## Changes

### API & Schema
- **api/marmot-api-v1.go**: `Auth` struct に `Users *[]string` フィールドを追加
- **api/marmot-api-v1.yaml**: OpenAPI スキーマに `users` 配列プロパティを追加

### Server Creation Logic
- **pkg/marmotd/server.go**:
  - `validateServerAuthSpec()` 関数を追加し、`spec.auth.user` と `spec.auth.users` の併用を拒否
  - 複数ユーザーを `[]string` で集約し cloud-init 生成に渡す

### Cloud-Init Generation
- **pkg/marmotd/cloud-init.go**:
  - `GenerateCloudInitISO()` シグネチャを `username string` から `usernames []string` に変更
  - `buildCloudInitUserData()` ヘルパー関数を追加
    - ユーザーが指定されない場合は従来通りのデフォルトユーザー設定
    - 複数ユーザー指定時は各ユーザーに同じ SSH 公開鍵を設定
    - 各ユーザーに `/bin/bash` と全権限の sudo アクセスを付与

### Tests
- **pkg/marmotd/server_auth_test.go**: 
  - `TestValidateServerAuthSpecRejectsUserAndUsersTogether()`: user と users 併用の拒否
  - `TestValidateServerAuthSpecRejectsEmptyUsernames()`: 空の username の拒否
- **pkg/marmotd/cloud-init_userdata_test.go**: 
  - `TestBuildCloudInitUserDataMultipleUsers()`: 複数ユーザーの user-data 生成確認
- **pkg/marmotd/cloud-init_test.go**: 既存 Ginkgo テストを `nil` usernames で実行

## Behavior

### 既存互換性
- `spec.auth.user` のみ指定: 従来通り単一ユーザーで動作
- `spec.auth.users` 指定なし: デフォルトユーザー (cloud-init の標準ユーザー) に公開鍵を設定

### 新機能
```yaml
spec:
  auth:
    url: https://github.com/takara9.keys
    users:
      - root
      - ubuntu
```

上記の場合、`root` と `ubuntu` の両ユーザーに同じ公開鍵が配置されます。

### エラー処理
- `spec.auth.user` と `spec.auth.users` を同時に指定: エラー で拒否
- `spec.auth.user` または `spec.auth.users` に空文字列: エラーで拒否

## Testing
```bash
# Auth validation tests
go test ./pkg/marmotd -run 'TestValidateServerAuthSpec'

# Cloud-init user-data generation test
go test ./pkg/marmotd -run 'TestBuildCloudInitUserDataMultipleUsers'

# Existing server ansible tests (unaffected)
go test ./cmd/mactl/cmd -run 'TestValidateServerAnsiblePlaybookSpec'
```

## Breaking Changes
なし。`spec.auth.user` は引き続き利用可能で、既存マニフェストは変更不要です。

## Related
- Closes #431


