### PR TITLE
デグレ対応

### DIFF
--- a/cmd/mactl/cmd/server_ansible.go
+++ b/cmd/mactl/cmd/server_ansible.go
@@ -97,8 +97,17 @@ func extractSuccessID(body []byte) (string, error) {
 
 func waitServerRunning(m *client.MarmotEndpoint, serverID string, timeout, interval time.Duration) error {
 	deadline := time.Now().Add(timeout)
+	var lastErr error
 	for {
 		body, _, err := m.GetServerById(serverID)
+		if err != nil {
+			lastErr = err
+			if strings.Contains(err.Error(), "IDが存在しません") {
+				return fmt.Errorf("server %s is not found before ansible apply: %w", serverID, err)
+			}
+		} else {
+			lastErr = nil
+		}
 		if err == nil {
 			var srv api.Server
 			if err := json.Unmarshal(body, &srv); err == nil {
@@ -120,6 +129,9 @@ func waitServerRunning(m *client.MarmotEndpoint, serverID string, timeout, inter
 			}
 		}
 		if time.Now().After(deadline) {
+			if lastErr != nil {
+				return fmt.Errorf("timeout waiting for server %s to become RUNNING: last error: %w", serverID, lastErr)
+			}
 			return fmt.Errorf("timeout waiting for server %s to become RUNNING", serverID)
 		}
 		time.Sleep(interval)


### PR DESCRIPTION
## 概要
`mactl create/apply` の Ansible playbook 適用フローで、`OS起動待機中.....` のまま原因不明で待ち続ける問題を改善しました。  
あわせて、`image export/import` と `server createimage` 周辺のメタデータ保持・ノード選択ロジックを整理し、運用時の失敗要因を減らしています。

## 変更内容

### 1) Ansible 適用フローの失敗原因を明確化
- `waitServerRunning` の待機ループで `GetServerById` エラーを保持するように変更
- サーバー未検出（`IDが存在しません`）を検知した場合は即エラーで中止
- タイムアウト時に「最後に発生した API エラー」を返すように変更

効果:
- 「ただ待ち続ける」状態を回避し、なぜ進まないのかを即座に把握できる

### 2) image export の current endpoint 制約を明確化
- current endpoint の `NodeName` を必須化（取得不可なら即エラー）
- 同名イメージ候補は current endpoint ノード上のものを優先選択
- endpoint を切り替えない方針に統一（候補失敗時はエラー返却）

効果:
- 別ノードの同名イメージを誤って選び `qcow2 file does not exist` になるケースを抑制

### 3) image export/import の OS メタデータ保持
- `mactl image export` で `metadata.json` をアーカイブ同梱
- `mactl image import` 側で `metadata.json` を読み取り `osName/osVersion` を復元

効果:
- export/import 後に OS 情報が欠落しない

### 4) server createimage の OS 情報引き継ぎ
- `MakeImageEntryFromRunningVM` で `OsName/OsVersion` を補完
  - `osVariant` からソースイメージ参照
  - 必要に応じて既知 variant から導出

効果:
- サーバー由来イメージで `osName/osVersion` が消える不具合を解消

## テスト
- `go test ./cmd/mactl/cmd -count=1`
- `go test ./pkg/db -count=1`
- `go test ./pkg/marmotd -run '^$'`

## 影響範囲
- `mactl create/apply` の Ansible 実行時エラーハンドリング
- `mactl image export/import`
- `server createimage` の image spec 生成ロジック

## 補足
本 PR は「動かない時に原因が見えること」を重視し、待機系処理の失敗ハンドリングを強化しています。