### PR TITLE
rootPasswordの有効化

### DIFF
--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -596,30 +596,10 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 
 	path := "/var/lib/marmot/isos/" + api.ServerID(serverConfig)
 
-	var password string
-	var sshKey string
-	var usernames []string
-
-	if serverConfig.Spec.Auth != nil {
-		if serverConfig.Spec.Auth.RootPassword != nil {
-			password = *serverConfig.Spec.Auth.RootPassword
-		}
-		if serverConfig.Spec.Auth.User != nil {
-			usernames = append(usernames, *serverConfig.Spec.Auth.User)
-		}
-		if serverConfig.Spec.Auth.Users != nil {
-			usernames = append(usernames, (*serverConfig.Spec.Auth.Users)...)
-		}
-		if serverConfig.Spec.Auth.Url != nil {
-			keys, err := FetchPublicKeys(*serverConfig.Spec.Auth.Url)
-			if err != nil {
-				slog.Error("公開鍵の取得に失敗", "url", *serverConfig.Spec.Auth.Url, "err", err)
-				return "", err
-			}
-			sshKey = strings.Join(keys, "\n")
-		} else if serverConfig.Spec.Auth.PublicKey != nil {
-			sshKey = *serverConfig.Spec.Auth.PublicKey
-		}
+	password, sshKey, usernames, err := cloudInitAuthInputs(serverConfig.Spec.Auth)
+	if err != nil {
+		slog.Error("公開鍵の取得に失敗", "err", err)
+		return "", err
 	}
 
 	isoPath, err := GenerateCloudInitISO(path, password, sshKey, usernames)
@@ -841,6 +821,50 @@ func validateServerAuthSpec(auth *api.Auth) error {
 		}
 	}
 	return nil
+}
+
+func cloudInitAuthInputs(auth *api.Auth) (string, string, []string, error) {
+	if auth == nil {
+		return "", "", nil, nil
+	}
+
+	var password string
+	var sshKey string
+	var usernames []string
+
+	if auth.RootPassword != nil {
+		password = *auth.RootPassword
+	}
+	if auth.User != nil {
+		usernames = append(usernames, *auth.User)
+	}
+	if auth.Users != nil {
+		usernames = append(usernames, (*auth.Users)...)
+	}
+	if auth.Url != nil {
+		keys, err := FetchPublicKeys(*auth.Url)
+		if err != nil {
+			return "", "", nil, err
+		}
+		sshKey = strings.Join(keys, "\n")
+	} else if auth.PublicKey != nil {
+		sshKey = *auth.PublicKey
+	}
+
+	if auth.RootPassword != nil && !containsUsername(usernames, "root") {
+		usernames = append(usernames, "root")
+	}
+
+	return password, sshKey, usernames, nil
+}
+
+func containsUsername(usernames []string, expected string) bool {
+	for _, username := range usernames {
+		if strings.TrimSpace(username) == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func appendVPNRouteIfEnabled(nic *api.NetworkInterface, vnet *api.VirtualNetwork) {

--- a/pkg/marmotd/server_auth_test.go
+++ b/pkg/marmotd/server_auth_test.go
@@ -28,3 +28,36 @@ func TestValidateServerAuthSpecRejectsEmptyUsernames(t *testing.T) {
 		t.Fatalf("validateServerAuthSpec() expected error for empty users entry")
 	}
 }
+
+func TestCloudInitAuthInputsAddsRootWhenRootPasswordIsSet(t *testing.T) {
+	password := "password123"
+	pass, _, usernames, err := cloudInitAuthInputs(&api.Auth{RootPassword: &password})
+	if err != nil {
+		t.Fatalf("cloudInitAuthInputs() unexpected error: %v", err)
+	}
+	if pass != password {
+		t.Fatalf("cloudInitAuthInputs() password = %q, want %q", pass, password)
+	}
+	if len(usernames) != 1 || usernames[0] != "root" {
+		t.Fatalf("cloudInitAuthInputs() usernames = %v, want [root]", usernames)
+	}
+}
+
+func TestCloudInitAuthInputsDoesNotDuplicateRoot(t *testing.T) {
+	password := "password123"
+	users := &[]string{"root", "ubuntu"}
+	_, _, usernames, err := cloudInitAuthInputs(&api.Auth{RootPassword: &password, Users: users})
+	if err != nil {
+		t.Fatalf("cloudInitAuthInputs() unexpected error: %v", err)
+	}
+
+	rootCount := 0
+	for _, username := range usernames {
+		if username == "root" {
+			rootCount++
+		}
+	}
+	if rootCount != 1 {
+		t.Fatalf("cloudInitAuthInputs() root count = %d, want 1 (usernames=%v)", rootCount, usernames)
+	}
+}


### PR DESCRIPTION
rootPassword が指定された場合、cloud-init 用 usernames に root を補完して chpasswd が生成される経路になります。

変更内容:
1. 認証情報の抽出を helper 化し、root 補完ロジックを追加  
server.go  
- cloudInitAuthInputs を追加
- auth.RootPassword がある場合、usernames に root が未含有なら追加
- 既存の公開鍵取得ロジックは維持

2. サーバー作成処理で新 helper を使用  
server.go  
- 既存の auth 展開コードを置き換え
- そのまま GenerateCloudInitISO に渡す

3. 重複防止 helper を追加  
server.go  
- containsUsername を追加して root の二重追加を防止

4. ユニットテストを追加  
server_auth_test.go  
- rootPassword のみ指定時に usernames が [root] になることを検証  
server_auth_test.go  
- users に root が既にある場合、重複しないことを検証

実行確認:
- go test ./pkg/marmotd -run 'TestCloudInitAuthInputs|TestValidateServerAuthSpec|TestBuildCloudInitUserData'
- 結果: 成功

