### PR TITLE
IPAM の信頼性改善

### DIFF
--- a/pkg/db/db-ipam.go
+++ b/pkg/db/db-ipam.go
@@ -426,11 +426,29 @@ func addIP(ip netip.Addr, delta int64) netip.Addr {
 }
 
 func addIPBig(ip netip.Addr, delta *big.Int) (netip.Addr, error) {
+	if ip.Is4() {
+		if delta.Sign() < 0 {
+			return netip.Addr{}, fmt.Errorf("ip calculation overflow")
+		}
+		if delta.BitLen() > 32 {
+			return netip.Addr{}, fmt.Errorf("ip calculation overflow")
+		}
+
+		a4 := ip.As4()
+		base := uint32(a4[0])<<24 | uint32(a4[1])<<16 | uint32(a4[2])<<8 | uint32(a4[3])
+		d := uint32(delta.Uint64())
+		if d > (^uint32(0) - base) {
+			return netip.Addr{}, fmt.Errorf("ip calculation overflow")
+		}
+		out := base + d
+		return netip.AddrFrom4([4]byte{byte(out >> 24), byte(out >> 16), byte(out >> 8), byte(out)}), nil
+	}
+
 	ipBytes := ip.As16()
 	val := new(big.Int).SetBytes(ipBytes[:])
 	result := new(big.Int).Add(val, delta)
 
-	max := new(big.Int).Lsh(big.NewInt(1), uint(ip.BitLen()))
+	max := new(big.Int).Lsh(big.NewInt(1), 128)
 	max.Sub(max, big.NewInt(1))
 	if result.Sign() < 0 || result.Cmp(max) > 0 {
 		return netip.Addr{}, fmt.Errorf("ip calculation overflow")

--- a/pkg/db/db-ipam.go
+++ b/pkg/db/db-ipam.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"math"
 	"math/big"
 	"net/netip"
 	"strings"
@@ -113,7 +112,19 @@ func (d *Database) CreateIpNetwork(vnetid string, spec *api.IPNetwork) (string, 
 	addr := networkAddr.Next()
 	net.Netmasklen = util.IntPtrInt(prefix.Bits())
 	net.StartAddress = util.StringPtr(addr.String())
-	addr = addIP(addr, int64(math.Pow(2, float64(int(prefix.Addr().BitLen()-prefix.Bits()))))-3) // ブロードキャストアドレスとゲートウェイを考慮して-3
+	hostBits := prefix.Addr().BitLen() - prefix.Bits()
+	if hostBits < 2 {
+		slog.Error("CreateIpNetwork()", "err", "prefix is too small for gateway and usable host", "addressMaskLen", prefix.String())
+		return "", fmt.Errorf("prefix is too small for gateway and usable host")
+	}
+	// ブロードキャストアドレスとゲートウェイを考慮して -3 する。
+	endDelta := new(big.Int).Lsh(big.NewInt(1), uint(hostBits))
+	endDelta.Sub(endDelta, big.NewInt(3))
+	addr, err = addIPBig(addr, endDelta)
+	if err != nil {
+		slog.Error("CreateIpNetwork()", "err", err, "addressMaskLen", prefix.String())
+		return "", err
+	}
 	net.EndAddress = util.StringPtr(addr.String())
 	net.NetworkAddress = util.StringPtr(networkAddr.String())
 	net.Gateway = util.StringPtr(networkAddr.Next().String()) // ゲートウェイはネットワークアドレスの次のアドレスとする
@@ -227,9 +238,12 @@ func (d *Database) DeleteIpNetworkById(vnetId, ipnetId string) error {
 // 渡したホストIDは、このホストによって使用中であることを示すために使用される。
 func (d *Database) AllocateIP(vnetId, ipnetId, hostId string) (string, int, error) {
 	net, err := d.GetIpNetworkById(vnetId, ipnetId)
-	if err == nil || err.Error() == "not found" {
-		// NOP
-	} else if err != nil {
+	if err != nil {
+		slog.Error("AllocateIP()", "err", err, "vnetId", vnetId, "ipnetId", ipnetId)
+		return "", 0, err
+	}
+	if net.AddressMaskLen == nil || strings.TrimSpace(*net.AddressMaskLen) == "" {
+		err := fmt.Errorf("ip network AddressMaskLen is empty")
 		slog.Error("AllocateIP()", "err", err, "vnetId", vnetId, "ipnetId", ipnetId)
 		return "", 0, err
 	}
@@ -239,31 +253,34 @@ func (d *Database) AllocateIP(vnetId, ipnetId, hostId string) (string, int, erro
 		slog.Error("AllocateIP()", "err", err, "vnetId", vnetId, "ipnetId", ipnetId)
 		return "", 0, err
 	}
+	prefix = prefix.Masked()
+
+	lockKey := NetworkPrefix + "/" + vnetId + "/ip_network/" + ipnetId + "/ipam_lock"
+	mutex, err := d.LockKey(lockKey)
+	if err != nil {
+		slog.Error("AllocateIP()", "err", err, "vnetId", vnetId, "ipnetId", ipnetId, "lockKey", lockKey)
+		return "", 0, err
+	}
+	defer d.UnlockKey(mutex)
+
 	networkAddr := prefix.Masked().Addr()
-	// 最初のホストアドレス (.1) から開始
-	addr := networkAddr.Next()
+	// .0 はネットワークアドレス、.1 はゲートウェイとして予約しているため .2 から探索する。
+	addr := networkAddr.Next().Next()
 
 	// 割り当てられているIPアドレスと比較して、未割り当てのIPアドレスを見つける
 	for {
-		nextAddr := addr.Next()
-		if !prefix.Contains(nextAddr) {
+		if !addr.IsValid() || !prefix.Contains(addr) {
 			slog.Error("AllocateIP()", "err", "no available IP addresses in the network", "vnetId", vnetId, "ipnetId", ipnetId)
 			return "", 0, fmt.Errorf("no available IP addresses in the network")
 		}
-		// 次へ進む
-		addr = nextAddr
 
-		// 異常値チェック
-		if !addr.IsValid() {
-			slog.Error("AllocateIP()", "err", "IP address is not valid", "vnetId", vnetId, "ipnetId", ipnetId)
-			return "", 0, fmt.Errorf("no available IP addresses in the network")
-		}
-
-		// ブロードキャストアドレスは使わない
-		nextAddr2 := addr.Next()
-		if !prefix.Contains(nextAddr2) {
-			slog.Error("AllocateIP()", "err", "no available IP addresses in the network", "vnetId", vnetId, "ipnetId", ipnetId)
-			return "", 0, fmt.Errorf("no available IP addresses in the network")
+		// IPv4 のブロードキャストアドレスは使わない。
+		if addr.Is4() {
+			nextAddr := addr.Next()
+			if !nextAddr.IsValid() || !prefix.Contains(nextAddr) {
+				slog.Error("AllocateIP()", "err", "no available IP addresses in the network", "vnetId", vnetId, "ipnetId", ipnetId)
+				return "", 0, fmt.Errorf("no available IP addresses in the network")
+			}
 		}
 
 		// 一致するものが無かったら、そのIPアドレスを割り当てる
@@ -273,14 +290,21 @@ func (d *Database) AllocateIP(vnetId, ipnetId, hostId string) (string, int, erro
 			return "", 0, err
 		}
 		if !found {
-			slog.Debug("割り当てられたIPアドレス", "IP	", addr.String())
-			d.SetIPaddrInUse(vnetId, ipnetId, addr.String(), hostId)
+			slog.Debug("割り当てられたIPアドレス", "IP\t", addr.String())
+			if err := d.SetIPaddrInUse(vnetId, ipnetId, addr.String(), hostId); err != nil {
+				slog.Error("AllocateIP()", "err", err, "vnetId", vnetId, "ipnetId", ipnetId, "candidateIP", addr.String(), "hostId", hostId)
+				return "", 0, err
+			}
 			return addr.String(), prefix.Bits(), nil
 		}
-	}
 
-	// ここに到達した場合、利用可能なIPアドレスがないことを意味する
-	return "", 0, fmt.Errorf("no available IP addresses in the network")
+		nextAddr := addr.Next()
+		if !nextAddr.IsValid() {
+			slog.Error("AllocateIP()", "err", "no available IP addresses in the network", "vnetId", vnetId, "ipnetId", ipnetId)
+			return "", 0, fmt.Errorf("no available IP addresses in the network")
+		}
+		addr = nextAddr
+	}
 }
 
 // IPアドレスを解放する
@@ -339,15 +363,6 @@ func (d *Database) SetIPaddrInUse(vnetId, ipnetId, ip, hostId string) error {
 		return err
 	}
 	key := NetworkPrefix + "/" + vnetId + "/ip_network/" + ipnetId + "/ip_address/" + *net.AddressMaskLen + "/" + ip
-	//key := IPAddressPrefix + "/" + *net.AddressMaskLen + "/" + ip
-
-	// デバック
-	fmt.Println("key=", key)
-	byteJson, err := json.MarshalIndent(rec, "", "    ")
-	if err != nil {
-		slog.Error("SetIPaddrInUse()", "err", err, "rec", rec)
-	}
-	fmt.Println("rec=", string(byteJson))
 
 	return d.PutJSON(key, rec)
 }
@@ -408,6 +423,28 @@ func addIP(ip netip.Addr, delta int64) netip.Addr {
 		return newIP.Unmap() // 元がIPv4ならIPv4形式に戻す
 	}
 	return newIP
+}
+
+func addIPBig(ip netip.Addr, delta *big.Int) (netip.Addr, error) {
+	ipBytes := ip.As16()
+	val := new(big.Int).SetBytes(ipBytes[:])
+	result := new(big.Int).Add(val, delta)
+
+	max := new(big.Int).Lsh(big.NewInt(1), uint(ip.BitLen()))
+	max.Sub(max, big.NewInt(1))
+	if result.Sign() < 0 || result.Cmp(max) > 0 {
+		return netip.Addr{}, fmt.Errorf("ip calculation overflow")
+	}
+
+	resultBytes := result.Bytes()
+	var newAddr [16]byte
+	copy(newAddr[16-len(resultBytes):], resultBytes)
+
+	newIP := netip.AddrFrom16(newAddr)
+	if ip.Is4() {
+		return newIP.Unmap(), nil
+	}
+	return newIP, nil
 }
 
 // PrefixLenToMask はプレフィックス長からネットマスク文字列を生成する（IPv4/IPv6 対応）

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -389,6 +390,9 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 			PortID:  uuid.New().String(),
 			Bus:     1,
 		}
+		if xnet.Spec.BridgeName != nil && isOVSBridge(strings.TrimSpace(*xnet.Spec.BridgeName)) {
+			defaultNS.InterfaceID = defaultNS.PortID
+		}
 		virtSpec.NetSpecs = []virt.NetSpec{defaultNS}
 
 		net.Networkid = api.VirtualNetworkID(xnet)
@@ -522,6 +526,9 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 				Network: vnet.Metadata.Name,
 				PortID:  uuid.New().String(),
 				Bus:     busno,
+			}
+			if vnet.Spec.BridgeName != nil && isOVSBridge(strings.TrimSpace(*vnet.Spec.BridgeName)) {
+				ns.InterfaceID = ns.PortID
 			}
 
 			// VLAN対応
@@ -876,10 +883,10 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 		}
 	}
 
