### PR TITLE
表示系のバグ対応

### DIFF
--- a/cmd/mactl/cmd/get.go
+++ b/cmd/mactl/cmd/get.go
@@ -941,12 +941,9 @@ func outputImages(images []api.Image) error {
 					hasLV = "yes"
 				}
 
-				hasQcow2 := "no"
-				if img.Spec.Qcow2Path != nil && strings.TrimSpace(*img.Spec.Qcow2Path) != "" {
-					hasQcow2 = "yes"
-				}
+				hasQcow2 := normalizeImageQcow2(img)
 
-				fmt.Printf("%-14s  %-9s  %-9s  %-7s  %-3s  %-5s  %s\n",
+				fmt.Printf("%-14s  %-9s  %-9s  %-7s  %-6s  %-5s  %s\n",
 					img.Metadata.Name,
 					nodeName,
 					status,
@@ -963,10 +960,10 @@ func outputImages(images []api.Image) error {
 		sort.SliceStable(aggregated, func(i, j int) bool {
 			return creationTime(aggregated[i].ageStatus).Before(creationTime(aggregated[j].ageStatus))
 		})
-		fmt.Println("NAME            STATUS     SYNCED    LV   QCOW2  AGE")
-		fmt.Println("----            ------     ------    --   -----  ---")
+		fmt.Println("NAME            STATUS     SYNCED    LV     QCOW2  AGE")
+		fmt.Println("----            ------     ------    ------  -----  ---")
 		for _, row := range aggregated {
-			fmt.Printf("%-14s  %-9s  %-8s  %-3s  %-5s  %s\n",
+			fmt.Printf("%-14s  %-9s  %-8s  %-6s  %-5s  %s\n",
 				row.name,
 				row.status,
 				row.synced,
@@ -1067,7 +1064,7 @@ func summarizeImageGroup(name string, images []api.Image, totalNodes int) imageS
 	if expectedNodes <= 0 {
 		expectedNodes = len(nodeSet)
 	}
-	uniform := len(statusSet) == 1 && len(lvSet) == 1 && len(qcow2Set) == 1
+	uniform := len(statusSet) == 1 && len(qcow2Set) == 1
 	complete := uniform && len(nodeSet) == expectedNodes
 
 	synced := "DEGRADE"
@@ -1116,6 +1113,9 @@ func normalizeImageLV(img api.Image) string {
 }
 
 func normalizeImageQcow2(img api.Image) string {
+	if normalizeImageStatus(img) == "WAITING" {
+		return "no"
+	}
 	if img.Spec.Qcow2Path != nil && strings.TrimSpace(*img.Spec.Qcow2Path) != "" {
 		return "yes"
 	}

--- a/cmd/mactl/cmd/get_image_output_test.go
+++ b/cmd/mactl/cmd/get_image_output_test.go
@@ -53,6 +53,24 @@ var _ = Describe("summarizeImages", func() {
 		Expect(result["other"].synced).To(Equal("COMPLETE"))
 	})
 
+	It("keeps COMPLETE when LV differs but QCOW2 is uniform across nodes", func() {
+		node1 := "marmot1"
+		node2 := "marmot2"
+		node3 := "marmot3"
+		lvPath := "/dev/vg1/boot-ubuntu"
+		images := []api.Image{
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node1}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path, LvPath: &lvPath}},
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node2}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node3}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+		}
+
+		summaries := summarizeImages(images)
+		Expect(summaries).To(HaveLen(1))
+		Expect(summaries[0].synced).To(Equal("COMPLETE"))
+		Expect(summaries[0].hasLV).To(Equal("mixed"))
+		Expect(summaries[0].hasQcow2).To(Equal("yes"))
+	})
+
 	It("marks image DEGRADE and status MIXED when per-node status differs", func() {
 		node1 := "marmot1"
 		node2 := "marmot2"
@@ -65,5 +83,17 @@ var _ = Describe("summarizeImages", func() {
 		Expect(summaries).To(HaveLen(1))
 		Expect(summaries[0].synced).To(Equal("DEGRADE"))
 		Expect(summaries[0].status).To(Equal("MIXED"))
+	})
+
+	It("renders WAITING images as QCOW2 no", func() {
+		node1 := "marmot1"
+		statusWaiting := "WAITING"
+		images := []api.Image{
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node1}, Status: &api.Status{Status: &statusWaiting}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+		}
+
+		summaries := summarizeImages(images)
+		Expect(summaries).To(HaveLen(1))
+		Expect(summaries[0].hasQcow2).To(Equal("no"))
 	})
 })


### PR DESCRIPTION
## 概要

`mactl get img` の表示に関するバグを 3 点修正しました。

## 不具合と対応

### 1. WAITING 状態のレプリカが QCOW2=yes と表示される

**原因:** QCOW2 列の判定が `Spec.Qcow2Path` の有無だけを見ていたため、
head ノードから引き継いだパスが入っていても、実際にはまだ取得していない
WAITING 状態のレプリカが `yes` と表示されていた。

**修正:** `normalizeImageQcow2` に状態チェックを追加し、STATUS が WAITING の場合は
パスの有無に関わらず `no` を返すように変更。

**修正前の表示例:**
```
ubuntu22.04  marmot2  WAITING  replica  no  yes  9s   ← 誤り
```
**修正後:**
```
ubuntu22.04  marmot2  WAITING  replica  no  no   9s
```

---

### 2. LV が混在すると QCOW2 が揃っていても DEGRADE になる

**原因:** SYNCED=COMPLETE の判定条件に `LV` の一致を含めていたため、
master だけ LV あり・replica は LV なし という正常な構成でも DEGRADE と誤表示されていた。

**修正:** `uniform` の計算から `lvSet` を除外し、STATUS と QCOW2 の一致のみで
COMPLETE を判定するように変更。

**修正前:**
```
ubuntu22.04  AVAILABLE  DEGRADE  mixed  yes  12m   ← LV が混在すると DEGRADE
```
**修正後:**
```
ubuntu22.04  AVAILABLE  COMPLETE  mixed  yes  12m
```

---

### 3. LV 列が `mixed` で幅が足りず後続列が詰まる

**原因:** LV 列の書式幅が `%-3s`（3文字）固定のため、`mixed`（5文字）が入ると後続列にはみ出し整列が崩れていた。

**修正:** LV 列の書式幅を `%-6s` に拡張し、ヘッダ罫線も合わせて調整。

**修正前:**
```
NAME      STATUS     SYNCED    LV   QCOW2  AGE
ubuntu22.04  AVAILABLE  COMPLETE  mixed  yes  12m
```
**修正後:**
```
NAME      STATUS     SYNCED    LV     QCOW2  AGE
ubuntu22.04  AVAILABLE  COMPLETE  mixed   yes  12m
```

---

## 変更ファイル

- get.go — 上記 3 点の表示ロジック修正
- get_image_output_test.go — 各修正に対応した回帰テストを追加

## テスト

- WAITING イメージが QCOW2=no と表示される回帰テストを追加
- LV 混在でも QCOW2 が揃っていれば COMPLETE になる回帰テストを追加
- 既存テストはすべて通過