### PR TITLE
DBアクセスのパニック発生の回避

### DIFF
--- a/pkg/controller/image-controller.go
+++ b/pkg/controller/image-controller.go
@@ -121,6 +121,7 @@ func (c *controller) imageControllerLoop() {
 			}
 			if dbErr := c.marmot.Db.UpdateImageStatus(image.Metadata.Id, db.IMAGE_CREATING); dbErr != nil {
 				slog.Error("UpdateImageStatus() failed", "imageId", image.Metadata.Id, "err", dbErr)
+				continue
 			}
 			// ラベルの存在をチェック
 			if image.Metadata.Labels != nil {

--- a/pkg/controller/image-controller.go
+++ b/pkg/controller/image-controller.go
@@ -85,7 +85,9 @@ func (c *controller) imageControllerLoop() {
 			deletionTime := *image.Status.DeletionTimeStamp
 			if time.Since(deletionTime) > c.deletionDelay {
 				slog.Debug("削除のタイムスタンプが一定時間以上経過しているイメージ検出", "IMAGE", image.Metadata.Name)
-				c.marmot.Db.UpdateImageStatus(image.Metadata.Id, db.IMAGE_DELETING)
+				if dbErr := c.marmot.Db.UpdateImageStatus(image.Metadata.Id, db.IMAGE_DELETING); dbErr != nil {
+					slog.Error("UpdateImageStatus() failed", "imageId", image.Metadata.Id, "err", dbErr)
+				}
 			}
 		}
 
@@ -112,10 +114,14 @@ func (c *controller) imageControllerLoop() {
 			// bootVolume 由来のイメージは、インポート済み扱いにせず必ずVMコピー処理へ進める。
 			if source != "bootVolume" && image.Spec.SourceUrl == nil && strings.TrimSpace(util.OrDefault(image.Spec.Qcow2Path, "")) != "" {
 				slog.Debug("インポート済みQCOW2イメージを利用可能に遷移", "image", image.Metadata.Name, "imageId", image.Metadata.Id)
-				c.marmot.Db.UpdateImageStatusMessage(image.Metadata.Id, db.IMAGE_AVAILABLE, "")
+				if dbErr := c.marmot.Db.UpdateImageStatusMessage(image.Metadata.Id, db.IMAGE_AVAILABLE, ""); dbErr != nil {
+					slog.Error("UpdateImageStatusMessage() failed", "imageId", image.Metadata.Id, "err", dbErr)
+				}
 				continue
 			}
-			c.marmot.Db.UpdateImageStatus(image.Metadata.Id, db.IMAGE_CREATING)
+			if dbErr := c.marmot.Db.UpdateImageStatus(image.Metadata.Id, db.IMAGE_CREATING); dbErr != nil {
+				slog.Error("UpdateImageStatus() failed", "imageId", image.Metadata.Id, "err", dbErr)
+			}
 			// ラベルの存在をチェック
 			if image.Metadata.Labels != nil {
 				if source == "bootVolume" {
@@ -166,7 +172,9 @@ func (c *controller) imageControllerLoop() {
 			slog.Debug("イメージは利用可能", "image", image.Metadata.Name)
 			if err := marmotd.CheckImageBackingStore(image); err != nil {
 				slog.Warn("AVAILABLE イメージの実体が見つからないため DELETED に更新", "imageId", image.Metadata.Id, "err", err)
-				c.marmot.Db.UpdateImageStatusMessage(image.Metadata.Id, db.IMAGE_DELETED, err.Error())
+				if dbErr := c.marmot.Db.UpdateImageStatusMessage(image.Metadata.Id, db.IMAGE_DELETED, err.Error()); dbErr != nil {
+					slog.Error("UpdateImageStatusMessage() failed", "imageId", image.Metadata.Id, "err", dbErr)
+				}
 				continue
 			}
 			if err := c.reconcileFollowerImageSpec(image); err != nil {
@@ -246,16 +254,22 @@ func (c *controller) startFollowerSync(waitingImage api.Image) error {
 
 	switch headImage.Status.StatusCode {
 	case db.IMAGE_AVAILABLE:
-		c.marmot.Db.UpdateImageStatusMessage(waitingImage.Metadata.Id, db.IMAGE_CREATING, "ヘッドノードからQCOW2イメージを取得中")
+		if dbErr := c.marmot.Db.UpdateImageStatusMessage(waitingImage.Metadata.Id, db.IMAGE_CREATING, "ヘッドノードからQCOW2イメージを取得中"); dbErr != nil {
+			slog.Error("UpdateImageStatusMessage() failed", "imageId", waitingImage.Metadata.Id, "err", dbErr)
+		}
 		go func(image api.Image, head api.Image) {
 			if err := c.syncFollowerImageFromHead(image, head); err != nil {
 				slog.Error("フォロワーイメージ同期に失敗", "imageId", image.Metadata.Id, "headImageId", head.Metadata.Id, "err", err)
-				c.marmot.Db.UpdateImageStatusMessage(image.Metadata.Id, db.IMAGE_CREATION_FAILED, err.Error())
+				if dbErr := c.marmot.Db.UpdateImageStatusMessage(image.Metadata.Id, db.IMAGE_CREATION_FAILED, err.Error()); dbErr != nil {
+					slog.Error("UpdateImageStatusMessage() failed", "imageId", image.Metadata.Id, "err", dbErr)
+				}
 			}
 		}(waitingImage, headImage)
 	case db.IMAGE_CREATION_FAILED, db.IMAGE_DELETED:
 		msg := fmt.Sprintf("head image is not available: headImageId=%s status=%s", headImage.Metadata.Id, util.OrDefault(headImage.Status.Status, ""))
-		c.marmot.Db.UpdateImageStatusMessage(waitingImage.Metadata.Id, db.IMAGE_CREATION_FAILED, msg)
+		if dbErr := c.marmot.Db.UpdateImageStatusMessage(waitingImage.Metadata.Id, db.IMAGE_CREATION_FAILED, msg); dbErr != nil {
+			slog.Error("UpdateImageStatusMessage() failed", "imageId", waitingImage.Metadata.Id, "err", dbErr)
+		}
 	default:
 		// WAITING を維持する。
 	}
@@ -333,7 +347,9 @@ func (c *controller) syncFollowerImageFromHead(followerImage api.Image, headImag
 		"followerNode", followerLatest.Metadata.NodeName,
 		"module", moduleKey,
 	)
-	c.marmot.Db.UpdateImageStatus(followerLatest.Metadata.Id, db.IMAGE_AVAILABLE)
+	if dbErr := c.marmot.Db.UpdateImageStatus(followerLatest.Metadata.Id, db.IMAGE_AVAILABLE); dbErr != nil {
+		slog.Error("UpdateImageStatus() failed", "imageId", followerLatest.Metadata.Id, "err", dbErr)
+	}
 
 	return nil
 }

--- a/pkg/controller/scheduler-controller.go
+++ b/pkg/controller/scheduler-controller.go
@@ -118,7 +118,9 @@ func (c *schedulerController) schedulerControllerLoop() {
 			if !clusterHasNode(statuses, assignedNode) {
 				msg := "metadata.nodeName=" + assignedNode + " はクラスタ内に存在しません"
 				slog.Warn("存在しない nodeName が指定されたサーバーを ERROR に更新", "serverId", api.ServerID(server), "nodeName", assignedNode)
-				c.marmot.Db.UpdateServerStatus(api.ServerID(server), db.SERVER_ERROR, msg)
+					if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(server), db.SERVER_ERROR, msg); dbErr != nil {
+						slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(server), "err", dbErr)
+					}
 			}
 			continue
 		}

--- a/pkg/controller/server-controller.go
+++ b/pkg/controller/server-controller.go
@@ -113,7 +113,9 @@ func (c *controller) serverControllerLoop() {
 			if assignErr != nil {
 				slog.Error("ResolveAndAssignServerNodeByStorage()", "serverId", api.ServerID(spec), "err", assignErr)
 				msg := fmt.Sprintf("サーバーのノード割当解決に失敗した。原因エラー: %v", assignErr)
-				c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg)
+				if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg); dbErr != nil {
+					slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+				}
 				continue
 			}
 			if strings.TrimSpace(assignedNode) != "" {
@@ -126,7 +128,9 @@ func (c *controller) serverControllerLoop() {
 			deletionTime := *spec.Status.DeletionTimeStamp
 			if time.Since(deletionTime) > c.deletionDelay {
 				slog.Debug("削除のタイムスタンプが一定時間以上経過しているサーバー検出", "SERVER", api.ServerID(spec))
-				c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_DELETING, "")
+				if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_DELETING, ""); dbErr != nil {
+					slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+				}
 				spec.Status.StatusCode = db.SERVER_DELETING
 				spec.Status.Status = util.StringPtr(db.ServerStatus[db.SERVER_DELETING])
 			}
@@ -164,20 +168,28 @@ func (c *controller) serverControllerLoop() {
 		switch spec.Status.StatusCode {
 		case db.SERVER_PENDING:
 			slog.Debug("生成待ち状態のサーバー検出", "SERVER", api.ServerID(spec))
-			c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_PROVISIONING, "")
+			if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_PROVISIONING, ""); dbErr != nil {
+				slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+			}
 			if _, err := c.marmot.CreateServerManage(api.ServerID(spec)); err != nil {
 				slog.Error("CreateServerManage()", "err", err)
 				msg := fmt.Sprintf("サーバーのプロビジョニングに失敗した。原因エラー: %v", err)
 				if isRetryableServerProvisionError(err) {
 					retryMsg := fmt.Sprintf("サーバーのプロビジョニング待機中（依存関係の準備待ち）: %v", err)
 					slog.Warn("CreateServerManage() failed with retryable error; keep server pending", "server", api.ServerID(spec), "err", err)
-					c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_PENDING, retryMsg)
+					if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_PENDING, retryMsg); dbErr != nil {
+						slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+					}
 					continue
 				}
-				c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg)
+				if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg); dbErr != nil {
+					slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+				}
 				continue
 			}
