### PR TITLE
イメージ処理の実装（途上）

### DIFF
--- a/cmd/mactl/cmd/manifest_test.go
+++ b/cmd/mactl/cmd/manifest_test.go
@@ -207,5 +207,31 @@ spec:
 				ApplyServerDefaults(server)
 			}).NotTo(Panic())
 		})
+
+		Describe("ManifestToImage", func() {
+			It("maps spec.osName and spec.osVersion", func() {
+				manifest := map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Image",
+					"metadata": map[string]interface{}{
+						"name": "ubuntu26.04",
+					},
+					"spec": map[string]interface{}{
+						"sourceUrl": "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img",
+						"osName":    "ubuntu",
+						"osVersion": "26.04",
+					},
+				}
+
+				image, err := ManifestToImage(manifest)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image.Spec.SourceUrl).NotTo(BeNil())
+				Expect(*image.Spec.SourceUrl).To(Equal("https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"))
+				Expect(image.Spec.OsName).NotTo(BeNil())
+				Expect(*image.Spec.OsName).To(Equal("ubuntu"))
+				Expect(image.Spec.OsVersion).NotTo(BeNil())
+				Expect(*image.Spec.OsVersion).To(Equal("26.04"))
+			})
+		})
 	})
 })

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,7 +16,7 @@ var _ = Describe("ReadYamlConfig", func() {
 	It("decodes lowerCamel keys like apiVersion and sourceUrl", func() {
 		tmpDir := GinkgoT().TempDir()
 		configPath := filepath.Join(tmpDir, "image.yaml")
-		content := "apiVersion: v1\nkind: Image\nmetadata:\n  name: ubuntu22.04\nspec:\n  sourceUrl: http://hmc/ubuntu-22.04-server-cloudimg-amd64.img\n"
+		content := "apiVersion: v1\nkind: Image\nmetadata:\n  name: ubuntu22.04\nspec:\n  sourceUrl: http://hmc/ubuntu-22.04-server-cloudimg-amd64.img\n  osName: ubuntu\n  osVersion: \"24.04\"\n"
 
 		err := os.WriteFile(configPath, []byte(content), 0o600)
 		Expect(err).NotTo(HaveOccurred())
@@ -29,6 +29,10 @@ var _ = Describe("ReadYamlConfig", func() {
 		Expect(conf.Metadata.Name).To(Equal("ubuntu22.04"))
 		Expect(conf.Spec.SourceUrl).NotTo(BeNil())
 		Expect(*conf.Spec.SourceUrl).To(Equal("http://hmc/ubuntu-22.04-server-cloudimg-amd64.img"))
+		Expect(conf.Spec.OsName).NotTo(BeNil())
+		Expect(*conf.Spec.OsName).To(Equal("ubuntu"))
+		Expect(conf.Spec.OsVersion).NotTo(BeNil())
+		Expect(*conf.Spec.OsVersion).To(Equal("24.04"))
 	})
 
 	It("reads a YAML config from a file", func() {

--- a/pkg/controller/image-controller.go
+++ b/pkg/controller/image-controller.go
@@ -167,6 +167,10 @@ func (c *controller) imageControllerLoop() {
 			if err := marmotd.CheckImageBackingStore(image); err != nil {
 				slog.Warn("AVAILABLE イメージの実体が見つからないため DELETED に更新", "imageId", image.Metadata.Id, "err", err)
 				c.marmot.Db.UpdateImageStatusMessage(image.Metadata.Id, db.IMAGE_DELETED, err.Error())
+				continue
+			}
+			if err := c.reconcileFollowerImageSpec(image); err != nil {
+				slog.Warn("フォロワーIMAGEのspec同期に失敗", "imageId", image.Metadata.Id, "err", err)
 			}
 		case db.IMAGE_DELETING:
 			slog.Debug("イメージの削除処理を実行", "image", image.Metadata.Name)
@@ -307,6 +311,30 @@ func (c *controller) syncFollowerImageFromHead(followerImage api.Image, headImag
 	followerLatest.Spec.Kind = util.StringPtr("os")
 	followerLatest.Spec.Type = util.StringPtr("qcow2")
 	followerLatest.Spec.SourceUrl = nil
+	if headImage.Spec.Kind != nil {
+		followerLatest.Spec.Kind = util.StringPtr(*headImage.Spec.Kind)
+	}
+	if headImage.Spec.Type != nil {
+		followerLatest.Spec.Type = util.StringPtr(*headImage.Spec.Type)
+	}
+	if headImage.Spec.SourceUrl != nil {
+		sourceURL := strings.TrimSpace(*headImage.Spec.SourceUrl)
+		if sourceURL != "" {
+			followerLatest.Spec.SourceUrl = util.StringPtr(sourceURL)
+		}
+	}
+	if headImage.Spec.OsName != nil {
+		osName := strings.TrimSpace(*headImage.Spec.OsName)
+		if osName != "" {
+			followerLatest.Spec.OsName = util.StringPtr(osName)
+		}
+	}
+	if headImage.Spec.OsVersion != nil {
+		osVersion := strings.TrimSpace(*headImage.Spec.OsVersion)
+		if osVersion != "" {
+			followerLatest.Spec.OsVersion = util.StringPtr(osVersion)
+		}
+	}
 	if headImage.Spec.Size != nil {
 		followerLatest.Spec.Size = util.IntPtrInt(*headImage.Spec.Size)
 	}
@@ -324,8 +352,80 @@ func (c *controller) syncFollowerImageFromHead(followerImage api.Image, headImag
 	if err := c.marmot.Db.UpdateImage(followerLatest.Metadata.Id, followerLatest); err != nil {
 		return err
 	}
+	c.marmot.Db.UpdateImageStatus(followerLatest.Metadata.Id, db.IMAGE_AVAILABLE)
 
 	return nil
+}
+
+func (c *controller) reconcileFollowerImageSpec(followerImage api.Image) error {
+	if followerImage.Metadata.Labels == nil {
+		return nil
+	}
+	labels := *followerImage.Metadata.Labels
+	if db.GetFollowerSyncRole(labels) != "follower" {
+		return nil
+	}
+	headImageID := db.GetHeadImageID(labels)
+	if headImageID == "" {
+		return nil
+	}
+
+	headImage, err := c.marmot.Db.GetImage(headImageID)
+	if err != nil {
+		return err
+	}
+
+	changed := false
+	changed = setStringPtrFromHead(&followerImage.Spec.Kind, headImage.Spec.Kind) || changed
+	changed = setStringPtrFromHead(&followerImage.Spec.Type, headImage.Spec.Type) || changed
+	changed = setStringPtrFromHead(&followerImage.Spec.SourceUrl, headImage.Spec.SourceUrl) || changed
+	changed = setStringPtrFromHead(&followerImage.Spec.OsName, headImage.Spec.OsName) || changed
+	changed = setStringPtrFromHead(&followerImage.Spec.OsVersion, headImage.Spec.OsVersion) || changed
+	changed = setIntPtrFromHead(&followerImage.Spec.Size, headImage.Spec.Size) || changed
+
+	if !changed {
+		return nil
+	}
+
+	return c.marmot.Db.UpdateImage(followerImage.Metadata.Id, followerImage)
+}
+
+func setStringPtrFromHead(dst **string, src *string) bool {
+	if src == nil {
+		if *dst != nil {
+			*dst = nil
+			return true
+		}
+		return false
+	}
+	trimmed := strings.TrimSpace(*src)
+	if trimmed == "" {
+		if *dst != nil {
+			*dst = nil
+			return true
+		}
+		return false
+	}
+	if *dst != nil && strings.TrimSpace(**dst) == trimmed {
+		return false
+	}
+	*dst = util.StringPtr(trimmed)
+	return true
+}
+
+func setIntPtrFromHead(dst **int, src *int) bool {
+	if src == nil {
+		if *dst != nil {
+			*dst = nil
+			return true
+		}
+		return false
+	}
+	if *dst != nil && **dst == *src {
+		return false
+	}
+	*dst = util.IntPtrInt(*src)
+	return true
 }
 
 func buildHeadImageDownloadURL(headIP, imageID string) string {

--- a/pkg/db/db-image.go
+++ b/pkg/db/db-image.go
@@ -528,25 +528,47 @@ func (d *Database) UpdateImageStatus(id string, status int) {
 
 // ステータスとメッセージの変更
 func (d *Database) UpdateImageStatusMessage(id string, status int, message string) {
-	slog.Debug("SetImageStatus() called", "id", id, "status", status)
-	image, err := d.GetImage(id)
+	for {
+		err := d.updateImageStatusMessage(id, status, message)
+		if err == ErrUpdateConflict {
+			slog.Warn("UpdateImageStatusMessage() retrying due to update conflict", "imageId", id)
+			continue
+		}
+		if err != nil {
+			slog.Error("UpdateImageStatusMessage() failed", "err", err, "imageId", id)
+			panic(err)
+		}
+		return
+	}
+}
+
+func (d *Database) updateImageStatusMessage(id string, status int, message string) error {
+	lockKey := "/lock/image/" + id
+	mutex, err := d.LockKey(lockKey)
 	if err != nil {
-		slog.Error("SetDeleteTimestamp() GetImage() failed", "err", err, "imageId", id)
-		panic(err)
+		return err
 	}
-	image.Status.StatusCode = status
-	image.Status.Status = util.StringPtr(ImageStatus[status])
-	// 状態が変わるたびにメッセージを消す（ポインタをnilにする）
-	image.Status.Message = nil
-	// 必要なら新しいメッセージをセット
-	if len(message) > 0 {
-		image.Status.Message = util.StringPtr(message)
+	defer d.UnlockKey(mutex)
+
+	var rec api.Image
+	key := ImagePrefix + "/" + id
+	resp, err := d.GetJSON(key, &rec)
+	if err != nil {
+		return err
 	}
-	image.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
-	if err := d.UpdateImage(id, image); err != nil {
-		slog.Error("SetDeleteTimestamp() UpdateImage() failed", "err", err, "imageId", id)
-		panic(err)
+
+	if rec.Status == nil {
+		rec.Status = &api.Status{}
 	}
+	rec.Status.StatusCode = status
+	rec.Status.Status = util.StringPtr(ImageStatus[status])
+	rec.Status.Message = nil
+	if trimmed := strings.TrimSpace(message); trimmed != "" {
+		rec.Status.Message = util.StringPtr(trimmed)
+	}
+	rec.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
+
+	return d.PutJSONCAS(key, resp.Kvs[0].ModRevision, rec)
 }
 
 // イメージのオブジェクトを部分更新
@@ -740,6 +762,40 @@ func (d *Database) MakeFollowerImageEntry(headImage api.Image, followerNodeName 
 	imageDir := fmt.Sprintf("/var/lib/marmot/images/%s", id)
 	imagePath := fmt.Sprintf("%s/osimage-%s.qcow2", imageDir, id)
 
+	followerSpec := api.ImageSpec{
+		Kind:      util.StringPtr("os"),
+		Type:      util.StringPtr("qcow2"),
+		Qcow2Path: util.StringPtr(imagePath),
+		SourceUrl: nil,
+	}
+	if headImage.Spec.Kind != nil {
+		followerSpec.Kind = util.StringPtr(*headImage.Spec.Kind)
+	}
+	if headImage.Spec.Type != nil {
+		followerSpec.Type = util.StringPtr(*headImage.Spec.Type)
+	}
+	if headImage.Spec.Size != nil {
+		followerSpec.Size = util.IntPtrInt(*headImage.Spec.Size)
+	}
+	if headImage.Spec.SourceUrl != nil {
+		sourceURL := strings.TrimSpace(*headImage.Spec.SourceUrl)
+		if sourceURL != "" {
+			followerSpec.SourceUrl = util.StringPtr(sourceURL)
+		}
+	}
+	if headImage.Spec.OsName != nil {
+		osName := strings.TrimSpace(*headImage.Spec.OsName)
+		if osName != "" {
+			followerSpec.OsName = util.StringPtr(osName)
+		}
+	}
+	if headImage.Spec.OsVersion != nil {
+		osVersion := strings.TrimSpace(*headImage.Spec.OsVersion)
+		if osVersion != "" {
+			followerSpec.OsVersion = util.StringPtr(osVersion)
+		}
+	}
+
 	follower := api.Image{
 		ApiVersion: "v1",
 		Kind:       "Image",
@@ -750,12 +806,7 @@ func (d *Database) MakeFollowerImageEntry(headImage api.Image, followerNodeName 
 			Id:       id,
 			Uuid:     util.StringPtr(uuidString),
 		},
-		Spec: api.ImageSpec{
-			Kind:      util.StringPtr("os"),
-			Type:      util.StringPtr("qcow2"),
-			Qcow2Path: util.StringPtr(imagePath),
-			SourceUrl: nil,
-		},
+		Spec: followerSpec,
 		Status: &api.Status{
 			StatusCode:          IMAGE_WAITING,
 			Status:              util.StringPtr(ImageStatus[IMAGE_WAITING]),

--- a/pkg/db/db-image_test.go
+++ b/pkg/db/db-image_test.go
@@ -16,6 +16,10 @@ func stringPtr(v string) *string {
 	return &v
 }
 
+func intPtr(v int) *int {
+	return &v
+}
+
 var _ = Describe("Image", Ordered, func() {
 	var port int = 11379
 	var url string = "http://127.0.0.1:" + fmt.Sprintf("%d", port)
@@ -142,6 +146,69 @@ var _ = Describe("Image", Ordered, func() {
 				Expect(*img.Spec.OsName).To(Equal("ubuntu"))
 				Expect(img.Spec.OsVersion).NotTo(BeNil())
 				Expect(*img.Spec.OsVersion).To(Equal("24.04"))
+			})
+
+			It("MakeFollowerImageEntry が osName/osVersion/sourceUrl を引き継ぐ", func() {
+				if v == nil {
+					var connErr error
+					v, connErr = db.NewDatabase(url)
+					Expect(connErr).NotTo(HaveOccurred())
+				}
+
+				head := api.Image{
+					ApiVersion: "v1",
+					Kind:       "Image",
+					Metadata: api.Metadata{
+						Id:       "head-image-id",
+						Name:     "ubuntu26.04",
+						NodeName: stringPtr("marmot1"),
+					},
+					Spec: api.ImageSpec{
+						Kind:      stringPtr("os"),
+						Type:      stringPtr("qcow2"),
+						SourceUrl: stringPtr("https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"),
+						OsName:    stringPtr("ubuntu"),
+						OsVersion: stringPtr("26.04"),
+						Size:      intPtr(16),
+					},
+				}
+
+				followerID, err := v.MakeFollowerImageEntry(head, "marmot2", "head-image-id")
+				Expect(err).NotTo(HaveOccurred())
+
+				follower, err := v.GetImage(followerID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(follower.Spec.OsName).NotTo(BeNil())
+				Expect(*follower.Spec.OsName).To(Equal("ubuntu"))
+				Expect(follower.Spec.OsVersion).NotTo(BeNil())
+				Expect(*follower.Spec.OsVersion).To(Equal("26.04"))
+				Expect(follower.Spec.SourceUrl).NotTo(BeNil())
+				Expect(*follower.Spec.SourceUrl).To(Equal("https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"))
+			})
+
+			It("UpdateImageStatus は status.message を nil にクリアする", func() {
+				if v == nil {
+					var connErr error
+					v, connErr = db.NewDatabase(url)
+					Expect(connErr).NotTo(HaveOccurred())
+				}
+
+				createdID, err := v.MakeImageEntryFromURLWithNode("test-image-status-message", "http://hmc/status-message.qcow2", "marmot1")
+				Expect(err).NotTo(HaveOccurred())
+
+				v.UpdateImageStatusMessage(createdID, db.IMAGE_CREATING, "ヘッドノードからQCOW2イメージを取得中")
+				creating, err := v.GetImage(createdID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(creating.Status).NotTo(BeNil())
+				Expect(creating.Status.Message).NotTo(BeNil())
+				Expect(*creating.Status.Message).To(Equal("ヘッドノードからQCOW2イメージを取得中"))
+
+				v.UpdateImageStatus(createdID, db.IMAGE_AVAILABLE)
+				available, err := v.GetImage(createdID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(available.Status).NotTo(BeNil())
+				Expect(available.Status.StatusCode).To(Equal(db.IMAGE_AVAILABLE))
+				Expect(available.Status.Message).To(BeNil())
 			})
 
 			It("Keyからイメージ情報を取得 #2", func() {

--- a/pkg/marmotd/api-image.go
+++ b/pkg/marmotd/api-image.go
@@ -43,6 +43,10 @@ func (s *Server) ApiCreateImage(ctx echo.Context) error {
 		slog.Error("ApiCreateImage()", "err", "Name is required")
 		return ctx.JSON(http.StatusBadRequest, api.Error{Code: 1, Message: "Name is required"})
 	}
+	if err := validateImageOSSpec(&imageSpec.Spec); err != nil {
+		slog.Error("ApiCreateImage()", "err", err)
+		return ctx.JSON(http.StatusBadRequest, api.Error{Code: 1, Message: err.Error()})
+	}
 	assignNodeNameIfUnset(&imageSpec.Metadata, s.Ma.NodeName)
 	assignedNodeName := ""
 	if imageSpec.Metadata.NodeName != nil {
@@ -149,6 +153,10 @@ func (s *Server) ApiUpdateImageById(ctx echo.Context, id string) error {
 	if err := ctx.Bind(&imageSpec); err != nil {
 		slog.Error("ApiUpdateImageById()", "err", err)
 		return ctx.JSON(http.StatusInternalServerError, api.Error{Code: 1, Message: err.Error()})
+	}
+	if err := validateImageOSSpec(&imageSpec.Spec); err != nil {
+		slog.Error("ApiUpdateImageById()", "err", err)
+		return ctx.JSON(http.StatusBadRequest, api.Error{Code: 1, Message: err.Error()})
 	}
 
 	err := s.Ma.UpdateImageManage(id, imageSpec)

--- a/pkg/marmotd/image.go
+++ b/pkg/marmotd/image.go
@@ -176,6 +176,7 @@ func (m *Marmot) CreateNewImageManageWithContext(ctx context.Context, id string)
 		slog.Error("Failed to update image data in DB", "imgId", id, "err", err)
 		return markFailed(err)
 	}
+	m.Db.UpdateImageStatus(id, db.IMAGE_AVAILABLE)
 
 	return &image, nil
 }

--- a/pkg/marmotd/image_os_validation.go
+++ b/pkg/marmotd/image_os_validation.go
@@ -1,0 +1,82 @@
+package marmotd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/takara9/marmot/api"
+)
+
+// validateImageOSSpec validates allowed values for spec.osName/spec.osVersion.
+func validateImageOSSpec(spec *api.ImageSpec) error {
+	if spec == nil {
+		return nil
+	}
+
+	osName := strings.TrimSpace(derefString(spec.OsName))
+	osVersion := strings.TrimSpace(derefString(spec.OsVersion))
+
+	if osName == "" && osVersion == "" {
+		return nil
+	}
+	if osName == "" {
+		return fmt.Errorf("spec.osName is required when spec.osVersion is set")
+	}
+	if osVersion == "" {
+		return fmt.Errorf("spec.osVersion is required when spec.osName is set")
+	}
+	if osName != strings.ToLower(osName) {
+		return fmt.Errorf("spec.osName must be lowercase")
+	}
+
+	canonical := canonicalOSName(osName)
+	if canonical == "" {
+		return fmt.Errorf("invalid spec.osName: %q (allowed: alpine, ubuntu, rockey, debian)", osName)
+	}
+
+	allowedVersions := map[string]map[string]struct{}{
+		"alpine": {
+			"3.23": {},
+		},
+		"ubuntu": {
+			"22.04": {},
+			"24.04": {},
+			"26.04": {},
+		},
+		"rockey": {
+			"8": {},
+			"9": {},
+		},
+		"debian": {
+			"13": {},
+		},
+	}
+
+	if _, ok := allowedVersions[canonical][osVersion]; !ok {
+		return fmt.Errorf("invalid spec.osVersion %q for spec.osName %q", osVersion, osName)
+	}
+
+	return nil
+}
+
+func canonicalOSName(name string) string {
+	switch name {
+	case "alpine":
+		return "alpine"
+	case "ubuntu":
+		return "ubuntu"
+	case "rockey":
+		return "rockey"
+	case "debian":
+		return "debian"
+	default:
+		return ""
+	}
+}
+
+func derefString(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}

--- a/pkg/marmotd/image_os_validation_test.go
+++ b/pkg/marmotd/image_os_validation_test.go
@@ -1,0 +1,98 @@
+package marmotd
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestValidateImageOSSpecAllowsEmptyPair(t *testing.T) {
+	err := validateImageOSSpec(&api.ImageSpec{})
+	if err != nil {
+		t.Fatalf("validateImageOSSpec() unexpected error: %v", err)
+	}
+}
+
+func TestValidateImageOSSpecRequiresPair(t *testing.T) {
+	err := validateImageOSSpec(&api.ImageSpec{OsVersion: util.StringPtr("24.04")})
+	if err == nil {
+		t.Fatalf("validateImageOSSpec() expected error when osName is missing")
+	}
+
+	err = validateImageOSSpec(&api.ImageSpec{OsName: util.StringPtr("ubuntu")})
+	if err == nil {
+		t.Fatalf("validateImageOSSpec() expected error when osVersion is missing")
+	}
+}
+
+func TestValidateImageOSSpecRejectsUppercaseName(t *testing.T) {
+	err := validateImageOSSpec(&api.ImageSpec{
+		OsName:    util.StringPtr("Ubuntu"),
+		OsVersion: util.StringPtr("24.04"),
+	})
+	if err == nil {
+		t.Fatalf("validateImageOSSpec() expected lowercase validation error")
+	}
+}
+
+func TestValidateImageOSSpecSupportsRequestedOSMatrix(t *testing.T) {
+	tests := []struct {
+		name      string
+		osName    string
+		osVersion string
+	}{
+		{name: "alpine", osName: "alpine", osVersion: "3.23"},
+		{name: "ubuntu", osName: "ubuntu", osVersion: "26.04"},
+		{name: "rockey", osName: "rockey", osVersion: "9"},
+		{name: "debian", osName: "debian", osVersion: "13"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateImageOSSpec(&api.ImageSpec{
+				OsName:    util.StringPtr(tt.osName),
+				OsVersion: util.StringPtr(tt.osVersion),
+			})
+			if err != nil {
+				t.Fatalf("validateImageOSSpec() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateImageOSSpecRejectsInvalidVersionPerOS(t *testing.T) {
+	err := validateImageOSSpec(&api.ImageSpec{
+		OsName:    util.StringPtr("alpine"),
+		OsVersion: util.StringPtr("3.24"),
+	})
+	if err == nil {
+		t.Fatalf("validateImageOSSpec() expected version validation error")
+	}
+
+	err = validateImageOSSpec(&api.ImageSpec{
+		OsName:    util.StringPtr("debian"),
+		OsVersion: util.StringPtr("12"),
+	})
+	if err == nil {
+		t.Fatalf("validateImageOSSpec() expected version validation error")
+	}
+}
+
+func TestValidateImageOSSpecRejectsTypoOSNames(t *testing.T) {
+	err := validateImageOSSpec(&api.ImageSpec{
+		OsName:    util.StringPtr("rockery"),
+		OsVersion: util.StringPtr("8"),
+	})
+	if err == nil {
+		t.Fatalf("validateImageOSSpec() expected osName validation error for rockery")
+	}
+
+	err = validateImageOSSpec(&api.ImageSpec{
+		OsName:    util.StringPtr("debina"),
+		OsVersion: util.StringPtr("13"),
+	})
+	if err == nil {
+		t.Fatalf("validateImageOSSpec() expected osName validation error for debina")
+	}
+}


### PR DESCRIPTION
## 概要
Image の OS メタデータ拡張と、ヘッド/レプリカ間の整合性改善を行いました。  
あわせて、Image の status 更新時に古い message が残る問題を修正しています。

## 背景・課題
- Image マニフェストで spec.osName / spec.osVersion を受け取れる必要がある
- レプリカ側 Image の spec がヘッド側と一致せず、osName/osVersion/sourceUrl などが欠落する
- status.status が AVAILABLE になっても status.message に過去メッセージが残る

## 変更内容
1. Image OS フィールドの受理・検証を強化
- spec.osName / spec.osVersion の組み合わせ検証を追加
- 受理値を厳格化
  - osName: alpine | ubuntu | rockey | debian（小文字のみ）
  - osVersion:
    - alpine: 3.23
    - ubuntu: 22.04 | 24.04 | 26.04
    - rockey: 8 | 9
    - debian: 13
- typo 値（rockery / debina）はエラーとして拒否

2. レプリカ Image の spec 伝播を修正
- フォロワーエントリ作成時にヘッド spec を引き継ぐよう修正
  - kind, type, size, sourceUrl, osName, osVersion
- 同期完了時にも同項目を再反映
- 既存 AVAILABLE フォロワーについても、コントローラループで spec 差分を補正するリコンシリエーションを追加

3. status.message 残留不具合を修正
- Image の status 更新処理を PatchStruct 経由から CAS 直接更新に変更
- status.statusCode/status 更新時に status.message を必ず nil クリア（message 引数がある場合のみ再セット）
- AVAILABLE 遷移後に明示的に status 更新 API を通し、message クリアを確実化

4. 回帰テスト追加
- config 読み込みで osName/osVersion をデコードできること
- manifest 変換で osName/osVersion が保持されること
- MakeFollowerImageEntry が osName/osVersion/sourceUrl を継承すること
- UpdateImageStatus 後に status.message が nil になること
- osName/osVersion の許可マトリクス・typo 拒否

## 影響範囲
- Image 作成/更新 API の入力検証が厳密化されます（不正値は 400）
- 既存のレプリカ Image もコントローラ実行で spec がヘッドと一致する方向に補正されます
- status 遷移後の stale message は解消されます

## 動作確認
- パッケージのビルド整合確認（pkg/db, pkg/controller, pkg/marmotd）
- 追加したユニット/回帰テストの実行で成功を確認

## 期待される結果
- mactl get img <name> -o json で、同一 Image 名のヘッド/レプリカ間で spec の主要項目が一致
- status が AVAILABLE のレコードで status.message が nil になること