### PR TITLE
netplan設定のバグ修正

### DIFF
--- a/pkg/util/hostbridge.go
+++ b/pkg/util/hostbridge.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // SetupHostBridge checks and configures host bridge for marmot
@@ -44,6 +46,12 @@ func SetupHostBridge() bool {
 		return false
 	}
 
+	preservedEthernets, err := loadPreservedNetplanEthernets("/etc/netplan", primaryNIC)
+	if err != nil {
+		slog.Warn("Failed to load existing netplan ethernet configs", "err", err)
+		preservedEthernets = map[string]Ethernet{}
+	}
+
 	// Backup existing netplan files
 	if err := backupNetplanFiles(); err != nil {
 		slog.Warn("Failed to backup netplan files", "err", err)
@@ -52,7 +60,7 @@ func SetupHostBridge() bool {
 
 	// Create netplan configuration
 	netplanFile := "/etc/netplan/00-host-bridge.yaml"
-	if err := createNetplanConfig(netplanFile, primaryNIC, bridgeConfig); err != nil {
+	if err := createNetplanConfig(netplanFile, primaryNIC, bridgeConfig, preservedEthernets); err != nil {
 		slog.Error("Failed to create netplan config", "file", netplanFile, "err", err)
 		return false
 	}
@@ -199,6 +207,49 @@ func getBridgeConfig(nicName string) bridgeConfigInfo {
 	return config
 }
 
+func loadPreservedNetplanEthernets(netplanDir string, primaryNIC string) (map[string]Ethernet, error) {
+	files, err := ioutil.ReadDir(netplanDir)
+	if err != nil {
+		return nil, err
+	}
+
+	preserved := make(map[string]Ethernet)
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		name := file.Name()
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		if strings.HasSuffix(name, ".marmot.bak") || strings.HasSuffix(name, ".bak") {
+			continue
+		}
+
+		path := filepath.Join(netplanDir, name)
+		input, err := ioutil.ReadFile(path)
+		if err != nil {
+			slog.Warn("Failed to read netplan file for preserve", "file", path, "err", err)
+			continue
+		}
+
+		var config NetplanConfig
+		if err := yaml.Unmarshal(input, &config); err != nil {
+			slog.Warn("Failed to parse netplan file for preserve", "file", path, "err", err)
+			continue
+		}
+
+		for ifaceName, ethCfg := range config.Network.Ethernets {
+			if ifaceName == primaryNIC {
+				continue
+			}
+			preserved[ifaceName] = ethCfg
+		}
+	}
+
+	return preserved, nil
+}
+
 // backupNetplanFiles backs up existing netplan configuration files
 func backupNetplanFiles() error {
 	netplanDir := "/etc/netplan"
@@ -211,15 +262,12 @@ func backupNetplanFiles() error {
 		if file.IsDir() {
 			continue
 		}
-		if file.Name()[0] == '_' {
-			continue // Already backed up
-		}
 		if !strings.HasSuffix(file.Name(), ".yaml") && !strings.HasSuffix(file.Name(), ".yml") {
 			continue
 		}
 
 		originalPath := filepath.Join(netplanDir, file.Name())
-		backupPath := filepath.Join(netplanDir, "_"+file.Name())
+		backupPath := filepath.Join(netplanDir, file.Name()+".marmot.bak")
 
 		input, err := ioutil.ReadFile(originalPath)
 		if err != nil {
@@ -227,18 +275,30 @@ func backupNetplanFiles() error {
 			continue
 		}
 
-		if err := ioutil.WriteFile(backupPath, input, 0644); err != nil {
-			slog.Warn("Failed to backup netplan file", "file", originalPath, "backup", backupPath, "err", err)
+		backedUp := false
+		if _, err := os.Stat(backupPath); err == nil {
+			slog.Debug("Netplan backup already exists", "backup", backupPath)
+			backedUp = true
+		} else if os.IsNotExist(err) {
+			if err := ioutil.WriteFile(backupPath, input, 0644); err != nil {
+				slog.Warn("Failed to backup netplan file", "file", originalPath, "backup", backupPath, "err", err)
+				continue
+			}
+			backedUp = true
+		} else {
+			slog.Warn("Failed to stat netplan backup file", "backup", backupPath, "err", err)
 			continue
 		}
 
 		slog.Debug("Backed up netplan file", "original", originalPath, "backup", backupPath)
 
-		// Remove original file after successful backup
-		if err := os.Remove(originalPath); err != nil {
-			slog.Warn("Failed to remove original netplan file", "file", originalPath, "err", err)
-		} else {
-			slog.Debug("Removed original netplan file", "file", originalPath)
+		if backedUp {
+			// Remove original file after successful backup or when backup already exists
+			if err := os.Remove(originalPath); err != nil {
+				slog.Warn("Failed to remove original netplan file", "file", originalPath, "err", err)
+			} else {
+				slog.Debug("Removed original netplan file", "file", originalPath)
+			}
 		}
 	}
 
@@ -246,57 +306,54 @@ func backupNetplanFiles() error {
 }
 
 // createNetplanConfig creates netplan configuration for bridge
-func createNetplanConfig(filePath string, nicName string, config bridgeConfigInfo) error {
-	yaml := fmt.Sprintf(`network:
-  version: 2
-  renderer: networkd
-  ethernets:
-    %s:
-      dhcp4: false
-      dhcp6: false
-  bridges:
-    br0:
-      interfaces: [%s]
-`, nicName, nicName)
+func createNetplanConfig(filePath string, nicName string, config bridgeConfigInfo, preservedEthernets map[string]Ethernet) error {
+	netplan := NetplanConfig{
+		Network: Network{
+			Version:  2,
+			Renderer: "networkd",
+			Ethernets: map[string]Ethernet{
+				nicName: {
+					DHCP4: false,
+					DHCP6: false,
+				},
+			},
+			Bridges: map[string]Bridge{},
+		},
+	}
 
-	// Add IP address if available
+	for ifaceName, ethCfg := range preservedEthernets {
+		if ifaceName == nicName {
+			continue
+		}
+		netplan.Network.Ethernets[ifaceName] = ethCfg
+	}
+
+	bridge := Bridge{
+		Interfaces: []string{nicName},
+		DHCP4:      false,
+		DHCP6:      false,
+		Parameters: BridgeParameters{STP: false},
+		Nameservers: Nameserver{
+			Addresses: []string{"8.8.8.8"},
+		},
+	}
 	if config.IPAddress != "" {
-		yaml += fmt.Sprintf(`      addresses:
-        - %s
-`, config.IPAddress)
+		bridge.Addresses = []string{config.IPAddress}
 	}
-
-	// Add routes if gateway available
 	if config.Gateway != "" {
-		yaml += fmt.Sprintf(`      routes:
-        - to: default
-          via: %s
-`, config.Gateway)
+		bridge.Routes = []Route{{To: "default", Via: config.Gateway}}
 	}
-
-	// Add nameservers with default 8.8.8.8
-	yaml += `      nameservers:
-`
-	yaml += `        addresses:
-`
-	yaml += `          - 8.8.8.8
-`
-
 	if config.Domain != "" {
-		yaml += `        search:
-`
-		yaml += fmt.Sprintf(`          - %s
-`, config.Domain)
+		bridge.Nameservers.Search = []string{config.Domain}
+	}
+	netplan.Network.Bridges["br0"] = bridge
+
+	data, err := yaml.Marshal(&netplan)
+	if err != nil {
+		return err
 	}
 
-	// Add bridge parameters
-	yaml += `      parameters:
-        stp: false
-      dhcp4: no
-      dhcp6: no
-`
-
-	if err := ioutil.WriteFile(filePath, []byte(yaml), 0644); err != nil {
+	if err := ioutil.WriteFile(filePath, data, 0644); err != nil {
 		return err
 	}
 

--- a/pkg/util/hostbridge_netplan_test.go
+++ b/pkg/util/hostbridge_netplan_test.go
@@ -1,0 +1,107 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadPreservedNetplanEthernetsIgnoresBackupFiles(t *testing.T) {
+	root := t.TempDir()
+	netplanDir := filepath.Join(root, "etc", "netplan")
+	if err := os.MkdirAll(netplanDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(netplanDir, "00-nic.yaml"), []byte(`network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enp1s0:
+      dhcp4: false
+      dhcp6: false
+    enp2s0:
+      addresses:
+        - 172.16.0.204/16
+      dhcp4: false
+      dhcp6: false
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(netplanDir, "00-nic.yaml.marmot.bak"), []byte(`network:
+  version: 2
+  ethernets:
+    enp9s0:
+      dhcp4: false
+      dhcp6: false
+	`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	preserved, err := loadPreservedNetplanEthernets(netplanDir, "enp1s0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := preserved["enp2s0"]; !ok {
+		t.Fatalf("expected enp2s0 to be preserved, got %#v", preserved)
+	}
+	if _, ok := preserved["enp1s0"]; ok {
+		t.Fatalf("expected enp1s0 to be excluded, got %#v", preserved)
+	}
+	if _, ok := preserved["enp9s0"]; ok {
+		t.Fatalf("expected backup file to be ignored, got %#v", preserved)
+	}
+}
+
+func TestCreateNetplanConfigPreservesAdditionalEthernets(t *testing.T) {
+	root := t.TempDir()
+	netplanDir := filepath.Join(root, "etc", "netplan")
+	if err := os.MkdirAll(netplanDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := filepath.Join(netplanDir, "00-host-bridge.yaml")
+	preserved := map[string]Ethernet{
+		"enp2s0": {
+			Addresses: []string{"172.16.0.204/16"},
+			DHCP4:     false,
+			DHCP6:     false,
+			Routes: []Route{{
+				To:  "10.0.0.0/8",
+				Via: "172.16.0.1",
+			}},
+		},
+	}
+
+	if err := createNetplanConfig(filePath, "enp1s0", bridgeConfigInfo{
+		IPAddress: "192.168.1.204",
+		Gateway:   "192.168.1.1",
+		Domain:    "labo.local",
+	}, preserved); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "br0:") {
+		t.Fatalf("expected br0 in generated config: %s", content)
+	}
+	if !strings.Contains(content, "enp1s0:") {
+		t.Fatalf("expected enp1s0 in generated config: %s", content)
+	}
+	if !strings.Contains(content, "enp2s0:") {
+		t.Fatalf("expected enp2s0 in generated config: %s", content)
+	}
+	if !strings.Contains(content, "172.16.0.204/16") {
+		t.Fatalf("expected preserved address in generated config: %s", content)
+	}
+	if !strings.Contains(content, "192.168.1.204") {
+		t.Fatalf("expected bridge address in generated config: %s", content)
+	}
+	if strings.Contains(content, ".marmot.bak") {
+		t.Fatalf("backup suffix should not appear in active config: %s", content)
+	}
+}

--- a/pkg/util/setup-linux.go
+++ b/pkg/util/setup-linux.go
@@ -441,6 +441,7 @@ type Network struct {
 	Version   int                 `yaml:"version"`
 	Renderer  string              `yaml:"renderer,omitempty"`
 	Ethernets map[string]Ethernet `yaml:"ethernets,omitempty"`
+	Bridges   map[string]Bridge   `yaml:"bridges,omitempty"`
 }
 
 type Ethernet struct {
@@ -449,6 +450,20 @@ type Ethernet struct {
 	DHCP6       bool       `yaml:"dhcp6"`
 	Routes      []Route    `yaml:"routes,omitempty"`
 	Nameservers Nameserver `yaml:"nameservers,omitempty"`
+}
+
+type Bridge struct {
+	Interfaces  []string         `yaml:"interfaces,omitempty"`
+	Addresses   []string         `yaml:"addresses,omitempty"`
+	DHCP4       bool             `yaml:"dhcp4"`
+	DHCP6       bool             `yaml:"dhcp6"`
+	Routes      []Route          `yaml:"routes,omitempty"`
+	Nameservers Nameserver       `yaml:"nameservers,omitempty"`
+	Parameters  BridgeParameters `yaml:"parameters,omitempty"`
+}
+
+type BridgeParameters struct {
+	STP bool `yaml:"stp"`
 }
 
 type Route struct {
@@ -512,12 +527,15 @@ func CreateNetplanInterfaces(requestConfig []api.NetworkInterface, mountPoint st
 			// ルート設定 (IPv4/IPv6共通)
 			if nic.Routes != nil {
 				for _, r := range *nic.Routes {
-					var route Route
-					if r.To != nil || r.Via != nil {
-						route = Route{
-							To:  *r.To,
-							Via: *r.Via,
-						}
+					if r.To == nil || r.Via == nil {
+						return fmt.Errorf("route requires both to and via on interface %s", ifaceName)
+					}
+					route := Route{
+						To:  *r.To,
+						Via: *r.Via,
+					}
+					if err := validateNetplanRoute(nic, route, ifaceName); err != nil {
+						return err
 					}
 					ethCfg.Routes = append(ethCfg.Routes, route)
 				}
@@ -568,6 +586,35 @@ func CreateNetplanInterfaces(requestConfig []api.NetworkInterface, mountPoint st
 	}
 
 	fmt.Printf("Generated %s successfully:\n\n%s", filePath, string(data))
+
+	return nil
+}
+
+func validateNetplanRoute(nic api.NetworkInterface, route Route, ifaceName string) error {
+	to := strings.TrimSpace(route.To)
+	via := strings.TrimSpace(route.Via)
+	if to == "" || via == "" {
+		return fmt.Errorf("route requires non-empty to and via on interface %s", ifaceName)
+	}
+	if !strings.EqualFold(to, "default") {
+		return nil
+	}
+	if nic.Address == nil || nic.Netmasklen == nil {
+		return nil
+	}
+
+	addr, err := netip.ParseAddr(strings.TrimSpace(*nic.Address))
+	if err != nil {
+		return fmt.Errorf("invalid interface address %q on interface %s: %w", *nic.Address, ifaceName, err)
+	}
+	prefix := netip.PrefixFrom(addr, *nic.Netmasklen).Masked()
+	viaAddr, err := netip.ParseAddr(via)
+	if err != nil {
+		return fmt.Errorf("invalid route gateway %q on interface %s: %w", via, ifaceName, err)
+	}
+	if viaAddr == prefix.Addr() {
+		return fmt.Errorf("default route gateway %s on interface %s must not be the network address %s", via, ifaceName, prefix.Addr())
+	}
 
 	return nil
 }

--- a/pkg/util/setup-linux_netplan_unit_test.go
+++ b/pkg/util/setup-linux_netplan_unit_test.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+)
+
+func TestCreateNetplanInterfacesRejectsDefaultRouteViaNetworkAddress(t *testing.T) {
+	mountPoint := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(mountPoint, "etc", "netplan"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	requestConfig := []api.NetworkInterface{
+		{
+			Networkname: "host-bridge",
+			Address:     StringPtr("192.168.1.210"),
+			Netmasklen:  IntPtrInt(24),
+			Routes: &[]api.Route{
+				{
+					To:  StringPtr("default"),
+					Via: StringPtr("192.168.1.0"),
+				},
+			},
+		},
+	}
+
+	err := CreateNetplanInterfaces(requestConfig, mountPoint)
+	if err == nil {
+		t.Fatal("CreateNetplanInterfaces() error = nil, want network address gateway validation error")
+	}
+	if !strings.Contains(err.Error(), "must not be the network address") {
+		t.Fatalf("CreateNetplanInterfaces() error = %q, want network address validation", err)
+	}
+}
+
+func TestCreateNetplanInterfacesAcceptsValidDefaultRoute(t *testing.T) {
+	mountPoint := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(mountPoint, "etc", "netplan"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	requestConfig := []api.NetworkInterface{
+		{
+			Networkname: "host-bridge",
+			Address:     StringPtr("192.168.1.210"),
+			Netmasklen:  IntPtrInt(24),
+			Routes: &[]api.Route{
+				{
+					To:  StringPtr("default"),
+					Via: StringPtr("192.168.1.1"),
+				},
+			},
+		},
+	}
+
+	if err := CreateNetplanInterfaces(requestConfig, mountPoint); err != nil {
+		t.Fatalf("CreateNetplanInterfaces() unexpected error = %v", err)
+	}
+}


### PR DESCRIPTION
## 概要

インストーラー実行後の netplan に発生していた 2 つの問題を修正します。

1. **バックアップファイルが netplan に処理され続ける問題**  
   従来は `_00-nic.yaml` のように先頭に `_` を付けてバックアップを残していました。netplan はファイル名が `.yaml` / `.yml` で終わるものをすべて読み込むため、これはバックアップではなく有効な設定ファイルとして扱われていました。

2. **`enp2s0` などのセカンダリ NIC 設定が消える問題**  
   ホストブリッジ化のとき、既存の `00-nic.yaml` を退避・削除した後、新しい `00-host-bridge.yaml` に primary NIC のブリッジ設定しか書き出していませんでした。そのため `enp2s0` などの設定が失われていました。

---

## 変更内容

### hostbridge.go

| 変更点 | 内容 |
|---|---|
| バックアップ命名 | `_<name>.yaml` → `<name>.yaml.marmot.bak` に変更。`.bak` は netplan が無視するため、誰がバックアップしたかも名前から明確 |
| 冪等バックアップ | すでに `.marmot.bak` が存在する場合は上書きせずそのまま元ファイルを削除するよう変更 |
| セカンダリ NIC 保持 | `loadPreservedNetplanEthernets()` を新設。バックアップ前に既存 netplan を解析し、primary NIC 以外の ethernet エントリを収集 |
| 構造体ベース生成 | `createNetplanConfig()` を文字列テンプレート → `NetplanConfig` 構造体の `yaml.Marshal` に書き替え。収集したセカンダリ NIC もそのまま埋め込む |

生成後の `00-host-bridge.yaml` のイメージ：

```yaml
network:
  version: 2
  renderer: networkd
  ethernets:
    enp1s0:          # primary NIC → bridge に昇格
      dhcp4: false
      dhcp6: false
    enp2s0:          # ← 保持されるようになった
      addresses:
        - 172.16.0.204/16
      dhcp4: false
      dhcp6: false
      routes:
        - to: 10.0.0.0/8
          via: 172.16.0.1
  bridges:
    br0:
      interfaces: [enp1s0]
      addresses:
        - 192.168.1.204/24
      ...
```

### setup-linux.go

- `Network` 型に `Bridges` フィールドを追加（hostbridge.go の構造体ベース生成に必要）
- `Bridge` / `BridgeParameters` 型を新設

### テスト

- hostbridge_netplan_test.go（新規）  
  - `.marmot.bak` ファイルを primary NIC の収集対象から除外することを確認  
  - セカンダリ NIC が `00-host-bridge.yaml` に含まれることを確認  
- setup-linux_netplan_unit_test.go（新規）  
  - デフォルトルートの gateway にネットワークアドレスを指定するとエラーになることを確認（issue #466 の回帰防止）  

---

## 関連 Issue

- Fixes #466 — netplan の `via` にネットワークアドレスが入ってしまうバグ（ルート検証も同 PR に含む）