### PR TITLE
イメージ表示の調整

### DIFF
--- a/cmd/mactl/cmd/get.go
+++ b/cmd/mactl/cmd/get.go
@@ -891,48 +891,68 @@ func outputServers(servers []api.Server) error {
 func outputImages(images []api.Image) error {
 	switch outputStyle {
 	case "text":
-		sort.SliceStable(images, func(i, j int) bool {
-			return creationTime(images[i].Status).Before(creationTime(images[j].Status))
-		})
-		fmt.Println("NAME            NODE-NAME  STATUS     ROLE   LV   QCOW2  AGE")
-		fmt.Println("----            ---------  ------     ----   --   -----  ---")
-		for _, img := range images {
-			nodeName := "-"
-			if img.Metadata.NodeName != nil && strings.TrimSpace(*img.Metadata.NodeName) != "" {
-				nodeName = strings.TrimSpace(*img.Metadata.NodeName)
-			}
-
-			status := "-"
-			if img.Status != nil && img.Status.Status != nil && strings.TrimSpace(*img.Status.Status) != "" {
-				status = strings.TrimSpace(*img.Status.Status)
-			}
-
-			role := "master"
-			if img.Metadata.Labels != nil {
-				if db.GetFollowerSyncRole(*img.Metadata.Labels) == "follower" {
-					role = "replica"
+		if getServerShowAll {
+			sort.SliceStable(images, func(i, j int) bool {
+				return creationTime(images[i].Status).Before(creationTime(images[j].Status))
+			})
+			fmt.Println("NAME            NODE-NAME  STATUS     ROLE     LV   QCOW2  AGE")
+			fmt.Println("----            ---------  ------     ------   --   -----  ---")
+			for _, img := range images {
+				nodeName := "-"
+				if img.Metadata.NodeName != nil && strings.TrimSpace(*img.Metadata.NodeName) != "" {
+					nodeName = strings.TrimSpace(*img.Metadata.NodeName)
 				}
-			}
 
-			hasLV := "no"
-			if (img.Spec.LvPath != nil && strings.TrimSpace(*img.Spec.LvPath) != "") ||
-				(img.Spec.LogicalVolume != nil && strings.TrimSpace(*img.Spec.LogicalVolume) != "") {
-				hasLV = "yes"
-			}
+				status := "-"
+				if img.Status != nil && img.Status.Status != nil && strings.TrimSpace(*img.Status.Status) != "" {
+					status = strings.TrimSpace(*img.Status.Status)
+				}
 
-			hasQcow2 := "no"
-			if img.Spec.Qcow2Path != nil && strings.TrimSpace(*img.Spec.Qcow2Path) != "" {
-				hasQcow2 = "yes"
-			}
+				role := "master"
+				if img.Metadata.Labels != nil {
+					if db.GetFollowerSyncRole(*img.Metadata.Labels) == "follower" {
+						role = "replica"
+					}
+				}
 
-			fmt.Printf("%-14s  %-9s  %-9s  %-5s  %-3s  %-5s  %s\n",
-				img.Metadata.Name,
-				nodeName,
-				status,
-				role,
-				hasLV,
-				hasQcow2,
-				formatServerAge(img.Status),
+				hasLV := "no"
+				if (img.Spec.LvPath != nil && strings.TrimSpace(*img.Spec.LvPath) != "") ||
+					(img.Spec.LogicalVolume != nil && strings.TrimSpace(*img.Spec.LogicalVolume) != "") {
+					hasLV = "yes"
+				}
+
+				hasQcow2 := "no"
+				if img.Spec.Qcow2Path != nil && strings.TrimSpace(*img.Spec.Qcow2Path) != "" {
+					hasQcow2 = "yes"
+				}
+
+				fmt.Printf("%-14s  %-9s  %-9s  %-7s  %-3s  %-5s  %s\n",
+					img.Metadata.Name,
+					nodeName,
+					status,
+					role,
+					hasLV,
+					hasQcow2,
+					formatServerAge(img.Status),
+				)
+			}
+			return nil
+		}
+
+		aggregated := summarizeImages(images)
+		sort.SliceStable(aggregated, func(i, j int) bool {
+			return creationTime(aggregated[i].ageStatus).Before(creationTime(aggregated[j].ageStatus))
+		})
+		fmt.Println("NAME            STATUS     SYNCED    LV   QCOW2  AGE")
+		fmt.Println("----            ------     ------    --   -----  ---")
+		for _, row := range aggregated {
+			fmt.Printf("%-14s  %-9s  %-8s  %-3s  %-5s  %s\n",
+				row.name,
+				row.status,
+				row.synced,
+				row.hasLV,
+				row.hasQcow2,
+				formatServerAge(row.ageStatus),
 			)
 		}
 		return nil
@@ -953,6 +973,140 @@ func outputImages(images []api.Image) error {
 	default:
 		return fmt.Errorf("output style must be text/json/yaml")
 	}
+}
+
+type imageSummary struct {
+	name      string
+	status    string
+	synced    string
+	hasLV     string
+	hasQcow2  string
+	ageStatus *api.Status
+}
+
+func summarizeImages(images []api.Image) []imageSummary {
+	totalNodes := collectUniqueNodeCount(images)
+	byName := map[string][]api.Image{}
+	for _, img := range images {
+		name := strings.TrimSpace(img.Metadata.Name)
+		if name == "" {
+			continue
+		}
+		byName[name] = append(byName[name], img)
+	}
+
+	result := make([]imageSummary, 0, len(byName))
+	for name, group := range byName {
+		result = append(result, summarizeImageGroup(name, group, totalNodes))
+	}
+
+	return result
+}
+
+func summarizeImageGroup(name string, images []api.Image, totalNodes int) imageSummary {
+	nodeSet := map[string]struct{}{}
+	statusSet := map[string]struct{}{}
+	lvSet := map[string]struct{}{}
+	qcow2Set := map[string]struct{}{}
+
+	var ageStatus *api.Status
+	for _, img := range images {
+		nodeName := ""
+		if img.Metadata.NodeName != nil {
+			nodeName = strings.TrimSpace(*img.Metadata.NodeName)
+		}
+		if nodeName != "" {
+			nodeSet[nodeName] = struct{}{}
+		}
+
+		statusSet[normalizeImageStatus(img)] = struct{}{}
+		lvSet[normalizeImageLV(img)] = struct{}{}
+		qcow2Set[normalizeImageQcow2(img)] = struct{}{}
+
+		if ageStatus == nil || creationTime(img.Status).Before(creationTime(ageStatus)) {
+			ageStatus = img.Status
+		}
+	}
+
+	status := firstMapKey(statusSet)
+	if len(statusSet) > 1 {
+		status = "MIXED"
+	}
+
+	lv := firstMapKey(lvSet)
+	if len(lvSet) > 1 {
+		lv = "mixed"
+	}
+
+	qcow2 := firstMapKey(qcow2Set)
+	if len(qcow2Set) > 1 {
+		qcow2 = "mixed"
+	}
+
+	expectedNodes := totalNodes
+	if expectedNodes <= 0 {
+		expectedNodes = len(nodeSet)
+	}
+	uniform := len(statusSet) == 1 && len(lvSet) == 1 && len(qcow2Set) == 1
+	complete := uniform && len(nodeSet) == expectedNodes
+
+	synced := "DEGRADE"
+	if complete {
+		synced = "COMPLETE"
+	}
+
+	return imageSummary{
+		name:      name,
+		status:    status,
+		synced:    synced,
+		hasLV:     lv,
+		hasQcow2:  qcow2,
+		ageStatus: ageStatus,
+	}
+}
+
+func collectUniqueNodeCount(images []api.Image) int {
+	nodes := map[string]struct{}{}
+	for _, img := range images {
+		if img.Metadata.NodeName == nil {
+			continue
+		}
+		nodeName := strings.TrimSpace(*img.Metadata.NodeName)
+		if nodeName == "" {
+			continue
+		}
+		nodes[nodeName] = struct{}{}
+	}
+	return len(nodes)
+}
+
+func normalizeImageStatus(img api.Image) string {
+	if img.Status == nil || img.Status.Status == nil || strings.TrimSpace(*img.Status.Status) == "" {
+		return "-"
+	}
+	return strings.TrimSpace(*img.Status.Status)
+}
+
+func normalizeImageLV(img api.Image) string {
+	if (img.Spec.LvPath != nil && strings.TrimSpace(*img.Spec.LvPath) != "") ||
+		(img.Spec.LogicalVolume != nil && strings.TrimSpace(*img.Spec.LogicalVolume) != "") {
+		return "yes"
+	}
+	return "no"
+}
+
+func normalizeImageQcow2(img api.Image) string {
+	if img.Spec.Qcow2Path != nil && strings.TrimSpace(*img.Spec.Qcow2Path) != "" {
+		return "yes"
+	}
+	return "no"
+}
+
+func firstMapKey(m map[string]struct{}) string {
+	for k := range m {
+		return k
+	}
+	return "-"
 }
 
 func outputVolumes(volumes []api.Volume) error {
@@ -1171,6 +1325,6 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	getCmd.Flags().StringVarP(&labelSelector, "selector", "l", "", "Label selector (e.g., key=value)")
 	getCmd.Flags().StringVarP(&getManifestFile, "file", "f", "", "Manifest file, URL, or - for stdin")
-	getCmd.Flags().BoolVarP(&getServerShowAll, "all", "a", false, "managedBy ラベル付きの server も含めて表示する")
+	getCmd.Flags().BoolVarP(&getServerShowAll, "all", "a", false, "server は managedBy を含め、image はノード別一覧を表示する")
 	getCmd.Flags().BoolVarP(&getVpnGatewayDownload, "download", "d", false, "vpngateway の VPN クライアント設定ファイル (.ovpn) をダウンロードする")
 }

--- a/cmd/mactl/cmd/get_image_output_test.go
+++ b/cmd/mactl/cmd/get_image_output_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/takara9/marmot/api"
+)
+
+var _ = Describe("summarizeImages", func() {
+	statusAvailable := "AVAILABLE"
+	statusProvisioning := "PROVISIONING"
+	qcow2Path := "/var/lib/marmot/images/demo.qcow2"
+
+	It("marks image COMPLETE when all cluster nodes have consistent entries", func() {
+		node1 := "marmot1"
+		node2 := "marmot2"
+		node3 := "marmot3"
+		images := []api.Image{
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node1}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node2}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node3}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+		}
+
+		summaries := summarizeImages(images)
+		Expect(summaries).To(HaveLen(1))
+		Expect(summaries[0].name).To(Equal("ubuntu"))
+		Expect(summaries[0].synced).To(Equal("COMPLETE"))
+		Expect(summaries[0].status).To(Equal("AVAILABLE"))
+		Expect(summaries[0].hasLV).To(Equal("no"))
+		Expect(summaries[0].hasQcow2).To(Equal("yes"))
+	})
+
+	It("marks image DEGRADE when image is missing on one of the cluster nodes", func() {
+		node1 := "marmot1"
+		node2 := "marmot2"
+		node3 := "marmot3"
+		images := []api.Image{
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node1}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node2}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+			{Metadata: api.Metadata{Name: "other", NodeName: &node1}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+			{Metadata: api.Metadata{Name: "other", NodeName: &node2}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+			{Metadata: api.Metadata{Name: "other", NodeName: &node3}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+		}
+
+		summaries := summarizeImages(images)
+		Expect(summaries).To(HaveLen(2))
+
+		result := map[string]imageSummary{}
+		for _, s := range summaries {
+			result[s.name] = s
+		}
+		Expect(result["ubuntu"].synced).To(Equal("DEGRADE"))
+		Expect(result["other"].synced).To(Equal("COMPLETE"))
+	})
+
+	It("marks image DEGRADE and status MIXED when per-node status differs", func() {
+		node1 := "marmot1"
+		node2 := "marmot2"
+		images := []api.Image{
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node1}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node2}, Status: &api.Status{Status: &statusProvisioning}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+		}
+
+		summaries := summarizeImages(images)
+		Expect(summaries).To(HaveLen(1))
+		Expect(summaries[0].synced).To(Equal("DEGRADE"))
+		Expect(summaries[0].status).To(Equal("MIXED"))
+	})
+})


### PR DESCRIPTION
## 概要
Closes #436

mactl get image/img の表示を改善しました。  
通常表示では重複行を集約し、同期状態を一目で判別できるようにしています。  
-a 指定時は従来どおりノード別詳細を表示し、運用時の確認性を維持しています。

## 変更内容
- 既定表示を「イメージ名単位の集約表示」に変更
- SYNCED 列を追加し、同期状態を COMPLETE / DEGRADE で表示
- -a 指定時はノード別一覧を表示（NODE-NAME 列あり）
- -a 詳細表示で列崩れしないよう ROLE 列の幅を拡張
- 同期判定ロジックを追加
- 同期判定ロジックのユニットテストを追加

## 期待される効果
- クラスタ内で同一イメージが複数ノードに存在する場合でも、通常表示が見やすくなる
- 同期崩れの検知が容易になる
- 詳細確認が必要な場合は -a で従来どおりノード別の状態を確認できる

## 変更ファイル
- get.go
- get_image_output_test.go

## 動作確認
- go test ./cmd/mactl/cmd -run TestCmd -count=1
- 結果: 成功

## 互換性
- text 出力のみ表示仕様を改善
- json / yaml 出力仕様は変更なし