### PR TITLE
スケジュールの改善

### DIFF
--- a/pkg/controller/server-controller.go
+++ b/pkg/controller/server-controller.go
@@ -108,6 +108,19 @@ func (c *controller) serverControllerLoop() {
 	}
 
 	for _, spec := range serverSpec {
+		if spec.Status != nil && spec.Status.StatusCode == db.SERVER_PENDING {
+			assignedNode, assignErr := c.marmot.ResolveAndAssignServerNodeByStorage(api.ServerID(spec))
+			if assignErr != nil {
+				slog.Error("ResolveAndAssignServerNodeByStorage()", "serverId", api.ServerID(spec), "err", assignErr)
+				msg := fmt.Sprintf("サーバーのノード割当解決に失敗した。原因エラー: %v", assignErr)
+				c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg)
+				continue
+			}
+			if strings.TrimSpace(assignedNode) != "" {
+				spec.Metadata.NodeName = util.StringPtr(assignedNode)
+			}
+		}
+
 		// 削除のタイムスタンプが一定時間以上経過しているかをチェックして、削除処理を実行する
 		if spec.Status != nil && spec.Status.DeletionTimeStamp != nil {
 			deletionTime := *spec.Status.DeletionTimeStamp
@@ -323,6 +336,13 @@ func isRetryableServerProvisionError(err error) bool {
 	}
 	if strings.Contains(msg, "no public keys found at") {
 		return true
+	}
+
+	// ノード間レプリケーション中に OS イメージ実体が未到達な場合は再試行する。
+	if strings.Contains(msg, "failed to copy qcow2 volume") {
+		if strings.Contains(msg, "no such file") || strings.Contains(msg, "not found") || strings.Contains(msg, "does not exist") {
+			return true
+		}
 	}
 
 	return false

--- a/pkg/controller/server-controller_test.go
+++ b/pkg/controller/server-controller_test.go
@@ -138,6 +138,11 @@ func TestIsRetryableServerProvisionError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "missing qcow2 source file copy is retryable",
+			err:  errors.New("failed to copy QCOW2 volume from /var/lib/marmot/images/x/osimage-x.qcow2 to /var/lib/marmot/volumes/boot-y.qcow2: exit status 1 (output: cp: cannot stat '/var/lib/marmot/images/x/osimage-x.qcow2': No such file or directory)"),
+			want: true,
+		},
+		{
 			name: "other provisioning error is not retryable",
 			err:  errors.New("boot volume path is required for qcow2"),
 			want: false,

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -52,6 +52,131 @@ func normalizeISCSITargetName(targetIQN string) string {
 	return t + "/0"
 }
 
+func volumeKindOrDefault(spec api.VolSpec) string {
+	if spec.Kind != nil {
+		if kind := strings.TrimSpace(*spec.Kind); kind != "" {
+			return kind
+		}
+	}
+	return "data"
+}
+
+func chooseAssignedNodeName(defaultNode string, requestedNode *string, storageNode string) (string, error) {
+	defaultAssigned := strings.TrimSpace(defaultNode)
+	assigned := defaultAssigned
+	requested := ""
+	if requestedNode != nil {
+		requested = strings.TrimSpace(*requestedNode)
+		if requested != "" {
+			assigned = requested
+		}
+	}
+
+	storage := strings.TrimSpace(storageNode)
+	if storage == "" {
+		return assigned, nil
+	}
+	if requested != "" && requested != storage && requested != defaultAssigned {
+		return "", fmt.Errorf("metadata.nodeName %q conflicts with pre-created storage volume node %q", requested, storage)
+	}
+	return storage, nil
+}
+
+func (m *Marmot) findPreCreatedStorageVolume(disk api.Volume) (*api.Volume, error) {
+	if diskID := strings.TrimSpace(api.VolumeID(disk)); diskID != "" {
+		vol, err := m.GetVolumeById(diskID)
+		if err != nil {
+			return nil, err
+		}
+		return vol, nil
+	}
+
+	name := strings.TrimSpace(disk.Metadata.Name)
+	if name == "" {
+		return nil, nil
+	}
+
+	kind := volumeKindOrDefault(disk.Spec)
+	volumes, err := m.Db.FindVolumeByName(name, kind)
+	if err != nil {
+		return nil, err
+	}
+	return selectReusableVolume(volumes)
+}
+
+func (m *Marmot) resolveStorageBoundNodeName(storage *[]api.Volume) (string, error) {
+	if storage == nil {
+		return "", nil
+	}
+
+	boundNode := ""
+	for i, disk := range *storage {
+		vol, err := m.findPreCreatedStorageVolume(disk)
+		if err != nil {
+			return "", fmt.Errorf("storage[%d] volume lookup failed: %w", i, err)
+		}
+		if vol == nil || vol.Metadata.NodeName == nil {
+			continue
+		}
+
+		node := strings.TrimSpace(*vol.Metadata.NodeName)
+		if node == "" {
+			continue
+		}
+		if boundNode == "" {
+			boundNode = node
+			continue
+		}
+		if boundNode != node {
+			return "", fmt.Errorf("storage volumes are distributed across nodes: %q and %q", boundNode, node)
+		}
+	}
+
+	return boundNode, nil
+}
+
+
+// ResolveAndAssignServerNodeByStorage inspects pre-created storage volumes and
+// updates server metadata.nodeName when storage constrains placement.
+func (m *Marmot) ResolveAndAssignServerNodeByStorage(serverID string) (string, error) {
+	serverID = strings.TrimSpace(serverID)
+	if serverID == "" {
+		return "", errors.New("server id is required")
+	}
+
+	serverConfig, err := m.Db.GetServerById(serverID)
+	if err != nil {
+		return "", err
+	}
+
+	storageNodeName, err := m.resolveStorageBoundNodeName(serverConfig.Spec.Storage)
+	if err != nil {
+		return "", err
+	}
+
+	assignedNodeName, err := chooseAssignedNodeName(m.NodeName, serverConfig.Metadata.NodeName, storageNodeName)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(assignedNodeName) == "" {
+		return "", nil
+	}
+
+	currentNode := ""
+	if serverConfig.Metadata.NodeName != nil {
+		currentNode = strings.TrimSpace(*serverConfig.Metadata.NodeName)
+	}
+	if currentNode == assignedNodeName {
+		return assignedNodeName, nil
+	}
+
+	patch := api.Server{Metadata: api.Metadata{NodeName: util.StringPtr(assignedNodeName)}}
+	if err := m.Db.UpdateServer(serverID, patch); err != nil {
+		return "", err
+	}
+
+	return assignedNodeName, nil
+}
 func resolveISCSIServerNode(statuses []api.HostStatus) string {
 	active := filterActiveHosts(statuses)
 	if len(active) == 0 {
@@ -163,11 +288,16 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 		return "", err
 	}
 
-	assignedNodeName := strings.TrimSpace(m.NodeName)
-	if serverConfig.Metadata.NodeName != nil {
-		if node := strings.TrimSpace(*serverConfig.Metadata.NodeName); node != "" {
-			assignedNodeName = node
-		}
+	storageNodeName, err := m.resolveStorageBoundNodeName(serverConfig.Spec.Storage)
+	if err != nil {
+		slog.Error("resolveStorageBoundNodeName()", "err", err)
+		return "", err
+	}
+
+	assignedNodeName, err := chooseAssignedNodeName(m.NodeName, serverConfig.Metadata.NodeName, storageNodeName)
+	if err != nil {
+		slog.Error("chooseAssignedNodeName()", "err", err)
+		return "", err
 	}
 	assignNodeNameIfUnset(&serverConfig.Metadata, assignedNodeName)
 
@@ -501,18 +631,17 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 			disk.ApiVersion = "v1"
 			disk.Kind = "Volume"
 
-			diskID := api.VolumeID(disk)
-			if len(diskID) > 0 {
-				slog.Debug("既存ボリュームを使用", "disk index", i, "volume id", diskID)
-				diskVol, err := m.GetVolumeById(diskID)
-				if err != nil {
-					slog.Error("GetVolumeById()", "err", err)
-					return "", err
-				}
+			diskVol, err := m.findPreCreatedStorageVolume(disk)
+			if err != nil {
+				slog.Error("findPreCreatedStorageVolume()", "err", err, "disk index", i)
+				return "", err
+			}
+			if diskVol != nil {
+				slog.Debug("既存ボリュームを使用", "disk index", i, "volume id", api.VolumeID(*diskVol))
 
 				// 永続フラグを立てる
-				var peersistent bool = true
-				diskVol.Spec.Persistent = &peersistent
+				var persistent bool = true
+				diskVol.Spec.Persistent = &persistent
 
 				slog.Debug("既存ボリュームの情報取得成功", "disk index", i, "volume id", api.VolumeID(*diskVol), "path", diskVol.Spec.Path, "status", diskVol.Status.Status)
 				(*serverConfig.Spec.Storage)[i] = *diskVol

--- a/pkg/marmotd/server_storage_scheduling_test.go
+++ b/pkg/marmotd/server_storage_scheduling_test.go
@@ -1,0 +1,56 @@
+package marmotd
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestChooseAssignedNodeName(t *testing.T) {
+	t.Run("uses storage node when request node is unset", func(t *testing.T) {
+		node, err := chooseAssignedNodeName("hv-default", nil, "hv-storage")
+		if err != nil {
+			t.Fatalf("chooseAssignedNodeName() error = %v", err)
+		}
+		if node != "hv-storage" {
+			t.Fatalf("chooseAssignedNodeName() = %q, want %q", node, "hv-storage")
+		}
+	})
+
+	t.Run("keeps requested node when storage node is empty", func(t *testing.T) {
+		node, err := chooseAssignedNodeName("hv-default", util.StringPtr("hv-requested"), "")
+		if err != nil {
+			t.Fatalf("chooseAssignedNodeName() error = %v", err)
+		}
+		if node != "hv-requested" {
+			t.Fatalf("chooseAssignedNodeName() = %q, want %q", node, "hv-requested")
+		}
+	})
+
+	t.Run("accepts matching requested and storage nodes", func(t *testing.T) {
+		node, err := chooseAssignedNodeName("hv-default", util.StringPtr("hv-storage"), "hv-storage")
+		if err != nil {
+			t.Fatalf("chooseAssignedNodeName() error = %v", err)
+		}
+		if node != "hv-storage" {
+			t.Fatalf("chooseAssignedNodeName() = %q, want %q", node, "hv-storage")
+		}
+	})
+
+	t.Run("overrides auto-assigned default node with storage node", func(t *testing.T) {
+		node, err := chooseAssignedNodeName("hv-default", util.StringPtr("hv-default"), "hv-storage")
+		if err != nil {
+			t.Fatalf("chooseAssignedNodeName() error = %v", err)
+		}
+		if node != "hv-storage" {
+			t.Fatalf("chooseAssignedNodeName() = %q, want %q", node, "hv-storage")
+		}
+	})
+
+	t.Run("rejects conflicting requested and storage nodes", func(t *testing.T) {
+		_, err := chooseAssignedNodeName("hv-default", util.StringPtr("hv-requested"), "hv-storage")
+		if err == nil {
+			t.Fatal("chooseAssignedNodeName() error = nil, want conflict error")
+		}
+	})
+}

--- a/pkg/qcow/qcow.go
+++ b/pkg/qcow/qcow.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 // QCOW2ボリュームの存在チェック
@@ -52,12 +55,20 @@ func CopyQcow(srcPath string, destPath string) error {
 // QCOW2 ボリュームのコピー
 func CopyQcowWithContext(ctx context.Context, srcPath string, destPath string) error {
 	slog.Debug("Copying QCOW2 volume", "srcPath", srcPath, "destPath", destPath)
+	destDir := filepath.Dir(destPath)
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("failed to ensure destination directory for QCOW2 copy: %s: %w", destDir, err)
+	}
 	//cmd := exec.Command("qemu-img", "convert", "-f", "qcow2", "-O", "qcow2", srcPath, destPath)
 	cmd := exec.CommandContext(ctx, "cp", srcPath, destPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		slog.Error("qemu-img copy failed", "output", string(output))
-		return fmt.Errorf("Failed to copy QCOW2 volume from %s to %s, error: %v", srcPath, destPath, err)
+		trimmed := strings.TrimSpace(string(output))
+		slog.Error("cp qcow2 failed", "output", trimmed)
+		if trimmed == "" {
+			return fmt.Errorf("failed to copy QCOW2 volume from %s to %s: %w", srcPath, destPath, err)
+		}
+		return fmt.Errorf("failed to copy QCOW2 volume from %s to %s: %w (output: %s)", srcPath, destPath, err, trimmed)
 	}
 	return nil
 }


### PR DESCRIPTION
## 概要

`spec.storage` で事前作成済みボリュームを参照するサーバー作成時に、ストレージが存在するノードへ正しくスケジュールされるよう修正しました。  
あわせて、ノード間のイメージ到達タイミング差で起きる QCOW2 コピー失敗を再試行可能として扱い、失敗時の診断情報も強化しています。

## 背景

事前作成済みボリューム（例: `volume2` が `marmot2` に存在）を `spec.storage` で指定しても、サーバーが `marmot1` 側で処理され、プロビジョニング失敗になるケースがありました。

主因:
1. `server-controller` の node gate 判定が先に走る
2. その時点で `metadata.nodeName` が自動/既定値のまま残っている
3. 本来処理すべきノードではなく別ノードで作成処理が進み、失敗する

## 変更内容

### 1) node gate 前に storage 由来ノードを解決・反映
`SERVER_PENDING` サーバーに対して、コントローラー側で先にストレージ拘束ノードを解決し、`server.metadata.nodeName` を更新してから node gate 判定を行うようにしました。

対象:
- server-controller.go

### 2) ストレージ由来ノード割当の共通処理を追加
`marmotd` 側に以下のヘルパーを追加しました。

- `ResolveAndAssignServerNodeByStorage(serverID)`

処理内容:
1. サーバー情報を取得
2. `spec.storage` の事前作成済みボリューム（ID/Name）を解決
3. ボリュームの `metadata.nodeName` から拘束ノードを決定
4. 明示指定ノードとの競合を検証
5. 必要に応じて `server.metadata.nodeName` を DB 更新

対象:
- server.go

### 3) QCOW2 コピー失敗の再試行判定を強化
`failed to copy QCOW2 volume ...` かつ `no such file / not found / does not exist` を含む場合、依存リソース未到達として再試行可能扱いにしました。

対象:
- server-controller.go

### 4) QCOW2 コピー失敗時の可観測性を改善
- コピー先ディレクトリを事前作成
- 失敗時にコマンド出力（stderr/stdout）をエラーメッセージへ含める

対象:
- qcow.go

## 修正後の動作

例:
- `vol3` が `node2` に存在
- `srv1` が `spec.storage` で `vol3` を参照

結果:
1. `srv1` は `node2` に割り当てられる
2. `metadata.nodeName` を別ノードで明示した場合は競合エラー
3. 画像未到達など一時要因のコピー失敗は `PENDING` で再試行

## テスト

実行済み:
1. `go test ./pkg/controller -run TestIsRetryableServerProvisionError -count=1`
2. `go test ./pkg/marmotd -run 'TestChooseAssignedNodeName|TestSelectReusableVolume' -count=1`

いずれも成功。

## 注意事項

本修正の中核はコントローラー処理順の変更を含むため、対象ノードの `marmotd/controller` バイナリ更新と再起動が必要です。