### PR TITLE
isOVSBridge で ovs-vsctl 実行失敗を無条件 false としていた点を修正

### DIFF
--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -390,7 +390,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 			PortID:  uuid.New().String(),
 			Bus:     1,
 		}
-		if xnet.Spec.BridgeName != nil && isOVSBridge(strings.TrimSpace(*xnet.Spec.BridgeName)) {
+		if xnet.Spec.BridgeName != nil && shouldAttachOVSInterfaceID(xnet, strings.TrimSpace(*xnet.Spec.BridgeName)) {
 			defaultNS.InterfaceID = defaultNS.PortID
 		}
 		virtSpec.NetSpecs = []virt.NetSpec{defaultNS}
@@ -527,7 +527,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 				PortID:  uuid.New().String(),
 				Bus:     busno,
 			}
-			if vnet.Spec.BridgeName != nil && isOVSBridge(strings.TrimSpace(*vnet.Spec.BridgeName)) {
+			if vnet.Spec.BridgeName != nil && shouldAttachOVSInterfaceID(vnet, strings.TrimSpace(*vnet.Spec.BridgeName)) {
 				ns.InterfaceID = ns.PortID
 			}
 
@@ -922,7 +922,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 			}
 			ns.Bridge = strings.TrimSpace(*vnet.Spec.BridgeName)
 			ns.Network = ""
-			if ns.InterfaceID == "" && isOVSBridge(ns.Bridge) {
+			if ns.InterfaceID == "" && shouldAttachOVSInterfaceID(vnet, ns.Bridge) {
 				ns.InterfaceID = ns.PortID
 			}
 			fallbackApplied = true
@@ -1165,9 +1165,23 @@ func isOVSBridge(bridgeName string) bool {
 
 	cmd := exec.CommandContext(ctx, "ovs-vsctl", "br-exists", name)
 	if err := cmd.Run(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			slog.Warn("ovs bridge check skipped: ovs-vsctl not found", "bridge", name, "err", err)
+		} else if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			slog.Warn("ovs bridge check timed out", "bridge", name, "timeout", "2s")
+		} else {
+			slog.Warn("ovs bridge check failed", "bridge", name, "err", err)
+		}
 		return false
 	}
 	return true
+}
+
+func shouldAttachOVSInterfaceID(vnet api.VirtualNetwork, bridgeName string) bool {
+	if isManagedOverlayNetwork(vnet) {
+		return true
+	}
+	return isOVSBridge(bridgeName)
 }
 
 func isManagedOverlayNetwork(vnet api.VirtualNetwork) bool {


### PR DESCRIPTION
**タイトル案**  
isOVSBridge の失敗時判定を改善し、OVS 接続判定の取りこぼしを低減

**概要**  
PR #473 の追加レビューで指摘された、ovs-vsctl 実行失敗時に isOVSBridge が無条件 false を返す問題に対応しました。  
実行失敗時のログ可視化を追加し、あわせてネットワーク属性を使った補助判定を導入して InterfaceID 未設定の再発リスクを下げています。

**背景**  
- 既存実装では ovs-vsctl 実行失敗時に false を返すだけで原因が見えづらかった  
- 環境差により OVS 判定が false negative になると、InterfaceID が付かず OVS attach エラー再発の懸念があった

**変更内容**  
- server.go  
- isOVSBridge で ovs-vsctl 実行失敗時に warning ログを追加  
- 失敗理由を分岐して出力  
- ovs-vsctl not found  
- timeout  
- その他実行失敗  
- shouldAttachOVSInterfaceID を追加  
- overlay network (vxlan/geneve) の場合はネットワーク属性で OVS 判定を補助  
- default NIC 経路、指定 NIC 経路、fallback 経路の InterfaceID 付与判定を shouldAttachOVSInterfaceID に統一

**影響範囲**  
- 変更ファイル: server.go  
- API 仕様変更なし  
- 外部インターフェース変更なし

**期待される効果**  
- OVS 判定失敗時の原因追跡が容易になる  
- 環境差による false negative で InterfaceID が欠落するリスクを低減  
- OVS attach エラー再発の抑止に寄与

**確認内容**  
- go test ./pkg/marmotd -run ^$ 成功  
- go test ./... -run ^$ 成功  
- 差分は 1 ファイル、17 insertions / 3 deletions

**レビューポイント**  
- warning ログ粒度は運用上十分か  
- overlay network を優先する補助判定の方針が妥当か  
- InterfaceID 判定統一による副作用がないか