### PR TITLE
起動前プリフライトチェックを追加

### DIFF
--- a/cmd/maadm/maadm_test.go
+++ b/cmd/maadm/maadm_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		fmt.Printf("Container2 started with ID: %s\n", containerID2)
 
 		e := echo.New()
-		server := marmotd.NewServer("hvc", "http://127.0.0.1:3379")
+		server := marmotd.NewServerWithOptions("hvc", "http://127.0.0.1:3379", true)
 		go func() {
 			// Setup slog
 			opts := &slog.HandlerOptions{

--- a/cmd/mactl/test-helper.go
+++ b/cmd/mactl/test-helper.go
@@ -42,7 +42,7 @@ func startMockServer() (*mockServerHandle, error) {
 	etcdEp := "http://127.0.0.1:3379"
 
 	e := echo.New()
-	server := marmotd.NewServer(nodeName, etcdEp)
+	server := marmotd.NewServerWithOptions(nodeName, etcdEp, true)
 	h.server = server
 
 	readyCh := make(chan struct{})

--- a/pkg/marmotd/api-core.go
+++ b/pkg/marmotd/api-core.go
@@ -1,11 +1,19 @@
 package marmotd
 
 import (
+	"context"
 	_ "embed"
+	"errors"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
+	"os/exec"
+	"strings"
 	"sync"
+	"syscall"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/takara9/marmot/api"
@@ -31,6 +39,13 @@ type Server struct {
 	Ma   *Marmot
 }
 
+var (
+	netDialTimeout       = net.DialTimeout
+	ovsLookPath          = exec.LookPath
+	ovsShowCommand       = runOVSShow
+	listenPacketForCheck = net.ListenPacket
+)
+
 // Marmot インスタンスの生成、これにより関数コールが可能となる
 // etcdUrl は、etcd サーバーの URL を指定する
 // nodeName は、ハイパーバイザーのノード名を指定する
@@ -52,6 +67,103 @@ func NewMarmot(nodeName string, etcdUrl string) (*Marmot, error) {
 	return &m, nil
 }
 
+func ValidateStartupPrerequisites(etcdURL, dnsListenAddr string) error {
+	var issues []string
+
+	if err := validateEtcdReachable(etcdURL); err != nil {
+		issues = append(issues, err.Error())
+	}
+	if err := validateOVSReady(); err != nil {
+		issues = append(issues, err.Error())
+	}
+	if err := validateDNSListenAddrAvailable(dnsListenAddr); err != nil {
+		issues = append(issues, err.Error())
+	}
+
+	if len(issues) > 0 {
+		return fmt.Errorf("startup preflight failed: %s", strings.Join(issues, "; "))
+	}
+
+	return nil
+}
+
+func validateEtcdReachable(etcdURL string) error {
+	addr := strings.TrimSpace(etcdURL)
+	if addr == "" {
+		return fmt.Errorf("etcd endpoint is empty")
+	}
+
+	hostPort := strings.TrimPrefix(strings.TrimPrefix(addr, "http://"), "https://")
+	if !strings.Contains(hostPort, ":") {
+		hostPort = net.JoinHostPort(hostPort, "2379")
+	}
+
+	conn, err := netDialTimeout("tcp", hostPort, 2*time.Second)
+	if err != nil {
+		return fmt.Errorf("etcd is not reachable at %s: %w", hostPort, err)
+	}
+	_ = conn.Close()
+	return nil
+}
+
+func validateOVSReady() error {
+	if _, err := ovsLookPath("ovs-vsctl"); err != nil {
+		return fmt.Errorf("ovs-vsctl is not available: %w", err)
+	}
+
+	if err := ovsShowCommand(); err != nil {
+		return fmt.Errorf("openvswitch is not ready (ovs-vsctl show failed): %w", err)
+	}
+
+	return nil
+}
+
+func runOVSShow() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ovs-vsctl", "show")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("timeout")
+		}
+		return fmt.Errorf("%w (output=%s)", err, strings.TrimSpace(string(output)))
+	}
+
+	return nil
+}
+
+func validateDNSListenAddrAvailable(dnsListenAddr string) error {
+	addr := strings.TrimSpace(dnsListenAddr)
+	if addr == "" {
+		return nil
+	}
+
+	conn, err := listenPacketForCheck("udp", addr)
+	if err != nil {
+		if isAddrInUse(err) {
+			return fmt.Errorf("dns listen address %s is already in use (possible port conflict)", addr)
+		}
+		return fmt.Errorf("failed to check dns listen address %s: %w", addr, err)
+	}
+	_ = conn.Close()
+	return nil
+}
+
+func isAddrInUse(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EADDRINUSE) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && errors.Is(opErr.Err, syscall.EADDRINUSE) {
+		return true
+	}
+	return false
+}
+
 // Marmot インスタンスの終了
 func (m *Marmot) Close() error {
 	if m.Virt != nil {
@@ -69,9 +181,14 @@ func (m *Marmot) Close() error {
 // marmotd サーバーの生成、REST API サーバーを起動する
 // marmotdで定義された関数に対して、REST API 経由でアクセスできるようにする
 func NewServer(node string, etcdurl string) *Server {
+	if err := ValidateStartupPrerequisites(etcdurl, CurrentConfig().DNSListenAddr); err != nil {
+		slog.Error("Startup preflight check failed", "err", err)
+		os.Exit(1)
+	}
+
 	marmotInstance, err := NewMarmot(node, etcdurl)
 	if err != nil {
-		slog.Error("Storage free space check", "err", err)
+		slog.Error("Failed to initialize Marmot core", "err", err)
 		os.Exit(1)
 	}
 	return &Server{

--- a/pkg/marmotd/api-core.go
+++ b/pkg/marmotd/api-core.go
@@ -181,9 +181,17 @@ func (m *Marmot) Close() error {
 // marmotd サーバーの生成、REST API サーバーを起動する
 // marmotdで定義された関数に対して、REST API 経由でアクセスできるようにする
 func NewServer(node string, etcdurl string) *Server {
-	if err := ValidateStartupPrerequisites(etcdurl, CurrentConfig().DNSListenAddr); err != nil {
-		slog.Error("Startup preflight check failed", "err", err)
-		os.Exit(1)
+	return NewServerWithOptions(node, etcdurl, false)
+}
+
+func NewServerWithOptions(node string, etcdurl string, skipPreflight bool) *Server {
+	if !skipPreflight {
+		if err := ValidateStartupPrerequisites(etcdurl, CurrentConfig().DNSListenAddr); err != nil {
+			slog.Error("Startup preflight check failed", "err", err)
+			os.Exit(1)
+		}
+	} else {
+		slog.Debug("Startup preflight check is skipped", "node", node, "etcd", etcdurl)
 	}
 
 	marmotInstance, err := NewMarmot(node, etcdurl)

--- a/pkg/marmotd/test-helper.go
+++ b/pkg/marmotd/test-helper.go
@@ -22,7 +22,7 @@ func StartMockServer(ctx context.Context, marmotPort int, etcdPort int) (*Server
 		slog.SetDefault(logger)
 	*/
 	e := echo.New()
-	server := NewServer("hvc", "http://127.0.0.1:"+fmt.Sprintf("%d", etcdPort))
+	server := NewServerWithOptions("hvc", "http://127.0.0.1:"+fmt.Sprintf("%d", etcdPort), true)
 
 	done := make(chan struct{})
 


### PR DESCRIPTION
コメントに対応する形で、実装案をコードとして入れました。  
狙いは「初回起動で詰まりやすい要因を起動直後に明示して止める」です。

実装した内容
1. 起動前プリフライトを追加  
- api-core.go  
- ValidateStartupPrerequisites を追加し、以下をまとめて検査します。  
- etcd 到達性  
- OVS 実行可否/起動状態  
- DNS リッスンアドレス（53番含む）の競合

2. 必須サービス確認  
- etcd: api-core.go  
  - TCP 接続で到達確認し、不可なら etcd is not reachable... を返却  
- OVS: api-core.go  
  - ovs-vsctl の存在確認  
  - ovs-vsctl show 実行確認（timeout も識別）

3. 53番ポート競合確認  
- api-core.go  
  - DNSListenAddr に対して UDP bind を試行  
  - EADDRINUSE を検出したら possible port conflict と明示

4. 不足時の分かるエラー  
- api-core.go  
  - 複数失敗を ; 区切りで集約して返す  
- api-core.go  
  - NewServer の先頭でプリフライト実行  
  - 失敗時は Startup preflight check failed として終了

5. 既存の分かりづらいログ文言も改善  
- api-core.go

確認結果
- go test ./pkg/marmotd -run ^$ 成功
- go test ./... -run ^$ 成功

