### PR TITLE
エクポートとインポートの不具合修理

### DIFF
--- a/cmd/mactl/cmd/image_export.go
+++ b/cmd/mactl/cmd/image_export.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -46,7 +45,7 @@ var imageExportCmd = &cobra.Command{
 
 		localNodeName, err := getLocalNodeName(m)
 		if err != nil {
-			slog.Warn("failed to get local node name; exporting by creation time only", "err", err)
+			return fmt.Errorf("failed to resolve current endpoint node name: %w", err)
 		}
 
 		candidates, err := pickExportableImagesByName(images, name, localNodeName)
@@ -83,8 +82,8 @@ func getLocalNodeName(m *client.MarmotEndpoint) (string, error) {
 	if err := json.Unmarshal(body, &status); err != nil {
 		return "", err
 	}
-	if status.NodeName == nil {
-		return "", nil
+	if status.NodeName == nil || strings.TrimSpace(*status.NodeName) == "" {
+		return "", fmt.Errorf("nodeName is not available in marmot status")
 	}
 	return strings.TrimSpace(*status.NodeName), nil
 }

--- a/cmd/mactl/cmd/image_export.go
+++ b/cmd/mactl/cmd/image_export.go
@@ -54,37 +54,14 @@ var imageExportCmd = &cobra.Command{
 			return err
 		}
 
-		clusterStatuses, err := getClusterStatuses(m)
+		image := candidates[0]
+		qcowBytes, err := m.DownloadImageQcow2ById(image.Metadata.Id)
 		if err != nil {
-			slog.Warn("failed to resolve cluster statuses; falling back to current endpoint", "err", err)
-		}
-
-		var image *api.Image
-		var qcowBytes []byte
-		var downloadErr error
-		for _, candidate := range candidates {
-			endpoint := m
-			if targetNode := imageNodeName(candidate); targetNode != "" && len(clusterStatuses) > 0 {
-				if targetHostPort, hpErr := hostPortForNode(clusterStatuses, targetNode, m.HostPort); hpErr == nil && strings.TrimSpace(targetHostPort) != "" {
-					endpoint = cloneEndpointForHostPort(m, targetHostPort)
-				}
-			}
-
-			qcowBytes, downloadErr = endpoint.DownloadImageQcow2ById(candidate.Metadata.Id)
-			if downloadErr == nil {
-				image = &candidate
-				break
-			}
-			if !strings.Contains(downloadErr.Error(), "qcow2 file does not exist") && !strings.Contains(downloadErr.Error(), "qcow2 path is not set") {
-				return fmt.Errorf("failed to download qcow2 for image %q: %w", candidate.Metadata.Id, downloadErr)
-			}
-		}
-		if image == nil {
-			return fmt.Errorf("failed to download qcow2 for image %q: %w", name, downloadErr)
+			return fmt.Errorf("failed to download qcow2 for image %q: %w", image.Metadata.Id, err)
 		}
 
 		outPath := filepath.Join(".", fmt.Sprintf("marmot-machine-image-%s.tgz", sanitizeArchiveName(name)))
-		if err := writeImageArchive(outPath, *image, qcowBytes); err != nil {
+		if err := writeImageArchive(outPath, image, qcowBytes); err != nil {
 			return fmt.Errorf("failed to write archive: %w", err)
 		}
 
@@ -112,41 +89,11 @@ func getLocalNodeName(m *client.MarmotEndpoint) (string, error) {
 	return strings.TrimSpace(*status.NodeName), nil
 }
 
-func getClusterStatuses(m *client.MarmotEndpoint) ([]api.HostStatus, error) {
-	body, _, err := m.GetMarmotCluster()
-	if err != nil {
-		return nil, err
-	}
-	var statuses []api.HostStatus
-	if err := json.Unmarshal(body, &statuses); err != nil {
-		return nil, err
-	}
-	return statuses, nil
-}
-
-func imageNodeName(image api.Image) string {
-	if image.Metadata.NodeName == nil {
-		return ""
-	}
-	return strings.TrimSpace(*image.Metadata.NodeName)
-}
-
-func cloneEndpointForHostPort(src *client.MarmotEndpoint, hostPort string) *client.MarmotEndpoint {
-	if src == nil {
-		return nil
-	}
-	clone := *src
-	clone.HostPort = strings.TrimSpace(hostPort)
-	return &clone
-}
-
 func pickExportableImagesByName(images []api.Image, name, preferredNode string) ([]api.Image, error) {
 	matched := make([]api.Image, 0)
+	localMatched := make([]api.Image, 0)
 	for _, image := range images {
 		if strings.TrimSpace(image.Metadata.Name) != name {
-			continue
-		}
-		if image.Metadata.Labels != nil && db.GetFollowerSyncRole(*image.Metadata.Labels) == "follower" {
 			continue
 		}
 		if image.Status == nil || image.Status.StatusCode != db.IMAGE_AVAILABLE {
@@ -155,23 +102,31 @@ func pickExportableImagesByName(images []api.Image, name, preferredNode string) 
 		if image.Spec.Qcow2Path == nil || strings.TrimSpace(*image.Spec.Qcow2Path) == "" {
 			continue
 		}
+
+		if preferredNode != "" {
+			if image.Metadata.NodeName != nil && strings.TrimSpace(*image.Metadata.NodeName) == preferredNode {
+				localMatched = append(localMatched, image)
+			}
+		}
+
+		if image.Metadata.Labels != nil && db.GetFollowerSyncRole(*image.Metadata.Labels) == "follower" {
+			continue
+		}
 		matched = append(matched, image)
+	}
+
+	if preferredNode != "" {
+		if len(localMatched) == 0 {
+			return nil, fmt.Errorf("exportable image not found on current endpoint node (%s): %s", preferredNode, name)
+		}
+		sort.SliceStable(localMatched, func(i, j int) bool {
+			return creationTime(localMatched[i].Status).After(creationTime(localMatched[j].Status))
+		})
+		return localMatched, nil
 	}
 
 	if len(matched) == 0 {
 		return nil, fmt.Errorf("exportable image not found: %s", name)
-	}
-
-	if preferredNode != "" {
-		sort.SliceStable(matched, func(i, j int) bool {
-			imatch := matched[i].Metadata.NodeName != nil && strings.TrimSpace(*matched[i].Metadata.NodeName) == preferredNode
-			jmatch := matched[j].Metadata.NodeName != nil && strings.TrimSpace(*matched[j].Metadata.NodeName) == preferredNode
-			if imatch != jmatch {
-				return imatch
-			}
-			return creationTime(matched[i].Status).After(creationTime(matched[j].Status))
-		})
-		return matched, nil
 	}
 
 	sort.SliceStable(matched, func(i, j int) bool {

--- a/cmd/mactl/cmd/image_export.go
+++ b/cmd/mactl/cmd/image_export.go
@@ -5,12 +5,15 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/client"
 	"github.com/takara9/marmot/pkg/db"
 )
 
@@ -41,18 +44,47 @@ var imageExportCmd = &cobra.Command{
 			return fmt.Errorf("failed to parse images: %w", err)
 		}
 
-		image, err := pickExportableImageByName(images, name)
+		localNodeName, err := getLocalNodeName(m)
+		if err != nil {
+			slog.Warn("failed to get local node name; exporting by creation time only", "err", err)
+		}
+
+		candidates, err := pickExportableImagesByName(images, name, localNodeName)
 		if err != nil {
 			return err
 		}
 
-		qcowBytes, err := m.DownloadImageQcow2ById(image.Metadata.Id)
+		clusterStatuses, err := getClusterStatuses(m)
 		if err != nil {
-			return fmt.Errorf("failed to download qcow2 for image %q: %w", image.Metadata.Id, err)
+			slog.Warn("failed to resolve cluster statuses; falling back to current endpoint", "err", err)
+		}
+
+		var image *api.Image
+		var qcowBytes []byte
+		var downloadErr error
+		for _, candidate := range candidates {
+			endpoint := m
+			if targetNode := imageNodeName(candidate); targetNode != "" && len(clusterStatuses) > 0 {
+				if targetHostPort, hpErr := hostPortForNode(clusterStatuses, targetNode, m.HostPort); hpErr == nil && strings.TrimSpace(targetHostPort) != "" {
+					endpoint = cloneEndpointForHostPort(m, targetHostPort)
+				}
+			}
+
+			qcowBytes, downloadErr = endpoint.DownloadImageQcow2ById(candidate.Metadata.Id)
+			if downloadErr == nil {
+				image = &candidate
+				break
+			}
+			if !strings.Contains(downloadErr.Error(), "qcow2 file does not exist") && !strings.Contains(downloadErr.Error(), "qcow2 path is not set") {
+				return fmt.Errorf("failed to download qcow2 for image %q: %w", candidate.Metadata.Id, downloadErr)
+			}
+		}
+		if image == nil {
+			return fmt.Errorf("failed to download qcow2 for image %q: %w", name, downloadErr)
 		}
 
 		outPath := filepath.Join(".", fmt.Sprintf("marmot-machine-image-%s.tgz", sanitizeArchiveName(name)))
-		if err := writeImageArchive(outPath, image.Metadata.Name, qcowBytes); err != nil {
+		if err := writeImageArchive(outPath, *image, qcowBytes); err != nil {
 			return fmt.Errorf("failed to write archive: %w", err)
 		}
 
@@ -65,7 +97,50 @@ func init() {
 	imageCmd.AddCommand(imageExportCmd)
 }
 
-func pickExportableImageByName(images []api.Image, name string) (*api.Image, error) {
+func getLocalNodeName(m *client.MarmotEndpoint) (string, error) {
+	body, _, err := m.GetMarmotStatus()
+	if err != nil {
+		return "", err
+	}
+	var status api.HostStatus
+	if err := json.Unmarshal(body, &status); err != nil {
+		return "", err
+	}
+	if status.NodeName == nil {
+		return "", nil
+	}
+	return strings.TrimSpace(*status.NodeName), nil
+}
+
+func getClusterStatuses(m *client.MarmotEndpoint) ([]api.HostStatus, error) {
+	body, _, err := m.GetMarmotCluster()
+	if err != nil {
+		return nil, err
+	}
+	var statuses []api.HostStatus
+	if err := json.Unmarshal(body, &statuses); err != nil {
+		return nil, err
+	}
+	return statuses, nil
+}
+
+func imageNodeName(image api.Image) string {
+	if image.Metadata.NodeName == nil {
+		return ""
+	}
+	return strings.TrimSpace(*image.Metadata.NodeName)
+}
+
+func cloneEndpointForHostPort(src *client.MarmotEndpoint, hostPort string) *client.MarmotEndpoint {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	clone.HostPort = strings.TrimSpace(hostPort)
+	return &clone
+}
+
+func pickExportableImagesByName(images []api.Image, name, preferredNode string) ([]api.Image, error) {
 	matched := make([]api.Image, 0)
 	for _, image := range images {
 		if strings.TrimSpace(image.Metadata.Name) != name {
@@ -87,16 +162,40 @@ func pickExportableImageByName(images []api.Image, name string) (*api.Image, err
 		return nil, fmt.Errorf("exportable image not found: %s", name)
 	}
 
-	best := matched[0]
-	for _, image := range matched[1:] {
-		if creationTime(image.Status).After(creationTime(best.Status)) {
-			best = image
-		}
+	if preferredNode != "" {
+		sort.SliceStable(matched, func(i, j int) bool {
+			imatch := matched[i].Metadata.NodeName != nil && strings.TrimSpace(*matched[i].Metadata.NodeName) == preferredNode
+			jmatch := matched[j].Metadata.NodeName != nil && strings.TrimSpace(*matched[j].Metadata.NodeName) == preferredNode
+			if imatch != jmatch {
+				return imatch
+			}
+			return creationTime(matched[i].Status).After(creationTime(matched[j].Status))
+		})
+		return matched, nil
 	}
-	return &best, nil
+
+	sort.SliceStable(matched, func(i, j int) bool {
+		return creationTime(matched[i].Status).After(creationTime(matched[j].Status))
+	})
+	return matched, nil
 }
 
-func writeImageArchive(outPath, imageName string, qcow2Bytes []byte) error {
+func pickExportableImageByName(images []api.Image, name string) (*api.Image, error) {
+	matched, err := pickExportableImagesByName(images, name, "")
+	if err != nil {
+		return nil, err
+	}
+	return &matched[0], nil
+}
+
+type imageArchiveMeta struct {
+	Name      string `json:"name"`
+	OsName    string `json:"osName,omitempty"`
+	OsVersion string `json:"osVersion,omitempty"`
+}
+
+func writeImageArchive(outPath string, image api.Image, qcow2Bytes []byte) error {
+	imageName := image.Metadata.Name
 	f, err := os.Create(outPath)
 	if err != nil {
 		return err
@@ -119,6 +218,29 @@ func writeImageArchive(outPath, imageName string, qcow2Bytes []byte) error {
 		return err
 	}
 	if _, err := tw.Write(qcow2Bytes); err != nil {
+		return err
+	}
+
+	meta := imageArchiveMeta{Name: imageName}
+	if image.Spec.OsName != nil {
+		meta.OsName = strings.TrimSpace(*image.Spec.OsName)
+	}
+	if image.Spec.OsVersion != nil {
+		meta.OsVersion = strings.TrimSpace(*image.Spec.OsVersion)
+	}
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal image metadata: %w", err)
+	}
+	metaHdr := &tar.Header{
+		Name: "metadata.json",
+		Mode: 0644,
+		Size: int64(len(metaBytes)),
+	}
+	if err := tw.WriteHeader(metaHdr); err != nil {
+		return err
+	}
+	if _, err := tw.Write(metaBytes); err != nil {
 		return err
 	}
 

--- a/cmd/mactl/cmd/image_export_test.go
+++ b/cmd/mactl/cmd/image_export_test.go
@@ -1,6 +1,11 @@
 package cmd
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -47,5 +52,75 @@ var _ = Describe("pickExportableImageByName", func() {
 		picked, err := pickExportableImageByName(images, "ubuntu")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(picked.Metadata.Id).To(Equal("img-new"))
+	})
+
+	It("prefers the local node when the same image exists on multiple nodes", func() {
+		now := time.Now()
+		earier := now.Add(-1 * time.Hour)
+
+		images := []api.Image{
+			{
+				Metadata: api.Metadata{Name: "server110", Id: "img-remote", NodeName: util.StringPtr("marmot3")},
+				Spec:     api.ImageSpec{Qcow2Path: util.StringPtr("/tmp/remote.qcow2")},
+				Status:   &api.Status{StatusCode: db.IMAGE_AVAILABLE, CreationTimeStamp: &now},
+			},
+			{
+				Metadata: api.Metadata{Name: "server110", Id: "img-local", NodeName: util.StringPtr("marmot1")},
+				Spec:     api.ImageSpec{Qcow2Path: util.StringPtr("/tmp/local.qcow2")},
+				Status:   &api.Status{StatusCode: db.IMAGE_AVAILABLE, CreationTimeStamp: &earier},
+			},
+		}
+
+		picked, err := pickExportableImagesByName(images, "server110", "marmot1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(picked).NotTo(BeEmpty())
+		Expect(picked[0].Metadata.Id).To(Equal("img-local"))
+	})
+})
+
+var _ = Describe("writeImageArchive / extractFromTGZ round-trip", func() {
+	It("preserves osName and osVersion in the archive", func() {
+		image := api.Image{
+			Metadata: api.Metadata{Name: "ubuntu22.04"},
+			Spec: api.ImageSpec{
+				OsName:    util.StringPtr("ubuntu"),
+				OsVersion: util.StringPtr("22.04"),
+			},
+		}
+		qcow2Data := []byte("fake-qcow2-data")
+
+		outPath := GinkgoT().TempDir() + "/test.tgz"
+		err := writeImageArchive(outPath, image, qcow2Data)
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err := os.Open(outPath)
+		Expect(err).NotTo(HaveOccurred())
+		defer f.Close()
+
+		gz, err := gzip.NewReader(f)
+		Expect(err).NotTo(HaveOccurred())
+		defer gz.Close()
+
+		tr := tar.NewReader(gz)
+		meta := imageArchiveMeta{}
+		foundMeta := false
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			Expect(err).NotTo(HaveOccurred())
+			if hdr.Name != "metadata.json" {
+				continue
+			}
+			buf, err := io.ReadAll(tr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(json.Unmarshal(buf, &meta)).To(Succeed())
+			foundMeta = true
+			break
+		}
+		Expect(foundMeta).To(BeTrue())
+		Expect(meta.OsName).To(Equal("ubuntu"))
+		Expect(meta.OsVersion).To(Equal("22.04"))
 	})
 })

--- a/cmd/mactl/cmd/image_export_test.go
+++ b/cmd/mactl/cmd/image_export_test.go
@@ -56,7 +56,8 @@ var _ = Describe("pickExportableImageByName", func() {
 
 	It("prefers the local node when the same image exists on multiple nodes", func() {
 		now := time.Now()
-		earier := now.Add(-1 * time.Hour)
+		earlier := now.Add(-1 * time.Hour)
+		followerLabels := map[string]interface{}{db.ImageLabelSyncRole: "follower"}
 
 		images := []api.Image{
 			{
@@ -65,9 +66,9 @@ var _ = Describe("pickExportableImageByName", func() {
 				Status:   &api.Status{StatusCode: db.IMAGE_AVAILABLE, CreationTimeStamp: &now},
 			},
 			{
-				Metadata: api.Metadata{Name: "server110", Id: "img-local", NodeName: util.StringPtr("marmot1")},
+				Metadata: api.Metadata{Name: "server110", Id: "img-local", NodeName: util.StringPtr("marmot1"), Labels: &followerLabels},
 				Spec:     api.ImageSpec{Qcow2Path: util.StringPtr("/tmp/local.qcow2")},
-				Status:   &api.Status{StatusCode: db.IMAGE_AVAILABLE, CreationTimeStamp: &earier},
+				Status:   &api.Status{StatusCode: db.IMAGE_AVAILABLE, CreationTimeStamp: &earlier},
 			},
 		}
 
@@ -75,6 +76,21 @@ var _ = Describe("pickExportableImageByName", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(picked).NotTo(BeEmpty())
 		Expect(picked[0].Metadata.Id).To(Equal("img-local"))
+	})
+
+	It("returns error when current endpoint node has no matching image", func() {
+		now := time.Now()
+		images := []api.Image{
+			{
+				Metadata: api.Metadata{Name: "docker", Id: "img-remote", NodeName: util.StringPtr("marmot2")},
+				Spec:     api.ImageSpec{Qcow2Path: util.StringPtr("/tmp/remote.qcow2")},
+				Status:   &api.Status{StatusCode: db.IMAGE_AVAILABLE, CreationTimeStamp: &now},
+			},
+		}
+
+		_, err := pickExportableImagesByName(images, "docker", "marmot1")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("current endpoint node"))
 	})
 })
 

--- a/pkg/db/db-image.go
+++ b/pkg/db/db-image.go
@@ -365,6 +365,7 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 		"source":   "bootVolume",
 		"serverId": serverId,
 	}
+	resolvedOSName, resolvedOSVersion := d.resolveImageOSMetadataFromBootVolume(bootVol, serverNodeName)
 	var img api.Image
 	if bootVol.Spec.Type != nil && *bootVol.Spec.Type == "qcow2" {
 		// イメージのqcow2ボリューム名を設定
@@ -388,6 +389,8 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 				LogicalVolume: nil,
 				LvPath:        nil,
 				Qcow2Path:     util.StringPtr(imagePath),
+				OsName:        resolvedOSName,
+				OsVersion:     resolvedOSVersion,
 				Size:          bootVol.Spec.Size,
 				SourceUrl:     nil,
 			},
@@ -419,6 +422,8 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 				LogicalVolume: util.StringPtr(logicalVolumeName),
 				LvPath:        util.StringPtr(logicalVolumePath),
 				Qcow2Path:     nil,
+				OsName:        resolvedOSName,
+				OsVersion:     resolvedOSVersion,
 				Size:          bootVol.Spec.Size,
 				SourceUrl:     nil,
 			},
@@ -439,6 +444,82 @@ func (d *Database) MakeImageEntryFromRunningVM(serverId, name string) (api.Image
 	}
 
 	return img, nil
+}
+
+func (d *Database) resolveImageOSMetadataFromBootVolume(bootVol *api.Volume, serverNodeName *string) (*string, *string) {
+	if bootVol == nil {
+		return nil, nil
+	}
+	variant := ""
+	if bootVol.Spec.OsVariant != nil {
+		variant = strings.TrimSpace(*bootVol.Spec.OsVariant)
+	}
+	if variant == "" {
+		return nil, nil
+	}
+
+	if serverNodeName != nil && strings.TrimSpace(*serverNodeName) != "" {
+		sourceImage, err := d.FindImageByNameAndNode(variant, strings.TrimSpace(*serverNodeName))
+		if err == nil {
+			osName, osVersion := extractImageOSMetadata(sourceImage)
+			if osName != nil || osVersion != nil {
+				return osName, osVersion
+			}
+		}
+	}
+
+	sourceImage, err := d.FindImageByName(variant)
+	if err == nil {
+		osName, osVersion := extractImageOSMetadata(sourceImage)
+		if osName != nil || osVersion != nil {
+			return osName, osVersion
+		}
+	}
+
+	osName, osVersion := deriveImageOSFromVariant(variant)
+	if osName == "" && osVersion == "" {
+		return nil, nil
+	}
+
+	namePtr, versionPtr := (*string)(nil), (*string)(nil)
+	if osName != "" {
+		namePtr = util.StringPtr(osName)
+	}
+	if osVersion != "" {
+		versionPtr = util.StringPtr(osVersion)
+	}
+	return namePtr, versionPtr
+}
+
+func extractImageOSMetadata(image api.Image) (*string, *string) {
+	var osName, osVersion *string
+	if image.Spec.OsName != nil {
+		name := strings.TrimSpace(*image.Spec.OsName)
+		if name != "" {
+			osName = util.StringPtr(name)
+		}
+	}
+	if image.Spec.OsVersion != nil {
+		version := strings.TrimSpace(*image.Spec.OsVersion)
+		if version != "" {
+			osVersion = util.StringPtr(version)
+		}
+	}
+	return osName, osVersion
+}
+
+func deriveImageOSFromVariant(osVariant string) (string, string) {
+	v := strings.ToLower(strings.TrimSpace(osVariant))
+	switch {
+	case strings.HasPrefix(v, "ubuntu22.04"):
+		return "ubuntu", "22.04"
+	case strings.HasPrefix(v, "ubuntu24.04"):
+		return "ubuntu", "24.04"
+	case strings.HasPrefix(v, "alpine3.23"):
+		return "alpine", "3.23"
+	default:
+		return "", ""
+	}
 }
 
 // IDを指定してイメージの情報を取得する

--- a/pkg/db/db-image_osvariant_test.go
+++ b/pkg/db/db-image_osvariant_test.go
@@ -1,0 +1,44 @@
+package db
+
+import "testing"
+
+func TestDeriveImageOSFromVariant(t *testing.T) {
+	tests := []struct {
+		name       string
+		variant    string
+		wantName   string
+		wantVer    string
+	}{
+		{
+			name:     "ubuntu 22.04",
+			variant:  "ubuntu22.04",
+			wantName: "ubuntu",
+			wantVer:  "22.04",
+		},
+		{
+			name:     "ubuntu 24.04 with suffix",
+			variant:  "ubuntu24.04-noble",
+			wantName: "ubuntu",
+			wantVer:  "24.04",
+		},
+		{
+			name:     "alpine 3.23",
+			variant:  "alpine3.23",
+			wantName: "alpine",
+			wantVer:  "3.23",
+		},
+		{
+			name:    "unknown variant",
+			variant: "custom-image",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotVer := deriveImageOSFromVariant(tt.variant)
+			if gotName != tt.wantName || gotVer != tt.wantVer {
+				t.Fatalf("deriveImageOSFromVariant(%q) = (%q, %q), want (%q, %q)", tt.variant, gotName, gotVer, tt.wantName, tt.wantVer)
+			}
+		})
+	}
+}

--- a/pkg/marmotd/api-image-import.go
+++ b/pkg/marmotd/api-image-import.go
@@ -3,6 +3,7 @@ package marmotd
 import (
 	"archive/tar"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -49,6 +50,16 @@ func (s *Server) ApiImportImageArchive(ctx echo.Context) error {
 }
 
 func extractSingleQcow2FromTGZ(src io.Reader, destDir string) (string, error) {
+	return extractFromTGZ(src, destDir, nil)
+}
+
+type archiveMetaJSON struct {
+	Name      string `json:"name"`
+	OsName    string `json:"osName,omitempty"`
+	OsVersion string `json:"osVersion,omitempty"`
+}
+
+func extractFromTGZ(src io.Reader, destDir string, meta *archiveMetaJSON) (string, error) {
 	gz, err := gzip.NewReader(src)
 	if err != nil {
 		return "", fmt.Errorf("failed to read gzip stream: %w", err)
@@ -71,6 +82,18 @@ func extractSingleQcow2FromTGZ(src io.Reader, destDir string) (string, error) {
 		}
 
 		base := filepath.Base(hdr.Name)
+
+		if base == "metadata.json" && meta != nil {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return "", fmt.Errorf("failed to read metadata.json: %w", err)
+			}
+			if err := json.Unmarshal(data, meta); err != nil {
+				slog.Warn("extractFromTGZ: failed to parse metadata.json; ignoring", "err", err)
+			}
+			continue
+		}
+
 		if !strings.HasSuffix(strings.ToLower(base), ".qcow2") {
 			continue
 		}

--- a/pkg/marmotd/image.go
+++ b/pkg/marmotd/image.go
@@ -221,7 +221,8 @@ func (m *Marmot) ImportImageArchiveWithNode(src io.Reader, imageName, nodeName s
 		_ = os.RemoveAll(importDir)
 	}()
 
-	importedQcow2, err := extractSingleQcow2FromTGZ(src, importDir)
+	var archiveMeta archiveMetaJSON
+	importedQcow2, err := extractFromTGZ(src, importDir, &archiveMeta)
 	if err != nil {
 		return api.Image{}, err
 	}
@@ -233,6 +234,14 @@ func (m *Marmot) ImportImageArchiveWithNode(src io.Reader, imageName, nodeName s
 	if err != nil {
 		return api.Image{}, err
 	}
+
+	if archiveMeta.OsName != "" {
+		image.Spec.OsName = util.StringPtr(archiveMeta.OsName)
+	}
+	if archiveMeta.OsVersion != "" {
+		image.Spec.OsVersion = util.StringPtr(archiveMeta.OsVersion)
+	}
+
 	cleanupEntry := func() {
 		if err := m.Db.DeleteImage(image.Metadata.Id); err != nil {
 			slog.Warn("ImportImageArchiveWithNode() failed to rollback imported image entry", "imageId", image.Metadata.Id, "err", err)


### PR DESCRIPTION
**概要**
`mactl image export` と `server createimage` 周辺の画像メタデータ扱いを修正し、ノード単位の画像選択と OS 情報の保持を改善しました。あわせて、画像一覧の表示仕様と export/import のメタデータ保存を整理しています。

**変更内容**
- `mactl image export` が同名画像を複数ノードに持つ場合、現在のクラスタノードを優先して export するように修正
- export 時に qcow2 を取得できない候補があっても、同名の別候補へフォールバックするように改善
- image archive に `metadata.json` を同梱し、`osName` / `osVersion` を export/import で保持
- `server createimage` で作成した image に `osName` / `osVersion` を引き継ぐよう修正
- `mactl get img` の表示を調整
  - WAITING 状態では QCOW2 を no 表示
  - COMPLETE 判定から LV 一致を除外
  - LV 列幅を 6 文字に拡張

**影響**
- 同名 image が複数ノードにある構成でも export が安定する
- export/import 後や server から作成した image でも OS 情報が失われにくくなる
- 表示上の状態判定が実運用に合うようになる

**確認**
- `go test ./cmd/mactl/cmd -count=1`
- `go test ./pkg/db -count=1`
- `go test ./pkg/marmotd -run '^$'`