-			c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_RUNNING, "")
+			if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_RUNNING, ""); dbErr != nil {
+				slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+			}
 		case db.SERVER_RUNNING:
 			slog.Debug("稼働中のサーバー検出", "SERVER", api.ServerID(spec))
 		case db.SERVER_STOPPING:
@@ -185,7 +197,9 @@ func (c *controller) serverControllerLoop() {
 			if err := c.marmot.StopServerManage(api.ServerID(spec)); err != nil {
 				slog.Error("StopServerManage()", "err", err)
 				msg := fmt.Sprintf("サーバーの停止に失敗: %v", err)
-				c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg)
+				if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg); dbErr != nil {
+					slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+				}
 			}
 		case db.SERVER_STOPPED:
 			slog.Debug("停止中のサーバー検出", "SERVER", api.ServerID(spec))
@@ -194,7 +208,9 @@ func (c *controller) serverControllerLoop() {
 			if err := c.marmot.StartServerManage(api.ServerID(spec)); err != nil {
 				slog.Error("StartServerManage()", "err", err)
 				msg := fmt.Sprintf("サーバーの起動に失敗: %v", err)
-				c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg)
+				if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg); dbErr != nil {
+					slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+				}
 			}
 		case db.SERVER_ERROR:
 			slog.Debug("エラー状態のサーバー検出", "SERVER", api.ServerID(spec))