-	// VM 起動直前に、オーバーレイネットワークのブリッジ存在を再確認する。
-	// ネットワークコントローラーとのタイミング競合でブリッジがまだ見えない場合に備える。
-	if err := m.ensureOverlayBridgesForServer(serverConfig); err != nil {
-		slog.Error("ensureOverlayBridgesForServer()", "err", err)
+	// VM 起動直前に、依存ネットワーク実体とオーバーレイブリッジを再確認する。
+	// ネットワークコントローラーとのタイミング競合や host 再起動後の実体欠落に備える。
+	if err := m.ensureServerNetworkDependencies(serverConfig); err != nil {
+		slog.Error("ensureServerNetworkDependencies()", "err", err)
 		return "", err
 	}
 
@@ -915,6 +922,9 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 			}
 			ns.Bridge = strings.TrimSpace(*vnet.Spec.BridgeName)
 			ns.Network = ""
+			if ns.InterfaceID == "" && isOVSBridge(ns.Bridge) {
+				ns.InterfaceID = ns.PortID
+			}
 			fallbackApplied = true
 		}
 		if fallbackApplied {
@@ -926,9 +936,9 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 		}
 	}
 	if err != nil && isLibvirtBridgeDeviceMissingError(err) {
-		slog.Warn("bridge device not ready; retrying after ensuring overlay bridges", "err", err)
-		if ensureErr := m.ensureOverlayBridgesForServer(serverConfig); ensureErr != nil {
-			slog.Error("ensureOverlayBridgesForServer() on retry", "err", ensureErr)
+		slog.Warn("bridge device not ready; retrying after ensuring server network dependencies", "err", err)
+		if ensureErr := m.ensureServerNetworkDependencies(serverConfig); ensureErr != nil {
+			slog.Error("ensureServerNetworkDependencies() on retry", "err", ensureErr)
 		} else {
 			consolePath, err = l.DefineAndStartVM(*dom)
 		}
@@ -1144,12 +1154,92 @@ func isLibvirtBridgeDeviceMissingError(err error) bool {
 	return strings.Contains(msg, "cannot get interface mtu") || strings.Contains(msg, "no such device")
 }
 
+func isOVSBridge(bridgeName string) bool {
+	name := strings.TrimSpace(bridgeName)
+	if name == "" {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ovs-vsctl", "br-exists", name)
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
+}
+
 func isManagedOverlayNetwork(vnet api.VirtualNetwork) bool {
 	if vnet.Spec.OverlayMode == nil {
 		return false
 	}
 	mode := strings.TrimSpace(string(*vnet.Spec.OverlayMode))
 	return strings.EqualFold(mode, string(api.Vxlan)) || strings.EqualFold(mode, string(api.Geneve))
+}
+
+func (m *Marmot) ensureServerNetworkDependencies(serverConfig api.Server) error {
+	if err := m.ensureServerLibvirtNetworks(serverConfig); err != nil {
+		return err
+	}
+	if err := m.ensureOverlayBridgesForServer(serverConfig); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Marmot) ensureServerLibvirtNetworks(serverConfig api.Server) error {
+	if serverConfig.Spec.NetworkInterface == nil {
+		return nil
+	}
+
+	for _, nic := range *serverConfig.Spec.NetworkInterface {
+		networkName := strings.TrimSpace(nic.Networkname)
+		if networkName == "" {
+			continue
+		}
+
+		vnet, err := m.Db.GetVirtualNetworkByName(networkName)
+		if err != nil {
+			return fmt.Errorf("failed to lookup virtual network %s: %w", networkName, err)
+		}
+
+		libvirtNet, found, err := m.Virt.GetVirtualNetworkByName(vnet.Metadata.Name)
+		if err != nil {
+			return fmt.Errorf("failed to lookup libvirt network %s: %w", vnet.Metadata.Name, err)
+		}
+
+		if !found {
+			xml, xmlErr := virt.CreateVirtualNetworkXML(vnet)
+			if xmlErr != nil {
+				return fmt.Errorf("failed to build virtual network XML for %s: %w", vnet.Metadata.Name, xmlErr)
+			}
+			if startErr := m.Virt.DefineAndStartVirtualNetwork(*xml); startErr != nil {
+				return fmt.Errorf("failed to define/start virtual network %s: %w", vnet.Metadata.Name, startErr)
+			}
+			continue
+		}
+
+		active, activeErr := libvirtNet.IsActive()
+		if activeErr != nil {
+			_ = libvirtNet.Free()
+			return fmt.Errorf("failed to check libvirt network state %s: %w", vnet.Metadata.Name, activeErr)
+		}
+
+		if !active {
+			if createErr := libvirtNet.Create(); createErr != nil {
+				_ = libvirtNet.Free()
+				return fmt.Errorf("failed to start libvirt network %s: %w", vnet.Metadata.Name, createErr)
+			}
+		}
+
+		if autostartErr := libvirtNet.SetAutostart(true); autostartErr != nil {
+			slog.Warn("failed to set network autostart", "network", vnet.Metadata.Name, "err", autostartErr)
+		}
+		_ = libvirtNet.Free()
+	}
+
+	return nil
 }
 
 func (m *Marmot) ensureOverlayBridgesForServer(serverConfig api.Server) error {


### PR DESCRIPTION
タイトル  
IPAM の信頼性改善: ネットワーク作成と IP 払い出しの条件不整合・到達不能コードを修正

概要  
server create / network create の根幹である IPAM 処理について、静的解析で指摘されていた条件不整合と到達不能コードを解消し、あわせて払い出し時の競合耐性と境界チェックを強化しました。単一ノード評価でも初回体験に直結するため、優先度高で対応しています。

背景  
- db-ipam.go で静的解析上の問題が検出されていた  
- 条件分岐の不整合により、異常系での挙動が不明瞭だった  
- AllocateIP の同時実行時に競合リスクがあった  
- ネットワーク終端計算が math.Pow ベースで、大きなプレフィックスに対して安全性に不安があった

主な変更点  
- AllocateIP のエラーハンドリングを整理  
- GetIpNetworkById 失敗時は即時エラー返却  
- AddressMaskLen の nil/空チェックを追加  
- 条件不整合を解消し、到達不能コードを削除  
- AllocateIP に IPAM ロックを導入し、同時払い出し時の競合を抑制  
- SetIPaddrInUse のエラーを握り潰さず返却  
- 払い出し開始アドレスを .2 からに明確化（.0: network, .1: gateway）  
- IPv4 のブロードキャスト払い出しを防止  
- CreateIpNetwork の終端アドレス計算を big.Int ベースへ変更  
- 小さすぎるプレフィックス（gateway と利用可能ホストを確保できないケース）を明示的に拒否  
- デバッグ出力を削除

影響範囲  
- 変更ファイル: db-ipam.go  
- API 仕様変更なし  
- 呼び出し側インターフェース変更なし  
- 既存機能の挙動は維持しつつ、異常系と競合時の安全性を向上

期待される効果  
- static analysis 警告の解消  
- IP 払い出し時の失敗原因が明確化  
- 同時実行時の重複払い出し/不整合リスク低減  
- ネットワーク作成時の境界計算の安全性向上

確認内容  
- db-ipam.go の静的エラー解消を確認  
- go test ./pkg/db -run '^$' 成功  
- go test ./... -run '^$' 成功

レビューポイント  
- AllocateIP のロック粒度が妥当か  
- .2 から払い出す現在仕様が既存期待と一致しているか  
- 小プレフィックス拒否条件（hostBits < 2）の運用上の妥当性

