### PR TITLE
iSCSI時にはAnyホストにスケジュールする

### DIFF
--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -104,18 +104,18 @@ func (m *Marmot) findPreCreatedStorageVolume(disk api.Volume) (*api.Volume, erro
 	return selectReusableVolume(volumes)
 }
 
-func (m *Marmot) resolveStorageBoundNodeName(storage *[]api.Volume) (string, error) {
-	if storage == nil {
-		return "", nil
-	}
-
+// nodeNameFromResolvedVolumes は解決済みのボリューム一覧からサーバーのノード制約を導出する。
+// spec.iscsiTargetIqn がセットされているボリュームはネットワーク越しにどのノードからも
+// アクセス可能なため、ノード配置制約の対象外とする。
+func nodeNameFromResolvedVolumes(vols []*api.Volume) (string, error) {
 	boundNode := ""
-	for i, disk := range *storage {
-		vol, err := m.findPreCreatedStorageVolume(disk)
-		if err != nil {
-			return "", fmt.Errorf("storage[%d] volume lookup failed: %w", i, err)
-		}
+	for _, vol := range vols {
 		if vol == nil || vol.Metadata.NodeName == nil {
+			continue
+		}
+
+		// iSCSI ターゲット IQN がセットされているボリュームは配置制約の対象外。
+		if vol.Spec.IscsiTargetIqn != nil && strings.TrimSpace(*vol.Spec.IscsiTargetIqn) != "" {
 			continue
 		}
 
@@ -131,8 +131,24 @@ func (m *Marmot) resolveStorageBoundNodeName(storage *[]api.Volume) (string, err
 			return "", fmt.Errorf("storage volumes are distributed across nodes: %q and %q", boundNode, node)
 		}
 	}
-
 	return boundNode, nil
+}
+
+func (m *Marmot) resolveStorageBoundNodeName(storage *[]api.Volume) (string, error) {
+	if storage == nil {
+		return "", nil
+	}
+
+	vols := make([]*api.Volume, 0, len(*storage))
+	for i, disk := range *storage {
+		vol, err := m.findPreCreatedStorageVolume(disk)
+		if err != nil {
+			return "", fmt.Errorf("storage[%d] volume lookup failed: %w", i, err)
+		}
+		vols = append(vols, vol)
+	}
+
+	return nodeNameFromResolvedVolumes(vols)
 }
 
 

--- a/pkg/marmotd/server_storage_scheduling_test.go
+++ b/pkg/marmotd/server_storage_scheduling_test.go
@@ -3,6 +3,7 @@ package marmotd
 import (
 	"testing"
 
+	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/util"
 )
 
@@ -51,6 +52,107 @@ func TestChooseAssignedNodeName(t *testing.T) {
 		_, err := chooseAssignedNodeName("hv-default", util.StringPtr("hv-requested"), "hv-storage")
 		if err == nil {
 			t.Fatal("chooseAssignedNodeName() error = nil, want conflict error")
+		}
+	})
+}
+
+func volWithNode(nodeName string) *api.Volume {
+	return &api.Volume{Metadata: api.Metadata{NodeName: util.StringPtr(nodeName)}}
+}
+
+func volWithNodeAndIqn(nodeName, iqn string) *api.Volume {
+	return &api.Volume{
+		Metadata: api.Metadata{NodeName: util.StringPtr(nodeName)},
+		Spec:     api.VolSpec{IscsiTargetIqn: util.StringPtr(iqn)},
+	}
+}
+
+func TestNodeNameFromResolvedVolumes(t *testing.T) {
+	t.Run("returns empty when no volumes", func(t *testing.T) {
+		node, err := nodeNameFromResolvedVolumes(nil)
+		if err != nil || node != "" {
+			t.Fatalf("got (%q, %v), want (\"\", nil)", node, err)
+		}
+	})
+
+	t.Run("returns node from single volume", func(t *testing.T) {
+		node, err := nodeNameFromResolvedVolumes([]*api.Volume{volWithNode("hv1")})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if node != "hv1" {
+			t.Fatalf("got %q, want %q", node, "hv1")
+		}
+	})
+
+	t.Run("returns same node when all volumes on same node", func(t *testing.T) {
+		vols := []*api.Volume{volWithNode("hv1"), volWithNode("hv1")}
+		node, err := nodeNameFromResolvedVolumes(vols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if node != "hv1" {
+			t.Fatalf("got %q, want %q", node, "hv1")
+		}
+	})
+
+	t.Run("returns error when volumes on different nodes", func(t *testing.T) {
+		vols := []*api.Volume{volWithNode("hv1"), volWithNode("hv2")}
+		_, err := nodeNameFromResolvedVolumes(vols)
+		if err == nil {
+			t.Fatal("expected error for volumes on different nodes, got nil")
+		}
+	})
+
+	t.Run("ignores iscsiTargetIqn volume for node binding", func(t *testing.T) {
+		// iSCSI IQN がセットされたボリュームはどのノードからもアクセス可能なので制約しない
+		vols := []*api.Volume{volWithNodeAndIqn("hv-iscsi", "iqn.2023-01.com.example:target1")}
+		node, err := nodeNameFromResolvedVolumes(vols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if node != "" {
+			t.Fatalf("got %q, want empty (iscsi volume should not constrain node)", node)
+		}
+	})
+
+	t.Run("local volume determines node; iscsiTargetIqn volume is ignored", func(t *testing.T) {
+		vols := []*api.Volume{
+			volWithNode("hv1"),
+			volWithNodeAndIqn("hv-iscsi", "iqn.2023-01.com.example:target1"),
+		}
+		node, err := nodeNameFromResolvedVolumes(vols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if node != "hv1" {
+			t.Fatalf("got %q, want %q", node, "hv1")
+		}
+	})
+
+	t.Run("iscsiTargetIqn volumes on mixed nodes do not cause conflict error", func(t *testing.T) {
+		// 2つの iSCSI ボリュームが異なるノードに存在しても、配置制約はかからない
+		vols := []*api.Volume{
+			volWithNodeAndIqn("hv1", "iqn.2023-01.com.example:target1"),
+			volWithNodeAndIqn("hv2", "iqn.2023-01.com.example:target2"),
+		}
+		node, err := nodeNameFromResolvedVolumes(vols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if node != "" {
+			t.Fatalf("got %q, want empty", node)
+		}
+	})
+
+	t.Run("skips nil volume", func(t *testing.T) {
+		vols := []*api.Volume{nil, volWithNode("hv1")}
+		node, err := nodeNameFromResolvedVolumes(vols)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if node != "hv1" {
+			t.Fatalf("got %q, want %q", node, "hv1")
 		}
 	})
 }


### PR DESCRIPTION
## 概要
iSCSI ボリューム利用時のサーバ配置判定を見直し、`spec.iscsiTargetIqn` が設定されたボリュームはノード拘束の対象外にしました。  
これにより、iSCSI ボリュームのみを利用する場合に Any ホストへスケジュールできるようになります。

## 背景
従来の配置判定では、解決済みストレージの `metadata.nodeName` を一律で参照していたため、ネットワーク越しに利用可能な iSCSI ボリュームでもノード固定が発生していました。  
その結果、不要なスケジューリング制約やノード衝突エラーにつながる可能性がありました。

## 変更内容
1. ノード拘束判定ロジックを関数として分離し、解決済みボリューム群から判定する形に整理
2. `spec.iscsiTargetIqn` が空でないボリュームはノード拘束判定から除外
3. 既存のボリューム解決処理（事前作成ボリュームの参照フロー）は維持
4. ユニットテストを拡充し、以下を追加検証
   - iSCSI ボリュームのみの場合は拘束なし（空ノード）
   - ローカル + iSCSI 混在時はローカル側ノードで拘束
   - iSCSI 同士で異なるノード情報でも衝突エラーにならない
   - 従来ケース（同一ノード/異ノード/空入力/nil要素）も網羅

## 期待される効果
- iSCSI 利用時の過剰なノード固定を解消
- ストレージ特性（ローカル/ネットワーク共有）に沿った配置判定に改善
- ローカルボリューム由来の安全な拘束判定は継続

## 動作確認
1. `go test ./pkg/marmotd -run 'TestNodeNameFromResolvedVolumes|TestChooseAssignedNodeName'`
2. 結果: `ok` (pass)