### PR TITLE
Volume表示の改善

### DIFF
--- a/cmd/mactl/cmd/get.go
+++ b/cmd/mactl/cmd/get.go
@@ -363,6 +363,9 @@ func getVolumeResources(name string) error {
 			return fmt.Errorf("failed to parse volumes: %w", err)
 		}
 
+		// volume 一覧は通常 data kind のみ。-a のときは全件表示。
+		volumes = filterDataKindVolumes(volumes, getServerShowAll)
+
 		// NAME でフィルター
 		if name != "" {
 			volumes = filterVolumesByName(volumes, name)
@@ -641,6 +644,23 @@ func filterVolumesByLabel(volumes []api.Volume, labelFilter string) []api.Volume
 	var result []api.Volume
 	for _, v := range volumes {
 		if MatchesLabel(convertLabels(v.Metadata.Labels), labelFilter) {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+func filterDataKindVolumes(volumes []api.Volume, showAll bool) []api.Volume {
+	if showAll {
+		return volumes
+	}
+
+	var result []api.Volume
+	for _, v := range volumes {
+		if v.Spec.Kind == nil {
+			continue
+		}
+		if strings.TrimSpace(*v.Spec.Kind) == "data" {
 			result = append(result, v)
 		}
 	}
@@ -1115,8 +1135,8 @@ func outputVolumes(volumes []api.Volume) error {
 		sort.SliceStable(volumes, func(i, j int) bool {
 			return creationTime(volumes[i].Status).Before(creationTime(volumes[j].Status))
 		})
-		fmt.Println("NAME          NODE  KIND  TYPE   iSCSI  SIZE(GB)  STATUS     PATH                  AGE")
-		fmt.Println("----          ----  ----  ----   -----  --------  ------     ----                  ---")
+		fmt.Println("NAME          NODE        KIND  TYPE   iSCSI  SIZE(GB)  STATUS     PATH                  AGE")
+		fmt.Println("----          ----        ----  ----   -----  --------  ------     ----                  ---")
 		for _, v := range volumes {
 			size := 0
 			if v.Spec.Size != nil {
@@ -1153,7 +1173,7 @@ func outputVolumes(volumes []api.Volume) error {
 				path = truncatePath(strings.TrimSpace(*v.Spec.Path), 22)
 			}
 
-			fmt.Printf("%-12s  %-4s  %-4s  %-5s  %-5s  %-8d  %-9s  %-20s  %s\n",
+			fmt.Printf("%-12s  %-10s  %-4s  %-5s  %-5s  %-8d  %-9s  %-20s  %s\n",
 				v.Metadata.Name,
 				node,
 				volKind,
@@ -1325,6 +1345,6 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	getCmd.Flags().StringVarP(&labelSelector, "selector", "l", "", "Label selector (e.g., key=value)")
 	getCmd.Flags().StringVarP(&getManifestFile, "file", "f", "", "Manifest file, URL, or - for stdin")
-	getCmd.Flags().BoolVarP(&getServerShowAll, "all", "a", false, "server は managedBy を含め、image はノード別一覧を表示する")
+	getCmd.Flags().BoolVarP(&getServerShowAll, "all", "a", false, "server は managedBy を含め、image はノード別一覧、volume は kind フィルターなしで全件表示する")
 	getCmd.Flags().BoolVarP(&getVpnGatewayDownload, "download", "d", false, "vpngateway の VPN クライアント設定ファイル (.ovpn) をダウンロードする")
 }

--- a/cmd/mactl/cmd/get_volume_filter_test.go
+++ b/cmd/mactl/cmd/get_volume_filter_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/api"
+)
+
+func TestFilterDataKindVolumes(t *testing.T) {
+	data := "data"
+	osKind := "os"
+	blank := ""
+
+	volumes := []api.Volume{
+		{Metadata: api.Metadata{Name: "v-data-1"}, Spec: api.VolSpec{Kind: &data}},
+		{Metadata: api.Metadata{Name: "v-os"}, Spec: api.VolSpec{Kind: &osKind}},
+		{Metadata: api.Metadata{Name: "v-nil"}, Spec: api.VolSpec{}},
+		{Metadata: api.Metadata{Name: "v-blank"}, Spec: api.VolSpec{Kind: &blank}},
+		{Metadata: api.Metadata{Name: "v-data-2"}, Spec: api.VolSpec{Kind: &data}},
+	}
+
+	got := filterDataKindVolumes(volumes, false)
+	if len(got) != 2 {
+		t.Fatalf("filterDataKindVolumes() len=%d, want 2", len(got))
+	}
+	if got[0].Metadata.Name != "v-data-1" {
+		t.Fatalf("filterDataKindVolumes()[0]=%q, want v-data-1", got[0].Metadata.Name)
+	}
+	if got[1].Metadata.Name != "v-data-2" {
+		t.Fatalf("filterDataKindVolumes()[1]=%q, want v-data-2", got[1].Metadata.Name)
+	}
+
+	gotAll := filterDataKindVolumes(volumes, true)
+	if len(gotAll) != len(volumes) {
+		t.Fatalf("filterDataKindVolumes(..., true) len=%d, want %d", len(gotAll), len(volumes))
+	}
+}


### PR DESCRIPTION
## 概要
`mactl get volume` / `mactl get vol` の表示挙動を改善しました。  
通常実行時は `spec.kind=data` のボリュームのみ表示し、`-a` 指定時はフィルターせず全件表示するように変更しています。  
あわせて、一覧の `NODE` 列幅を 10 文字に拡張し、可読性を向上させました。

## 背景・課題
- `mactl get vol` で `boot` 系 (`spec.kind=os`) を含む全ボリュームが表示され、`data` ボリューム確認時にノイズが多い
- 一方で運用上、`-a` 指定時には全件確認したい
- 表示上、`NODE` 列が狭く、値が詰まって見えるケースがある

## 変更内容
1. `get volume` の kind フィルター追加
- 通常: `spec.kind=data` のみ表示
- 対象: `mactl get volume`, `mactl get vol`

2. `-a/--all` 指定時の例外処理
- `mactl get vol -a` では kind フィルターを無効化し、全ボリュームを表示

3. 一覧フォーマット調整
- `NODE` 列幅を 10 文字に変更
- ヘッダ行/データ行の整列を更新

## 期待される効果
- 日常利用の `mactl get vol` は `data` ボリュームに絞られ、確認が容易になる
- 必要時は `-a` で従来どおり全件確認できる
- テキスト一覧の視認性が改善する

## テスト
- cmd の単体テストを実行し成功
- 追加/更新した主な確認
  - `data` のみ抽出されること
  - `-a` 指定時に全件が返ること
  - 既存コマンド群に回帰がないこと

## 互換性
- API レスポンス仕様の変更なし
- 変更は CLI 側の表示・フィルタリング挙動のみ
- `-a` を使わない `get vol` の表示対象は意図的に変更（`data` のみ）