@@ -222,7 +238,9 @@ func (c *controller) serverControllerLoop() {
 				if err := c.marmot.DeleteServerByIdManage(api.ServerID(spec)); err != nil {
 					slog.Error("DeleteServerById()", "err", err)
 					msg := fmt.Sprintf("サーバーの削除に失敗: %v", err)
-					c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg)
+					if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg); dbErr != nil {
+						slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+					}
 				}
 			}
 
@@ -259,7 +277,9 @@ func (c *controller) serverControllerLoop() {
 			if err := c.marmot.Db.DeleteServerById(api.ServerID(spec)); err != nil {
 				slog.Error("DeleteServerById()", "err", err)
 				msg := fmt.Sprintf("サーバーのデータベースからの削除に失敗: %v", err)
-				c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg)
+				if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg); dbErr != nil {
+					slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+				}
 			}
 
 		case db.SERVER_PROVISIONING:
@@ -268,7 +288,9 @@ func (c *controller) serverControllerLoop() {
 			if spec.Status != nil && spec.Status.Message != nil && strings.TrimSpace(*spec.Status.Message) != "" {
 				msg = *spec.Status.Message
 			}
-			c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg)
+			if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg); dbErr != nil {
+				slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+			}
 
 		default:
 			slog.Warn("不明な状態のサーバー検出", "SERVER", api.ServerID(spec), "STATUS", *spec.Status.Status)

