### PR TITLE
Pr 476

### DIFF
--- a/pkg/util/resolver.go
+++ b/pkg/util/resolver.go
@@ -64,10 +64,16 @@ func backupResolvConfIfNeeded(sourcePath, backupPath string) error {
 		return fmt.Errorf("read %s for backup: %w", sourcePath, err)
 	}
 
-	if err := os.WriteFile(backupPath, content, 0644); err != nil {
+	f, err := os.OpenFile(backupPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
 		if os.IsExist(err) {
 			return nil
 		}
+		return fmt.Errorf("create backup %s: %w", backupPath, err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(content); err != nil {
 		return fmt.Errorf("write backup %s: %w", backupPath, err)
 	}
 

--- a/pkg/util/resolver.go
+++ b/pkg/util/resolver.go
@@ -6,10 +6,16 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
 const marmotResolvConfTemplate = "# generate by marmotd\nnameserver %s\noptions edns0 trust-ad\nsearch host-bridge\n"
+
+const (
+	resolvConfPath             = "/etc/resolv.conf"
+	marmotResolvConfBackupFile = "resolv.conf.marmot.bak"
+)
 
 // SetupLocalResolver disables systemd-resolved and rewrites /etc/resolv.conf for marmot internal DNS.
 // If /etc/resolv.conf already has a nameserver entry that matches the IP derived from dnsListenAddr,
@@ -23,6 +29,10 @@ func SetupLocalResolver(dnsListenAddr string) error {
 	}
 
 	resolvConfContent := fmt.Sprintf(marmotResolvConfTemplate, nameserver)
+	backupPath := filepath.Join(filepath.Dir(resolvConfPath), marmotResolvConfBackupFile)
+	if err := backupResolvConfIfNeeded(resolvConfPath, backupPath); err != nil {
+		return err
+	}
 
 	if err := runSystemctlResolved("stop"); err != nil {
 		return err
@@ -30,18 +40,44 @@ func SetupLocalResolver(dnsListenAddr string) error {
 	if err := runSystemctlResolved("disable"); err != nil {
 		return err
 	}
-	if err := os.Remove("/etc/resolv.conf"); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove /etc/resolv.conf: %w", err)
+	if err := os.Remove(resolvConfPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove %s: %w", resolvConfPath, err)
 	}
-	if err := os.WriteFile("/etc/resolv.conf", []byte(resolvConfContent), 0644); err != nil {
-		return fmt.Errorf("write /etc/resolv.conf: %w", err)
+	if err := os.WriteFile(resolvConfPath, []byte(resolvConfContent), 0644); err != nil {
+		return fmt.Errorf("write %s: %w", resolvConfPath, err)
 	}
+	return nil
+}
+
+func backupResolvConfIfNeeded(sourcePath, backupPath string) error {
+	if _, err := os.Stat(backupPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", backupPath, err)
+	}
+
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read %s for backup: %w", sourcePath, err)
+	}
+
+	if err := os.WriteFile(backupPath, content, 0644); err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+		return fmt.Errorf("write backup %s: %w", backupPath, err)
+	}
+
+	slog.Info("resolv.conf backup created", "path", backupPath)
 	return nil
 }
 
 // currentNameserverInResolvConf returns the first nameserver IP found in /etc/resolv.conf.
 func currentNameserverInResolvConf() (string, error) {
-	data, err := os.ReadFile("/etc/resolv.conf")
+	data, err := os.ReadFile(resolvConfPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/resolver_test.go
+++ b/pkg/util/resolver_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -87,4 +88,70 @@ func TestNameserverForDNSListenAddr(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBackupResolvConfIfNeeded(t *testing.T) {
+	t.Run("creates backup when missing", func(t *testing.T) {
+		dir := t.TempDir()
+		src := filepath.Join(dir, "resolv.conf")
+		bak := filepath.Join(dir, "resolv.conf.marmot.bak")
+		original := "nameserver 8.8.8.8\n"
+
+		if err := os.WriteFile(src, []byte(original), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := backupResolvConfIfNeeded(src, bak); err != nil {
+			t.Fatalf("backupResolvConfIfNeeded() error = %v", err)
+		}
+
+		got, err := os.ReadFile(bak)
+		if err != nil {
+			t.Fatalf("failed to read backup: %v", err)
+		}
+		if string(got) != original {
+			t.Fatalf("backup content = %q, want %q", string(got), original)
+		}
+	})
+
+	t.Run("does not overwrite existing backup", func(t *testing.T) {
+		dir := t.TempDir()
+		src := filepath.Join(dir, "resolv.conf")
+		bak := filepath.Join(dir, "resolv.conf.marmot.bak")
+		existing := "nameserver 1.1.1.1\n"
+		updatedSrc := "nameserver 9.9.9.9\n"
+
+		if err := os.WriteFile(src, []byte(updatedSrc), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(bak, []byte(existing), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := backupResolvConfIfNeeded(src, bak); err != nil {
+			t.Fatalf("backupResolvConfIfNeeded() error = %v", err)
+		}
+
+		got, err := os.ReadFile(bak)
+		if err != nil {
+			t.Fatalf("failed to read backup: %v", err)
+		}
+		if string(got) != existing {
+			t.Fatalf("backup was overwritten: got %q, want %q", string(got), existing)
+		}
+	})
+
+	t.Run("no source file still succeeds", func(t *testing.T) {
+		dir := t.TempDir()
+		src := filepath.Join(dir, "resolv.conf")
+		bak := filepath.Join(dir, "resolv.conf.marmot.bak")
+
+		if err := backupResolvConfIfNeeded(src, bak); err != nil {
+			t.Fatalf("backupResolvConfIfNeeded() error = %v", err)
+		}
+
+		if _, err := os.Stat(bak); !os.IsNotExist(err) {
+			t.Fatalf("backup should not be created when source is missing")
+		}
+	})
 }


### PR DESCRIPTION
ご指摘ありがとうございます。  
resolver.go のバックアップ作成処理を、`Stat -> WriteFile` から `os.OpenFile(..., O_CREATE|O_EXCL|O_WRONLY, ...)` を使う排他的作成に変更しました。  
これにより、レース時を含めて既存バックアップを上書きしない挙動になります。  
確認として、`go test ./... -run '^$'` と、resolver 関連の対象テストも通っています。
