### PR TITLE
create/apply 時に metadata.id を表示する

### DIFF
--- a/cmd/mactl/cmd/apply.go
+++ b/cmd/mactl/cmd/apply.go
@@ -567,15 +567,18 @@ func applyNetworkLoadBalancer(manifest map[string]interface{}) error {
 func processApplyResponse(byteBody []byte, updated bool) error {
 	switch outputStyle {
 	case "text":
-		var data any
-		if err := json.Unmarshal(byteBody, &data); err != nil {
+		id, err := extractResponseID(byteBody)
+		if err != nil {
 			return fmt.Errorf("failed to parse response: %w", err)
 		}
-		serveMap := data.(map[string]any)
+		displayID := id
+		if displayID == "" {
+			displayID = "<nil>"
+		}
 		if updated {
-			fmt.Printf("リソースが更新されました。ID: %v\n", serveMap["id"])
+			fmt.Printf("リソースが更新されました。ID: %s\n", displayID)
 		} else {
-			fmt.Printf("リソースが作成されました。ID: %v\n", serveMap["id"])
+			fmt.Printf("リソースが作成されました。ID: %s\n", displayID)
 		}
 		return nil
 

--- a/cmd/mactl/cmd/create.go
+++ b/cmd/mactl/cmd/create.go
@@ -450,12 +450,15 @@ func createNetworkLoadBalancer(manifest map[string]interface{}) error {
 func processCreateResponse(byteBody []byte) error {
 	switch outputStyle {
 	case "text":
-		var data any
-		if err := json.Unmarshal(byteBody, &data); err != nil {
+		id, err := extractResponseID(byteBody)
+		if err != nil {
 			return fmt.Errorf("failed to parse response: %w", err)
 		}
-		serveMap := data.(map[string]any)
-		fmt.Printf("リソースの作成要求が受け入れられました。ID: %v\n", serveMap["id"])
+		if id == "" {
+			fmt.Printf("リソースの作成要求が受け入れられました。ID: <nil>\n")
+			return nil
+		}
+		fmt.Printf("リソースの作成要求が受け入れられました。ID: %s\n", id)
 		return nil
 
 	case "json":

--- a/cmd/mactl/cmd/response_id.go
+++ b/cmd/mactl/cmd/response_id.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+func extractResponseID(body []byte) (string, error) {
+	var data map[string]any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return "", err
+	}
+	return extractResponseIDFromMap(data), nil
+}
+
+func extractResponseIDFromMap(data map[string]any) string {
+	if data == nil {
+		return ""
+	}
+
+	if metadata, ok := data["metadata"].(map[string]any); ok {
+		if id := normalizeResponseID(metadata["id"]); id != "" {
+			return id
+		}
+	}
+
+	return normalizeResponseID(data["id"])
+}
+
+func normalizeResponseID(v any) string {
+	id := strings.TrimSpace(fmt.Sprint(v))
+	if id == "" || id == "<nil>" || id == "<null>" {
+		return ""
+	}
+	return id
+}

--- a/cmd/mactl/cmd/response_id_test.go
+++ b/cmd/mactl/cmd/response_id_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestExtractResponseIDPrefersMetadataID(t *testing.T) {
+	id, err := extractResponseID([]byte(`{"id":"legacy","metadata":{"id":"meta-123"}}`))
+	if err != nil {
+		t.Fatalf("extractResponseID() unexpected err: %v", err)
+	}
+	if id != "meta-123" {
+		t.Fatalf("extractResponseID() = %q, want meta-123", id)
+	}
+}
+
+func TestExtractResponseIDFallbackTopLevelID(t *testing.T) {
+	id, err := extractResponseID([]byte(`{"id":"top-999"}`))
+	if err != nil {
+		t.Fatalf("extractResponseID() unexpected err: %v", err)
+	}
+	if id != "top-999" {
+		t.Fatalf("extractResponseID() = %q, want top-999", id)
+	}
+}
+
+func TestExtractResponseIDEmptyWhenMissing(t *testing.T) {
+	id, err := extractResponseID([]byte(`{"metadata":{}}`))
+	if err != nil {
+		t.Fatalf("extractResponseID() unexpected err: %v", err)
+	}
+	if id != "" {
+		t.Fatalf("extractResponseID() = %q, want empty", id)
+	}
+}
+
+func TestProcessCreateResponseUsesMetadataIDInText(t *testing.T) {
+	withOutputStyle("text", t, func() {
+		out := captureStdoutForIDTest(t, func() {
+			err := processCreateResponse([]byte(`{"id":null,"metadata":{"id":"vol-101"}}`))
+			if err != nil {
+				t.Fatalf("processCreateResponse() unexpected err: %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "ID: vol-101") {
+			t.Fatalf("stdout = %q, want contains ID: vol-101", out)
+		}
+	})
+}
+
+func TestProcessApplyResponseUsesMetadataIDInText(t *testing.T) {
+	withOutputStyle("text", t, func() {
+		out := captureStdoutForIDTest(t, func() {
+			err := processApplyResponse([]byte(`{"id":null,"metadata":{"id":"gw-202"}}`), true)
+			if err != nil {
+				t.Fatalf("processApplyResponse() unexpected err: %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "ID: gw-202") {
+			t.Fatalf("stdout = %q, want contains ID: gw-202", out)
+		}
+	})
+}
+
+func withOutputStyle(style string, t *testing.T, fn func()) {
+	t.Helper()
+	previous := outputStyle
+	outputStyle = style
+	t.Cleanup(func() {
+		outputStyle = previous
+	})
+	fn()
+}
+
+func captureStdoutForIDTest(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() failed: %v", err)
+	}
+
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("io.Copy() failed: %v", err)
+	}
+	_ = r.Close()
+	return buf.String()
+}

--- a/cmd/mactl/cmd/server_ansible.go
+++ b/cmd/mactl/cmd/server_ansible.go
@@ -85,12 +85,11 @@ func validateServerAnsiblePlaybookSpec(server api.Server) (string, error) {
 }
 
 func extractSuccessID(body []byte) (string, error) {
-	var data map[string]any
-	if err := json.Unmarshal(body, &data); err != nil {
+	id, err := extractResponseID(body)
+	if err != nil {
 		return "", err
 	}
-	id := strings.TrimSpace(fmt.Sprint(data["id"]))
-	if id == "" || id == "<nil>" {
+	if id == "" {
 		return "", fmt.Errorf("id is empty")
 	}
 	return id, nil

--- a/cmd/mactl/cmd/server_ansible_test.go
+++ b/cmd/mactl/cmd/server_ansible_test.go
@@ -97,6 +97,14 @@ func TestExtractSuccessID(t *testing.T) {
 		t.Fatalf("extractSuccessID() = %q, want s1234", id)
 	}
 
+	id, err = extractSuccessID([]byte(`{"id":null,"metadata":{"id":"s5678"},"message":"ok"}`))
+	if err != nil {
+		t.Fatalf("extractSuccessID() unexpected err: %v", err)
+	}
+	if id != "s5678" {
+		t.Fatalf("extractSuccessID() = %q, want s5678", id)
+	}
+
 	if _, err := extractSuccessID([]byte(`{"message":"ok"}`)); err == nil {
 		t.Fatalf("extractSuccessID() expected error for missing id")
 	}


### PR DESCRIPTION
## 概要
mactl create/apply のテキスト出力で、仮想サーバー以外のリソース作成・更新時に ID: <nil> と表示される問題を修正しました。  
JSON/YAML では metadata.id が返っているため、テキスト出力も metadata.id を優先して表示するように統一しています。

## 背景・課題
- 現状のテキスト出力はトップレベル id のみ参照していた
- 一部リソースは metadata.id のみ設定され、トップレベル id は未設定
- その結果、create/apply の受付メッセージが ID: <nil> になる

## 変更内容
- レスポンス ID 抽出の共通処理を追加
  - metadata.id を優先
  - 未設定時はトップレベル id にフォールバック
- create のテキスト出力で共通 ID 抽出処理を利用
- apply の作成時/更新時テキスト出力で共通 ID 抽出処理を利用
- サーバー ansible 連携で使う成功 ID 抽出も同じ共通処理へ統一

## 期待される効果
- mactl create/apply の全リソースで、作成要求・更新要求のテキストメッセージに正しい ID が表示される
- JSON/YAML 出力とテキスト出力の ID 表示が整合する
- 将来のレスポンス形式差分に対する耐性が向上する

## テスト
- cmd/mactl/cmd パッケージのテストを実行し成功
- 追加/更新した主な検証内容
  - metadata.id 優先で ID を取得できること
  - トップレベル id へのフォールバック
  - create/apply の text 出力に metadata.id が反映されること
  - ansible 用成功 ID 抽出で metadata.id 経路が有効であること

## 互換性
- API レスポンス自体の仕様変更はなし
- 変更はテキスト表示ロジック中心で、既存の JSON/YAML 出力には影響なし
 