--- a/pkg/controller/server-controller.go
+++ b/pkg/controller/server-controller.go
@@ -170,6 +170,7 @@ func (c *controller) serverControllerLoop() {
 			slog.Debug("生成待ち状態のサーバー検出", "SERVER", api.ServerID(spec))
 			if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_PROVISIONING, ""); dbErr != nil {
 				slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+				continue
 			}
 			if _, err := c.marmot.CreateServerManage(api.ServerID(spec)); err != nil {
 				slog.Error("CreateServerManage()", "err", err)

--- a/pkg/db/db-image.go
+++ b/pkg/db/db-image.go
@@ -603,12 +603,12 @@ func (d *Database) DeleteImage(id string) error {
 }
 
 // ステータスの変更
-func (d *Database) UpdateImageStatus(id string, status int) {
-	d.UpdateImageStatusMessage(id, status, "")
+func (d *Database) UpdateImageStatus(id string, status int) error {
+	return d.UpdateImageStatusMessage(id, status, "")
 }
 
 // ステータスとメッセージの変更
-func (d *Database) UpdateImageStatusMessage(id string, status int, message string) {
+func (d *Database) UpdateImageStatusMessage(id string, status int, message string) error {
 	for {
 		err := d.updateImageStatusMessage(id, status, message)
 		if err == ErrUpdateConflict {
@@ -617,9 +617,9 @@ func (d *Database) UpdateImageStatusMessage(id string, status int, message strin
 		}
 		if err != nil {
 			slog.Error("UpdateImageStatusMessage() failed", "err", err, "imageId", id)
-			panic(err)
+			return err
 		}
-		return
+		return nil
 	}
 }
 

--- a/pkg/db/db-servers.go
+++ b/pkg/db/db-servers.go
@@ -195,7 +195,7 @@ func (d *Database) updateServer(id string, spec api.Server) error {
 }
 
 // サーバーオブジェクトのステータスを更新
-func (d *Database) UpdateServerStatus(id string, status int, message string) {
+func (d *Database) UpdateServerStatus(id string, status int, message string) error {
 	for {
 		err := d.updateServerStatus(id, status, message)
 		if err == ErrUpdateConflict {
@@ -203,9 +203,9 @@ func (d *Database) UpdateServerStatus(id string, status int, message string) {
 			continue
 		} else if err != nil {
 			slog.Error("UpdateServerStatus() failed", "err", err, "serverId", id)
-			panic(err)
+			return err
 		}
-		break
+		return nil
 	}
 }
 

--- a/pkg/db/db-volumes.go
+++ b/pkg/db/db-volumes.go
@@ -348,7 +348,7 @@ func (d *Database) FindVolumeByName(name, kind string) ([]api.Volume, error) {
 }
 
 // OSボリュームの状態更新
-// エラーが出る場合、パニックして停止させるべき
+// エラー時はログ出力して処理を中断する（panic は発生させない）
 func (d *Database) UpdateVolumeStatus(id string, status int) {
 	d.UpdateVolumeStatusMessage(id, status, "")
 }

--- a/pkg/db/db-volumes.go
+++ b/pkg/db/db-volumes.go
@@ -360,8 +360,8 @@ func (d *Database) UpdateVolumeStatusMessage(id string, status int, message stri
 	}
 	vol, err := d.GetVolumeById(id)
 	if err != nil {
-		slog.Error("panic! failed to get volume by id", "err", err, "id", id)
-		//panic(fmt.Sprintf("failed to get volume by id: %s", id))
+		slog.Error("UpdateVolumeStatusMessage() failed to get volume", "err", err, "id", id)
+		return
 	}
 	vol.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
 	vol.Status.StatusCode = status
@@ -373,8 +373,7 @@ func (d *Database) UpdateVolumeStatusMessage(id string, status int, message stri
 	}
 
 	if err = d.UpdateVolume(id, vol); err != nil {
-		slog.Error("panic! failed to update volume", "err", err, "volId", id)
-		//panic(fmt.Sprintf("failed to update volume: %s", id))
+		slog.Error("UpdateVolumeStatusMessage() failed to update volume", "err", err, "volId", id)
 	}
 }
 
@@ -386,13 +385,12 @@ func (d *Database) SetVolumeDeletionTimestamp(id string) {
 	}
 	vol, err := d.GetVolumeById(id)
 	if err != nil {
-		slog.Error("panic! failed to get volume by id", "err", err, "id", id)
-		//panic(fmt.Sprintf("failed to get volume by id: %s", id))
+		slog.Error("SetVolumeDeletionTimestamp() failed to get volume", "err", err, "id", id)
+		return
 	}
 	vol.Status.DeletionTimeStamp = util.TimePtr(time.Now())
 	if err = d.UpdateVolume(id, vol); err != nil {
-		slog.Error("panic! failed to update volume", "err", err, "volId", id)
-		//panic(fmt.Sprintf("failed to update volume: %s", id))
+		slog.Error("SetVolumeDeletionTimestamp() failed to update volume", "err", err, "volId", id)
 	}
 }
 

--- a/pkg/marmotd/api-server.go
+++ b/pkg/marmotd/api-server.go
@@ -127,7 +127,10 @@ func (s *Server) ApiStopServerById(ctx echo.Context, id string) error {
 		return ctx.JSON(http.StatusInternalServerError, api.Error{Code: 1, Message: err.Error()})
 	}
 
-	s.Ma.Db.UpdateServerStatus(id, db.SERVER_STOPPING, "")
+	if err := s.Ma.Db.UpdateServerStatus(id, db.SERVER_STOPPING, ""); err != nil {
+		slog.Error("UpdateServerStatus()", "err", err, "id", id)
+		return ctx.JSON(http.StatusInternalServerError, api.Error{Code: 1, Message: err.Error()})
+	}
 
 	var resp api.Success
 	resp.Id = id
@@ -145,7 +148,10 @@ func (s *Server) ApiStartServerById(ctx echo.Context, id string) error {
 		return ctx.JSON(http.StatusInternalServerError, api.Error{Code: 1, Message: err.Error()})
 	}
 
-	s.Ma.Db.UpdateServerStatus(id, db.SERVER_STARTING, "")
+	if err := s.Ma.Db.UpdateServerStatus(id, db.SERVER_STARTING, ""); err != nil {
+		slog.Error("UpdateServerStatus()", "err", err, "id", id)
+		return ctx.JSON(http.StatusInternalServerError, api.Error{Code: 1, Message: err.Error()})
+	}
 
 	var resp api.Success
 	resp.Id = id

--- a/pkg/marmotd/image-timeout.go
+++ b/pkg/marmotd/image-timeout.go
@@ -16,8 +16,8 @@ var updateImageRecord = func(m *Marmot, image api.Image) error {
 	return m.Db.UpdateImage(image.Metadata.Id, image)
 }
 
-var updateImageFailureStatus = func(m *Marmot, imageID, message string) {
-	m.Db.UpdateImageStatusMessage(imageID, db.IMAGE_CREATION_FAILED, message)
+var updateImageFailureStatus = func(m *Marmot, imageID, message string) error {
+	return m.Db.UpdateImageStatusMessage(imageID, db.IMAGE_CREATION_FAILED, message)
 }
 
 func contextTimeoutHint(ctx context.Context) time.Duration {
@@ -71,6 +71,8 @@ func (m *Marmot) markImageCreationFailed(image api.Image, err error) error {
 		return err
 	}
 
-	updateImageFailureStatus(m, image.Metadata.Id, err.Error())
+	if updateErr := updateImageFailureStatus(m, image.Metadata.Id, err.Error()); updateErr != nil {
+		slog.Error("UpdateImageStatusMessage() failed while setting image failure status", "image id", image.Metadata.Id, "err", updateErr)
+	}
 	return err
 }

--- a/pkg/marmotd/image-timeout_test.go
+++ b/pkg/marmotd/image-timeout_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Image timeout helpers", func() {
 	Describe("markImageCreationFailed", func() {
 		var (
 			originalUpdateImageRecord        func(*Marmot, api.Image) error
-			originalUpdateImageFailureStatus func(*Marmot, string, string)
+			originalUpdateImageFailureStatus func(*Marmot, string, string) error
 		)
 
 		BeforeEach(func() {
@@ -124,8 +124,9 @@ var _ = Describe("Image timeout helpers", func() {
 				updated = in
 				return nil
 			}
-			updateImageFailureStatus = func(_ *Marmot, imageID, message string) {
+			updateImageFailureStatus = func(_ *Marmot, imageID, message string) error {
 				Fail("fallback status update should not be called")
+				return nil
 			}
 
 			err := m.markImageCreationFailed(image, baseErr)
@@ -151,10 +152,11 @@ var _ = Describe("Image timeout helpers", func() {
 				Fail("direct image update should not be called")
 				return nil
 			}
-			updateImageFailureStatus = func(_ *Marmot, imageID, message string) {
+			updateImageFailureStatus = func(_ *Marmot, imageID, message string) error {
 				called = true
 				Expect(imageID).To(Equal("img-3"))
 				Expect(message).To(Equal("timeout"))
+				return nil
 			}
 
 			err := m.markImageCreationFailed(image, baseErr)

--- a/pkg/marmotd/image.go
+++ b/pkg/marmotd/image.go
@@ -182,7 +182,10 @@ func (m *Marmot) CreateNewImageManageWithContext(ctx context.Context, id string)
 		slog.Error("Failed to update image data in DB", "imgId", id, "err", err)
 		return markFailed(err)
 	}
-	m.Db.UpdateImageStatus(id, db.IMAGE_AVAILABLE)
+	if err := m.Db.UpdateImageStatus(id, db.IMAGE_AVAILABLE); err != nil {
+		slog.Error("UpdateImageStatus()", "imgId", id, "err", err)
+		return markFailed(err)
+	}
 
 	return &image, nil
 }

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -1522,7 +1522,10 @@ func (m *Marmot) MakeImageEntryFromRunningVMWithContext(ctx context.Context, ser
 		slog.Error("MakeImageEntryFromRunningVMWithContext()", "err", err, "serverId", serverId, "imageName", name)
 		return "", markFailed(err)
 	}
-	m.Db.UpdateImageStatus(imageID, db.IMAGE_AVAILABLE)
+	if err := m.Db.UpdateImageStatus(imageID, db.IMAGE_AVAILABLE); err != nil {
+		slog.Error("UpdateImageStatus()", "imageId", imageID, "err", err)
+		return "", markFailed(err)
+	}
 
 	return imageID, nil
 }


### PR DESCRIPTION
## 概要

db の DB 更新失敗時に `panic` が発生し、プロセスが落ちる問題を解消します。

## 背景

`UpdateServerStatus`・`UpdateImageStatusMessage` / `UpdateImageStatus` は、etcd への書き込みに失敗したとき `panic(err)` でプロセスを即停止させていました。DB 更新の失敗は一時的な通信エラーでも発生するため、これが外部評価・本番環境において「突然プロセスが落ちる」不安定な挙動として表面化していました。

また `UpdateVolumeStatusMessage` / `SetVolumeDeletionTimestamp` も、`GetVolumeById` 失敗時にコメントアウトされた `panic` が残っており、ログメッセージに `"panic!"` という誤解を招く文字列が混在していました。さらに取得失敗時に nil の `vol` をそのまま使い続ける nil アクセスパニックの経路も潜在していました。

## 変更内容

### db — panic 除去・戻り値変更

| ファイル | 関数 | 変更 |
|---|---|---|
| db-servers.go | `UpdateServerStatus` | `void` → `error` 返却、`panic` を `return err` に変更 |
| db-image.go | `UpdateImageStatusMessage` / `UpdateImageStatus` | 同上 |
| db-volumes.go | `UpdateVolumeStatusMessage` / `SetVolumeDeletionTimestamp` | `GetVolumeById` 失敗時に `return` を追加して nil アクセスを防止、ログメッセージを標準形式に統一、コメントアウト済み `panic` を削除 |

### controller — 呼び出し箇所のエラーハンドリング追加

`UpdateServerStatus` / `UpdateImageStatus` / `UpdateImageStatusMessage` の全呼び出し箇所を `if dbErr := ...; dbErr != nil { slog.Error(...) }` 形式に変更し、DB 更新失敗時もコントローラーループが継続するようにしました。

対象ファイル: server-controller.go、scheduler-controller.go、image-controller.go

## 動作確認

```
go build ./...
go test ./pkg/db/... ./pkg/controller/... -count=1
```

全パッケージがビルド・テスト通過しています。

## 期待される効果

- etcd 一時障害時にプロセスが落ちなくなる
- DB 更新失敗はエラーログとして記録され、運用時に原因追跡が可能になる