### PR TITLE
Fix/create image

### DIFF
--- a/pkg/controller/image-controller.go
+++ b/pkg/controller/image-controller.go
@@ -104,7 +104,13 @@ func (c *controller) imageControllerLoop() {
 			if err := c.ensureFollowerImagesWaiting(image); err != nil {
 				slog.Error("フォロワー用イメージエントリーの作成に失敗", "headImageId", image.Metadata.Id, "err", err)
 			}
-			if image.Spec.SourceUrl == nil && strings.TrimSpace(util.OrDefault(image.Spec.Qcow2Path, "")) != "" {
+			source := ""
+			if image.Metadata.Labels != nil {
+				source = db.GetImageSource(*image.Metadata.Labels)
+			}
+
+			// bootVolume 由来のイメージは、インポート済み扱いにせず必ずVMコピー処理へ進める。
+			if source != "bootVolume" && image.Spec.SourceUrl == nil && strings.TrimSpace(util.OrDefault(image.Spec.Qcow2Path, "")) != "" {
 				slog.Debug("インポート済みQCOW2イメージを利用可能に遷移", "image", image.Metadata.Name, "imageId", image.Metadata.Id)
 				c.marmot.Db.UpdateImageStatusMessage(image.Metadata.Id, db.IMAGE_AVAILABLE, "")
 				continue
@@ -112,7 +118,6 @@ func (c *controller) imageControllerLoop() {
 			c.marmot.Db.UpdateImageStatus(image.Metadata.Id, db.IMAGE_CREATING)
 			// ラベルの存在をチェック
 			if image.Metadata.Labels != nil {
-				source := db.GetImageSource(*image.Metadata.Labels)
 				if source == "bootVolume" {
 					slog.Debug("実行中VMからイメージの作成", "image", image.Metadata.Name, "source", "bootVolume")
 					serverId := db.GetImageServerID(*image.Metadata.Labels)

--- a/pkg/db/db-image.go
+++ b/pkg/db/db-image.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 	"time"
 
@@ -368,13 +367,9 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 	}
 	var img api.Image
 	if bootVol.Spec.Type != nil && *bootVol.Spec.Type == "qcow2" {
-		// イメージを書き込むディレクトリの作成
-		imageDir := fmt.Sprintf("/var/lib/marmot/images/%s", id)
-		if err := os.MkdirAll(imageDir, 0755); err != nil {
-			slog.Error("CreateImageFromVolume() failed to create image directory", "err", err, "imageDir", imageDir)
-			return api.Image{}, err
-		}
 		// イメージのqcow2ボリューム名を設定
+		// 実体ディレクトリの作成は、割り当てノードで実行されるコントローラー側で行う。
+		imageDir := fmt.Sprintf("/var/lib/marmot/images/%s", id)
 		imagePath := fmt.Sprintf("%s/osimage-%s.qcow2", imageDir, id)
 		img = api.Image{
 			ApiVersion: "v1",
@@ -382,7 +377,7 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 			Metadata: api.Metadata{
 				Name:     name,
 				Labels:   &labels,
-				NodeName: util.StringPtr("marmot1"),
+				NodeName: serverNodeName,
 				Id:       id,
 				Uuid:     util.StringPtr(uuidString),
 			},
@@ -413,7 +408,7 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 			Metadata: api.Metadata{
 				Name:     name,
 				Labels:   &labels,
-				NodeName: util.StringPtr("marmot1"),
+				NodeName: serverNodeName,
 				Id:       id,
 				Uuid:     util.StringPtr(uuidString),
 			},

--- a/pkg/db/db-image.go
+++ b/pkg/db/db-image.go
@@ -382,7 +382,7 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 			Metadata: api.Metadata{
 				Name:     name,
 				Labels:   &labels,
-				NodeName: serverNodeName,
+				NodeName: util.StringPtr("marmot1"),
 				Id:       id,
 				Uuid:     util.StringPtr(uuidString),
 			},
@@ -413,7 +413,7 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 			Metadata: api.Metadata{
 				Name:     name,
 				Labels:   &labels,
-				NodeName: serverNodeName,
+				NodeName: util.StringPtr("marmot1"),
 				Id:       id,
 				Uuid:     util.StringPtr(uuidString),
 			},

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -1291,6 +1293,19 @@ func (m *Marmot) MakeImageEntryFromRunningVMWithContext(ctx context.Context, ser
 	}
 
 	if bootVol.Spec.Type != nil && *bootVol.Spec.Type == "qcow2" {
+		if image.Spec.Qcow2Path == nil || strings.TrimSpace(*image.Spec.Qcow2Path) == "" {
+			err := fmt.Errorf("image qcow2 path is empty")
+			slog.Error("MakeImageEntryFromRunningVMWithContext()", "err", err, "serverId", serverId, "imageName", name)
+			return "", markFailed(err)
+		}
+
+		// イメージを作成するノード上で出力先ディレクトリを作成する。
+		imageDir := filepath.Dir(*image.Spec.Qcow2Path)
+		if err := os.MkdirAll(imageDir, 0755); err != nil {
+			slog.Error("os.MkdirAll()", "err", err, "imageDir", imageDir, "serverId", serverId, "imageName", name)
+			return "", markFailed(err)
+		}
+
 		// qcow2ファイルのコピー
 		slog.Debug("qcow2ファイルのコピー", "source path", *bootVol.Spec.Path, "destination path", *image.Spec.Qcow2Path)
 		if bootVol.Spec.Path != nil {


### PR DESCRIPTION
## 概要
Issue #434 の修正です。  
marmot2 など master 以外のノード上の実行中サーバーから createimage した際に、イメージが DELETED になる問題を解消します。

## 背景
再現パターン:
1. サーバーが marmot2 上で RUNNING
2. createimage を実行
3. image list で一度作成受付されるが、最終的に DELETED
4. image detail の message は missing image backing store

原因は主に 2 点でした。
1. VM 由来イメージが IMAGE_PENDING で「インポート済み QCOW2」と誤判定され、VM コピー処理をスキップして AVAILABLE に遷移していた
2. QCOW2 の出力先ディレクトリ作成タイミングが不適切で、実際のコピー実行ノード側で実体が揃わないケースがあった

## 変更内容
1. IMAGE_PENDING の分岐修正
- source=bootVolume のイメージは、インポート済みショートカットを使わず、必ず VM コピー処理へ進むように変更

2. 実行ノードでの出力先確保
- VM から QCOW2 をコピーする直前に、コピー実行ノード側で出力先ディレクトリを作成するよう変更
- QCOW2 パス未設定時のガードを追加

3. DB 登録時の副作用削減
- DB エントリー作成時にファイルシステムを先行操作しないように調整
- イメージ実体作成の責務を、実際に処理するノード側に寄せた

## 期待される動作
1. サーバーがどのノードにあっても、createimage はそのサーバー配置ノードで VM コピー処理が実行される
2. ヘッドイメージ作成後、フォロワー同期フローで他ノードへ同期される
3. 以前のような AVAILABLE 直後の backing store チェックによる DELETED 落ちを防止する

## 影響範囲
- イメージ作成コントローラーの IMAGE_PENDING ステータス遷移
- 実行中 VM からの QCOW2 作成処理
- DB 登録時のイメージ作成前処理

## 検証
実施済み:
1. 関連パッケージのビルド確認
2. 既存軽量テストの実行
- pkg/db
- pkg/marmotd（指定テスト）
- pkg/controller

補足:
- 本リポジトリでは Ginkgo の実行構成上、全体一括テストで RunSpecs 再実行制約に触れるケースがあるため、関連範囲を中心に確認

## 運用上の注意
この修正はコントローラー挙動を含むため、反映時はクラスタ内ノードでバージョンを揃えてデプロイする前提です。  
ノード間で旧版と新版が混在すると、状態遷移が不整合になる可能性があります。

## 関連
- Closes #434