### PR TITLE
存在しないノードに対する処理を改善

### DIFF
--- a/cmd/mactl/cmd/apply.go
+++ b/cmd/mactl/cmd/apply.go
@@ -228,12 +228,9 @@ func applyVolume(manifest map[string]interface{}) error {
 	if strings.TrimSpace(volume.Metadata.Name) == "" {
 		return fmt.Errorf("metadata.name is required")
 	}
-	if volume.Spec.Type == nil || strings.TrimSpace(*volume.Spec.Type) == "" {
-		return fmt.Errorf("spec.type is required")
-	}
-	if volume.Spec.Kind == nil || strings.TrimSpace(*volume.Spec.Kind) == "" {
-		return fmt.Errorf("spec.kind is required")
-	}
+
+	// spec.type/spec.kind の既定値を補完
+	ApplyVolumeDefaults(volume)
 
 	// ボリュームが既に存在するかチェック
 	exists := false

--- a/cmd/mactl/cmd/create.go
+++ b/cmd/mactl/cmd/create.go
@@ -200,12 +200,9 @@ func createVolume(manifest map[string]interface{}) error {
 	if strings.TrimSpace(volume.Metadata.Name) == "" {
 		return fmt.Errorf("metadata.name is required")
 	}
-	if volume.Spec.Type == nil || strings.TrimSpace(*volume.Spec.Type) == "" {
-		return fmt.Errorf("spec.type is required")
-	}
-	if volume.Spec.Kind == nil || strings.TrimSpace(*volume.Spec.Kind) == "" {
-		return fmt.Errorf("spec.kind is required")
-	}
+
+	// spec.type/spec.kind の既定値を補完
+	ApplyVolumeDefaults(volume)
 
 	// ボリュームが既に存在するかチェック
 	list, _, err := m.ListVolumes()

--- a/cmd/mactl/cmd/manifest.go
+++ b/cmd/mactl/cmd/manifest.go
@@ -255,6 +255,21 @@ func ApplyServerDefaults(server *api.Server) {
 	}
 }
 
+// ApplyVolumeDefaults は volume.spec の既定値を補完する。
+// spec.type が未指定なら qcow2、spec.kind が未指定なら data を設定する。
+func ApplyVolumeDefaults(volume *api.Volume) {
+	if volume == nil {
+		return
+	}
+
+	if volume.Spec.Type == nil || strings.TrimSpace(*volume.Spec.Type) == "" {
+		volume.Spec.Type = util.StringPtr("qcow2")
+	}
+	if volume.Spec.Kind == nil || strings.TrimSpace(*volume.Spec.Kind) == "" {
+		volume.Spec.Kind = util.StringPtr("data")
+	}
+}
+
 // ManifestToImage マニフェストを Image 構造体に変換
 func ManifestToImage(manifest map[string]interface{}) (*api.Image, error) {
 	data, err := json.Marshal(manifest)

--- a/cmd/mactl/cmd/volume_create.go
+++ b/cmd/mactl/cmd/volume_create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/config"
-	"github.com/takara9/marmot/pkg/util"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -35,12 +34,8 @@ var volumeCreateCmd = &cobra.Command{
 		if strings.TrimSpace(conf.Metadata.Name) == "" {
 			return fmt.Errorf("Metadata.name is required in the configuration")
 		}
-		if conf.Spec.Type == nil || strings.TrimSpace(*conf.Spec.Type) == "" {
-			conf.Spec.Type = util.StringPtr("qcow2")
-		}
-		if conf.Spec.Kind == nil || strings.TrimSpace(*conf.Spec.Kind) == "" {
-			conf.Spec.Kind = util.StringPtr("data")
-		}
+
+		ApplyVolumeDefaults(&conf)
 
 		byteBody, _, err := m.CreateVolume(conf)
 		if err != nil {

--- a/cmd/mactl/cmd/volume_create.go
+++ b/cmd/mactl/cmd/volume_create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/config"
+	"github.com/takara9/marmot/pkg/util"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -35,10 +36,10 @@ var volumeCreateCmd = &cobra.Command{
 			return fmt.Errorf("Metadata.name is required in the configuration")
 		}
 		if conf.Spec.Type == nil || strings.TrimSpace(*conf.Spec.Type) == "" {
-			return fmt.Errorf("Spec.type is required in the configuration")
+			conf.Spec.Type = util.StringPtr("qcow2")
 		}
 		if conf.Spec.Kind == nil || strings.TrimSpace(*conf.Spec.Kind) == "" {
-			return fmt.Errorf("Spec.kind is required in the configuration")
+			conf.Spec.Kind = util.StringPtr("data")
 		}
 
 		byteBody, _, err := m.CreateVolume(conf)

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -1,0 +1,13 @@
+package controller
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}

--- a/pkg/controller/server-controller_test.go
+++ b/pkg/controller/server-controller_test.go
@@ -2,164 +2,67 @@ package controller
 
 import (
 	"errors"
-	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/db"
 	"github.com/takara9/marmot/pkg/util"
 )
 
-func TestClusterHasAnyNode(t *testing.T) {
-	tests := []struct {
-		name     string
-		statuses []api.HostStatus
-		want     bool
-	}{
-		{
-			name: "has valid node",
-			statuses: []api.HostStatus{
-				{NodeName: util.StringPtr("hvc")},
+var _ = Describe("server controller helpers", func() {
+	Describe("clusterHasAnyNode", func() {
+		DescribeTable("cluster node availability",
+			func(statuses []api.HostStatus, want bool) {
+				Expect(clusterHasAnyNode(statuses)).To(Equal(want))
 			},
-			want: true,
-		},
-		{
-			name: "node name with spaces only",
-			statuses: []api.HostStatus{
-				{NodeName: util.StringPtr("   ")},
-				{},
+			Entry("has valid node", []api.HostStatus{{NodeName: util.StringPtr("hvc")}}, true),
+			Entry("node name with spaces only", []api.HostStatus{{NodeName: util.StringPtr("   ")}, {}}, false),
+			Entry("empty statuses", []api.HostStatus{}, false),
+		)
+	})
+
+	Describe("shouldBypassNodeGateForDeletingServer", func() {
+		deletingStatus := &api.Status{StatusCode: db.SERVER_DELETING}
+		runningStatus := &api.Status{StatusCode: db.SERVER_RUNNING}
+		statusesWithNode := []api.HostStatus{{NodeName: util.StringPtr("hvc")}}
+		emptyStatuses := []api.HostStatus{}
+
+		DescribeTable("bypass behavior by status and assignment",
+			func(spec api.Server, statuses []api.HostStatus, wantBypass bool, wantReason string) {
+				gotBypass, gotReason := shouldBypassNodeGateForDeletingServer(spec, statuses)
+				Expect(gotBypass).To(Equal(wantBypass))
+				Expect(gotReason).To(Equal(wantReason))
 			},
-			want: false,
-		},
-		{
-			name: "empty statuses",
-			statuses: []api.HostStatus{},
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := clusterHasAnyNode(tt.statuses)
-			if got != tt.want {
-				t.Fatalf("clusterHasAnyNode() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestShouldBypassNodeGateForDeletingServer(t *testing.T) {
-	deletingStatus := &api.Status{StatusCode: db.SERVER_DELETING}
-	runningStatus := &api.Status{StatusCode: db.SERVER_RUNNING}
-
-	statusesWithNode := []api.HostStatus{{NodeName: util.StringPtr("hvc")}}
-	emptyStatuses := []api.HostStatus{}
-
-	tests := []struct {
-		name       string
-		spec       api.Server
-		statuses   []api.HostStatus
-		wantBypass bool
-		wantReason string
-	}{
-		{
-			name:       "not deleting",
-			spec:       api.Server{Status: runningStatus},
-			statuses:   statusesWithNode,
-			wantBypass: false,
-			wantReason: "",
-		},
-		{
-			name:       "cluster empty",
-			spec:       api.Server{Status: deletingStatus},
-			statuses:   emptyStatuses,
-			wantBypass: true,
-			wantReason: "cluster_nodes_empty",
-		},
-		{
-			name: "assigned node not found",
-			spec: api.Server{
+			Entry("not deleting", api.Server{Status: runningStatus}, statusesWithNode, false, ""),
+			Entry("cluster empty", api.Server{Status: deletingStatus}, emptyStatuses, true, "cluster_nodes_empty"),
+			Entry("assigned node not found", api.Server{
 				Status: deletingStatus,
 				Metadata: api.Metadata{
 					NodeName: util.StringPtr("ws1"),
 				},
-			},
-			statuses:   statusesWithNode,
-			wantBypass: true,
-			wantReason: "assigned_node_not_found",
-		},
-		{
-			name: "assigned node found",
-			spec: api.Server{
+			}, statusesWithNode, true, "assigned_node_not_found"),
+			Entry("assigned node found", api.Server{
 				Status: deletingStatus,
 				Metadata: api.Metadata{
 					NodeName: util.StringPtr("hvc"),
 				},
+			}, statusesWithNode, false, ""),
+		)
+	})
+
+	Describe("isRetryableServerProvisionError", func() {
+		DescribeTable("retryable classification",
+			func(err error, want bool) {
+				Expect(isRetryableServerProvisionError(err)).To(Equal(want))
 			},
-			statuses:   statusesWithNode,
-			wantBypass: false,
-			wantReason: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotBypass, gotReason := shouldBypassNodeGateForDeletingServer(tt.spec, tt.statuses)
-			if gotBypass != tt.wantBypass || gotReason != tt.wantReason {
-				t.Fatalf("shouldBypassNodeGateForDeletingServer() = (%v, %q), want (%v, %q)", gotBypass, gotReason, tt.wantBypass, tt.wantReason)
-			}
-		})
-	}
-}
-
-func TestIsRetryableServerProvisionError(t *testing.T) {
-	tests := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{
-			name: "network missing is retryable",
-			err:  errors.New("network 'webservers-net' is not found"),
-			want: true,
-		},
-		{
-			name: "ssh key fetch transport error is retryable",
-			err:  errors.New("failed to fetch keys from https://github.com/foo.keys: Get \"https://github.com/foo.keys\": dial tcp: i/o timeout"),
-			want: true,
-		},
-		{
-			name: "ssh key fetch http status error is retryable",
-			err:  errors.New("unexpected HTTP status 503 from https://github.com/foo.keys"),
-			want: true,
-		},
-		{
-			name: "ssh key empty response is retryable",
-			err:  errors.New("no public keys found at https://github.com/foo.keys"),
-			want: true,
-		},
-		{
-			name: "missing qcow2 source file copy is retryable",
-			err:  errors.New("failed to copy QCOW2 volume from /var/lib/marmot/images/x/osimage-x.qcow2 to /var/lib/marmot/volumes/boot-y.qcow2: exit status 1 (output: cp: cannot stat '/var/lib/marmot/images/x/osimage-x.qcow2': No such file or directory)"),
-			want: true,
-		},
-		{
-			name: "other provisioning error is not retryable",
-			err:  errors.New("boot volume path is required for qcow2"),
-			want: false,
-		},
-		{
-			name: "nil error is not retryable",
-			err:  nil,
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isRetryableServerProvisionError(tt.err)
-			if got != tt.want {
-				t.Fatalf("isRetryableServerProvisionError() = %v, want %v, err=%v", got, tt.want, tt.err)
-			}
-		})
-	}
-}
+			Entry("network missing is retryable", errors.New("network 'webservers-net' is not found"), true),
+			Entry("ssh key fetch transport error is retryable", errors.New("failed to fetch keys from https://github.com/foo.keys: Get \"https://github.com/foo.keys\": dial tcp: i/o timeout"), true),
+			Entry("ssh key fetch http status error is retryable", errors.New("unexpected HTTP status 503 from https://github.com/foo.keys"), true),
+			Entry("ssh key empty response is retryable", errors.New("no public keys found at https://github.com/foo.keys"), true),
+			Entry("missing qcow2 source file copy is retryable", errors.New("failed to copy QCOW2 volume from /var/lib/marmot/images/x/osimage-x.qcow2 to /var/lib/marmot/volumes/boot-y.qcow2: exit status 1 (output: cp: cannot stat '/var/lib/marmot/images/x/osimage-x.qcow2': No such file or directory)"), true),
+			Entry("other provisioning error is not retryable", errors.New("boot volume path is required for qcow2"), false),
+			Entry("nil error is not retryable", nil, false),
+		)
+	})
+})

--- a/pkg/controller/volume-controller.go
+++ b/pkg/controller/volume-controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -68,6 +69,12 @@ func StartVolController(node string, etcdUrl string, deletionDelaySeconds int) (
 func (c *controller) volumeControllerLoop() {
 	slog.Debug("ボリュームコントローラーの制御ループ実行", "CONTROLLER", time.Now().Format("2006-01-02 15:04:05"))
 
+	statuses, err := c.marmot.Db.GetAllHostStatus()
+	if err != nil {
+		slog.Warn("GetAllHostStatus() failed; ボリュームの nodeName 存在確認をスキップ", "err", err)
+		statuses = nil
+	}
+
 	vols, err := c.marmot.GetVolumes()
 	if err != nil {
 		slog.Error("failed to get volumes", "err", err)
@@ -76,6 +83,28 @@ func (c *controller) volumeControllerLoop() {
 	slog.Debug("取得したボリュームの数", "numVolumes", len(vols))
 	for _, vol := range vols {
 		volID := api.VolumeID(vol)
+		if shouldFail, message := shouldFailVolumeForMissingAssignedNode(vol, statuses); shouldFail {
+			assignedNode := ""
+			if vol.Metadata.NodeName != nil {
+				assignedNode = strings.TrimSpace(*vol.Metadata.NodeName)
+			}
+			slog.Warn("存在しない nodeName 指定のためボリュームを ERROR に更新", "volId", volID, "assignedNode", assignedNode, "message", message)
+			c.db.UpdateVolumeStatusMessage(volID, db.VOLUME_ERROR, message)
+			continue
+		}
+
+		if shouldDelete, reason := shouldDeleteVolumeForMissingAssignedNode(vol, statuses); shouldDelete {
+			assignedNode := ""
+			if vol.Metadata.NodeName != nil {
+				assignedNode = strings.TrimSpace(*vol.Metadata.NodeName)
+			}
+			slog.Warn("存在しない nodeName 指定のためボリューム定義を削除", "volId", volID, "assignedNode", assignedNode, "reason", reason)
+			if err := c.db.DeleteVolume(volID); err != nil {
+				slog.Error("DeleteVolume()", "err", err, "volId", volID)
+			}
+			continue
+		}
+
 		if ok, assignedNode, reason := evaluateNodeAssignment(&vol.Metadata, c.marmot.NodeName); !ok {
 			objectName := vol.Metadata.Name
 			slog.Debug("別ノード割当のボリュームをスキップ", "volumeId", volID, "volumeName", objectName, "controllerNode", c.marmot.NodeName, "assignedNode", assignedNode, "reason", reason)
@@ -189,4 +218,58 @@ func (c *controller) volumeControllerLoop() {
 		}
 	}
 	// ワークキューから処理を取り出して、処理を実行する
+}
+
+func shouldDeleteVolumeForMissingAssignedNode(vol api.Volume, statuses []api.HostStatus) (bool, string) {
+	if vol.Status == nil || vol.Status.StatusCode != db.VOLUME_DELETING {
+		return false, ""
+	}
+
+	if vol.Metadata.NodeName == nil {
+		return false, ""
+	}
+
+	assignedNode := strings.TrimSpace(*vol.Metadata.NodeName)
+	if assignedNode == "" {
+		return false, ""
+	}
+
+	if !clusterHasAnyNode(statuses) {
+		return false, ""
+	}
+
+	if clusterHasNode(statuses, assignedNode) {
+		return false, ""
+	}
+
+	return true, "assigned_node_not_found"
+}
+
+func shouldFailVolumeForMissingAssignedNode(vol api.Volume, statuses []api.HostStatus) (bool, string) {
+	if vol.Status == nil {
+		return false, ""
+	}
+
+	if vol.Status.StatusCode != db.VOLUME_PENDING && vol.Status.StatusCode != db.VOLUME_PROVISIONING {
+		return false, ""
+	}
+
+	if vol.Metadata.NodeName == nil {
+		return false, ""
+	}
+
+	assignedNode := strings.TrimSpace(*vol.Metadata.NodeName)
+	if assignedNode == "" {
+		return false, ""
+	}
+
+	if !clusterHasAnyNode(statuses) {
+		return false, ""
+	}
+
+	if clusterHasNode(statuses, assignedNode) {
+		return false, ""
+	}
+
+	return true, fmt.Sprintf("metadata.nodeName %q is not found in cluster", assignedNode)
 }

--- a/pkg/controller/volume-controller_test.go
+++ b/pkg/controller/volume-controller_test.go
@@ -1,0 +1,127 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestShouldDeleteVolumeForMissingAssignedNode(t *testing.T) {
+	hvc := util.StringPtr("hvc")
+	ws1 := util.StringPtr("ws1")
+	statuses := []api.HostStatus{{NodeName: hvc}}
+
+	tests := []struct {
+		name     string
+		vol      api.Volume
+		statuses []api.HostStatus
+		wantDelete bool
+	}{
+		{
+			name: "pending volume with missing assigned node does not delete",
+			vol: api.Volume{
+				Metadata: api.Metadata{NodeName: ws1},
+				Status:   &api.Status{StatusCode: db.VOLUME_PENDING},
+			},
+			statuses: statuses,
+			wantDelete: false,
+		},
+		{
+			name: "deleting volume with existing assigned node does not delete",
+			vol: api.Volume{
+				Metadata: api.Metadata{NodeName: hvc},
+				Status:   &api.Status{StatusCode: db.VOLUME_DELETING},
+			},
+			statuses: statuses,
+			wantDelete: false,
+		},
+		{
+			name: "deleting volume with missing assigned node deletes",
+			vol: api.Volume{
+				Metadata: api.Metadata{NodeName: ws1},
+				Status:   &api.Status{StatusCode: db.VOLUME_DELETING},
+			},
+			statuses: statuses,
+			wantDelete: true,
+		},
+		{
+			name: "empty cluster status skips delete to avoid false positives",
+			vol: api.Volume{
+				Metadata: api.Metadata{NodeName: ws1},
+				Status:   &api.Status{StatusCode: db.VOLUME_PENDING},
+			},
+			statuses: []api.HostStatus{},
+			wantDelete: false,
+		},
+		{
+			name: "nil nodeName does not delete",
+			vol: api.Volume{
+				Metadata: api.Metadata{},
+				Status:   &api.Status{StatusCode: db.VOLUME_DELETING},
+			},
+			statuses: statuses,
+			wantDelete: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDelete, _ := shouldDeleteVolumeForMissingAssignedNode(tt.vol, tt.statuses)
+			if gotDelete != tt.wantDelete {
+				t.Fatalf("shouldDeleteVolumeForMissingAssignedNode() = %v, want %v", gotDelete, tt.wantDelete)
+			}
+		})
+	}
+}
+
+func TestShouldFailVolumeForMissingAssignedNode(t *testing.T) {
+	hvc := util.StringPtr("hvc")
+	ws1 := util.StringPtr("ws1")
+	statuses := []api.HostStatus{{NodeName: hvc}}
+
+	tests := []struct {
+		name     string
+		vol      api.Volume
+		statuses []api.HostStatus
+		wantFail bool
+	}{
+		{
+			name: "pending volume with missing assigned node fails",
+			vol: api.Volume{
+				Metadata: api.Metadata{NodeName: ws1},
+				Status:   &api.Status{StatusCode: db.VOLUME_PENDING},
+			},
+			statuses: statuses,
+			wantFail: true,
+		},
+		{
+			name: "provisioning volume with missing assigned node fails",
+			vol: api.Volume{
+				Metadata: api.Metadata{NodeName: ws1},
+				Status:   &api.Status{StatusCode: db.VOLUME_PROVISIONING},
+			},
+			statuses: statuses,
+			wantFail: true,
+		},
+		{
+			name: "deleting volume with missing assigned node does not fail",
+			vol: api.Volume{
+				Metadata: api.Metadata{NodeName: ws1},
+				Status:   &api.Status{StatusCode: db.VOLUME_DELETING},
+			},
+			statuses: statuses,
+			wantFail: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFail, _ := shouldFailVolumeForMissingAssignedNode(tt.vol, tt.statuses)
+			if gotFail != tt.wantFail {
+				t.Fatalf("shouldFailVolumeForMissingAssignedNode() = %v, want %v", gotFail, tt.wantFail)
+			}
+		})
+	}
+}

--- a/pkg/controller/volume-controller_test.go
+++ b/pkg/controller/volume-controller_test.go
@@ -14,10 +14,11 @@ func TestShouldDeleteVolumeForMissingAssignedNode(t *testing.T) {
 	statuses := []api.HostStatus{{NodeName: hvc}}
 
 	tests := []struct {
-		name     string
-		vol      api.Volume
-		statuses []api.HostStatus
+		name       string
+		vol        api.Volume
+		statuses   []api.HostStatus
 		wantDelete bool
+		wantReason string
 	}{
 		{
 			name: "pending volume with missing assigned node does not delete",
@@ -25,8 +26,9 @@ func TestShouldDeleteVolumeForMissingAssignedNode(t *testing.T) {
 				Metadata: api.Metadata{NodeName: ws1},
 				Status:   &api.Status{StatusCode: db.VOLUME_PENDING},
 			},
-			statuses: statuses,
+			statuses:   statuses,
 			wantDelete: false,
+			wantReason: "",
 		},
 		{
 			name: "deleting volume with existing assigned node does not delete",
@@ -34,8 +36,9 @@ func TestShouldDeleteVolumeForMissingAssignedNode(t *testing.T) {
 				Metadata: api.Metadata{NodeName: hvc},
 				Status:   &api.Status{StatusCode: db.VOLUME_DELETING},
 			},
-			statuses: statuses,
+			statuses:   statuses,
 			wantDelete: false,
+			wantReason: "",
 		},
 		{
 			name: "deleting volume with missing assigned node deletes",
@@ -43,17 +46,19 @@ func TestShouldDeleteVolumeForMissingAssignedNode(t *testing.T) {
 				Metadata: api.Metadata{NodeName: ws1},
 				Status:   &api.Status{StatusCode: db.VOLUME_DELETING},
 			},
-			statuses: statuses,
+			statuses:   statuses,
 			wantDelete: true,
+			wantReason: "assigned_node_not_found",
 		},
 		{
 			name: "empty cluster status skips delete to avoid false positives",
 			vol: api.Volume{
 				Metadata: api.Metadata{NodeName: ws1},
-				Status:   &api.Status{StatusCode: db.VOLUME_PENDING},
+				Status:   &api.Status{StatusCode: db.VOLUME_DELETING},
 			},
-			statuses: []api.HostStatus{},
+			statuses:   []api.HostStatus{},
 			wantDelete: false,
+			wantReason: "",
 		},
 		{
 			name: "nil nodeName does not delete",
@@ -61,16 +66,20 @@ func TestShouldDeleteVolumeForMissingAssignedNode(t *testing.T) {
 				Metadata: api.Metadata{},
 				Status:   &api.Status{StatusCode: db.VOLUME_DELETING},
 			},
-			statuses: statuses,
+			statuses:   statuses,
 			wantDelete: false,
+			wantReason: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotDelete, _ := shouldDeleteVolumeForMissingAssignedNode(tt.vol, tt.statuses)
+			gotDelete, gotReason := shouldDeleteVolumeForMissingAssignedNode(tt.vol, tt.statuses)
 			if gotDelete != tt.wantDelete {
 				t.Fatalf("shouldDeleteVolumeForMissingAssignedNode() = %v, want %v", gotDelete, tt.wantDelete)
+			}
+			if gotReason != tt.wantReason {
+				t.Fatalf("shouldDeleteVolumeForMissingAssignedNode() reason = %q, want %q", gotReason, tt.wantReason)
 			}
 		})
 	}
@@ -82,10 +91,11 @@ func TestShouldFailVolumeForMissingAssignedNode(t *testing.T) {
 	statuses := []api.HostStatus{{NodeName: hvc}}
 
 	tests := []struct {
-		name     string
-		vol      api.Volume
-		statuses []api.HostStatus
+		name       string
+		vol        api.Volume
+		statuses   []api.HostStatus
 		wantFail bool
+		wantMessage string
 	}{
 		{
 			name: "pending volume with missing assigned node fails",
@@ -93,8 +103,9 @@ func TestShouldFailVolumeForMissingAssignedNode(t *testing.T) {
 				Metadata: api.Metadata{NodeName: ws1},
 				Status:   &api.Status{StatusCode: db.VOLUME_PENDING},
 			},
-			statuses: statuses,
-			wantFail: true,
+			statuses:    statuses,
+			wantFail:    true,
+			wantMessage: "metadata.nodeName \"ws1\" is not found in cluster",
 		},
 		{
 			name: "provisioning volume with missing assigned node fails",
@@ -102,8 +113,9 @@ func TestShouldFailVolumeForMissingAssignedNode(t *testing.T) {
 				Metadata: api.Metadata{NodeName: ws1},
 				Status:   &api.Status{StatusCode: db.VOLUME_PROVISIONING},
 			},
-			statuses: statuses,
-			wantFail: true,
+			statuses:    statuses,
+			wantFail:    true,
+			wantMessage: "metadata.nodeName \"ws1\" is not found in cluster",
 		},
 		{
 			name: "deleting volume with missing assigned node does not fail",
@@ -111,16 +123,20 @@ func TestShouldFailVolumeForMissingAssignedNode(t *testing.T) {
 				Metadata: api.Metadata{NodeName: ws1},
 				Status:   &api.Status{StatusCode: db.VOLUME_DELETING},
 			},
-			statuses: statuses,
-			wantFail: false,
+			statuses:    statuses,
+			wantFail:    false,
+			wantMessage: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFail, _ := shouldFailVolumeForMissingAssignedNode(tt.vol, tt.statuses)
+			gotFail, gotMessage := shouldFailVolumeForMissingAssignedNode(tt.vol, tt.statuses)
 			if gotFail != tt.wantFail {
 				t.Fatalf("shouldFailVolumeForMissingAssignedNode() = %v, want %v", gotFail, tt.wantFail)
+			}
+			if gotMessage != tt.wantMessage {
+				t.Fatalf("shouldFailVolumeForMissingAssignedNode() message = %q, want %q", gotMessage, tt.wantMessage)
 			}
 		})
 	}

--- a/pkg/db/db-volumes.go
+++ b/pkg/db/db-volumes.go
@@ -93,13 +93,13 @@ func (d *Database) CreateVolumeOnDB2(inputVol api.Volume) (*api.Volume, error) {
 		volume.Metadata.Name = name
 	}
 	// OSかDATAかの種別で、サイズのデフォルト値を変える
-	if volume.Spec.Kind == nil {
+	if volume.Spec.Kind == nil || strings.TrimSpace(*volume.Spec.Kind) == "" {
 		volume.Spec.Kind = util.StringPtr("data") // デフォルトはdata
 		// サイズのデフォルト値を設定
 		if volume.Spec.Size == nil {
 			volume.Spec.Size = util.IntPtrInt(1) // 1GB
 		}
-	} else if *volume.Spec.Kind == "os" {
+	} else if strings.TrimSpace(*volume.Spec.Kind) == "os" {
 		// OSボリュームはサイズ未指定(または0以下)時のみデフォルト値を設定
 		if volume.Spec.Size == nil || *volume.Spec.Size <= 0 {
 			volume.Spec.Size = util.IntPtrInt(16) // 16GB
@@ -107,13 +107,13 @@ func (d *Database) CreateVolumeOnDB2(inputVol api.Volume) (*api.Volume, error) {
 	}
 
 	// ボリュームタイプのデフォルト値を設定し、パスを決定する
-	if volume.Spec.Type == nil {
+	if volume.Spec.Type == nil || strings.TrimSpace(*volume.Spec.Type) == "" {
 		volume.Spec.Type = util.StringPtr("qcow2")
 	}
 
 	// QCOW2ボリュームの場合、パスを決定する。OSとDATAでパスを分ける。OSはboot-<id>.qcow2、DATAはdata-<id>.qcow2
-	if *volume.Spec.Type == "qcow2" {
-		if *volume.Spec.Kind == "os" {
+	if strings.TrimSpace(*volume.Spec.Type) == "qcow2" {
+		if strings.TrimSpace(*volume.Spec.Kind) == "os" {
 			volume.Spec.Path = util.StringPtr(fmt.Sprintf("/var/lib/marmot/volumes/boot-%s.qcow2", api.VolumeID(volume)))
 		} else {
 			volume.Spec.Path = util.StringPtr(fmt.Sprintf("/var/lib/marmot/volumes/data-%s.qcow2", api.VolumeID(volume)))
@@ -121,12 +121,12 @@ func (d *Database) CreateVolumeOnDB2(inputVol api.Volume) (*api.Volume, error) {
 	}
 
 	// LVMボリュームの場合、パスを決定する
-	if *volume.Spec.Type == "lvm" {
+	if strings.TrimSpace(*volume.Spec.Type) == "lvm" {
 		configureLVMVolumeSpec(&volume.Spec, api.VolumeID(volume))
 	}
 
 	// OSボリュームの場合、OsVariantのデフォルト値を設定する  必要か？
-	if *volume.Spec.Kind == "os" {
+	if strings.TrimSpace(*volume.Spec.Kind) == "os" {
 		if volume.Spec.OsVariant == nil {
 			volume.Spec.OsVariant = util.StringPtr("ubuntu22.04")
 		}


### PR DESCRIPTION
## 概要
存在しない metadata.nodeName が指定された Volume の扱いを整理し、削除時のみオブジェクト削除で完了するように改善しました。  
あわせて、作成時の挙動は従来どおり維持し、意図しない挙動変更を防いでいます。

## 背景・課題
- 存在しないノード名が metadata.nodeName に指定された Volume が残留し、処理が完了しないケースがある
- 一方で、作成時のエラー挙動まで変えてしまうと既存運用に影響が出る

## 変更内容
1. 削除時のみの特例処理を追加
- metadata.nodeName がクラスタ内に存在しない
- かつステータスが DELETING
- 上記条件を満たす場合、Volume オブジェクトを削除して処理完了とする

2. 作成時の挙動は維持
- PENDING/PROVISIONING で存在しないノード指定の場合は、従来どおり VOLUME_ERROR に遷移
- 作成系のリトライ/エラー制御の方針は変更しない

3. 判定ロジックの分離
- 削除対象判定と作成系エラー判定を分離し、意図が明確な実装に整理

## 期待される効果
- 実体が存在しないノードに紐づいた削除対象 Volume が残留せず、クリーンに完了できる
- 作成時の既存挙動を維持しつつ、削除時の運用詰まりのみ解消できる

## テスト
- controller の関連テストで以下を確認
  - DELETING かつ nodeName 不在時のみ削除判定になること
  - PENDING/PROVISIONING は削除せず、エラー側判定になること
- 既存パッケージのコンパイル/テスト実行で回帰がないことを確認

## 互換性
- API 仕様変更なし
- 変更はコントローラーの状態遷移ロジックのみ
- 既存の作成時エラー挙動は維持されるため、互換性リスクは低い