### PR TITLE
デバッグメッセージの抑止

### DIFF
--- a/cmd/marmotd/marmotd-main.go
+++ b/cmd/marmotd/marmotd-main.go
@@ -8,12 +8,17 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/takara9/marmot/pkg/controller"
+	"github.com/takara9/marmot/pkg/db"
 	internaldns "github.com/takara9/marmot/pkg/internal-dns"
 	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/networkfabric"
 	"github.com/takara9/marmot/pkg/util"
+	"github.com/takara9/marmot/pkg/virt"
 )
 
-var controllerCounter uint64 = 0
+var debugMode bool = false
+
+//var controllerCounter uint64 = 0
 
 // 定期的に実行したい関数
 //func dispatchJobTask() {
@@ -59,6 +64,14 @@ func main() {
 		cfg.NodeName = hostname
 	}
 	marmotd.SetRuntimeConfig(cfg)
+	db.SetDebugMode(debugMode)
+	controller.SetDebugMode(debugMode)
+	marmotd.SetDebugMode(debugMode)
+	networkfabric.SetOVNNBCTLDebugLogging(debugMode)
+	networkfabric.SetOVSVSCTLDebugLogging(debugMode)
+	marmotd.SetOVNBootstrapDebugLogging(debugMode)
+	util.SetDebugMode(debugMode)
+	virt.SetDebugMode(debugMode)
 	if err := marmotd.EnsureGatewayRuntimeAssets(); err != nil {
 		slog.Error("Failed to initialize gateway runtime assets", "err", err)
 		return

--- a/pkg/controller/debug.go
+++ b/pkg/controller/debug.go
@@ -1,0 +1,20 @@
+package controller
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+var debugModeEnabled atomic.Bool
+
+// SetDebugMode toggles debug-only prints in pkg/controller.
+func SetDebugMode(enabled bool) {
+	debugModeEnabled.Store(enabled)
+}
+
+func debugPrintln(a ...interface{}) {
+	if !debugModeEnabled.Load() {
+		return
+	}
+	fmt.Println(a...)
+}

--- a/pkg/controller/server-controller.go
+++ b/pkg/controller/server-controller.go
@@ -248,14 +248,14 @@ func (c *controller) serverControllerLoop() {
 			// IPアドレス開放処理の実行
 			if spec.Spec.NetworkInterface != nil {
 				for _, nic := range *spec.Spec.NetworkInterface {
-					fmt.Println("NIC=========================================")
+					debugPrintln("NIC=========================================")
 					jsonbyte, err := json.MarshalIndent(nic, "", "  ")
 					if err != nil {
 						slog.Error("json.MarshalIndent()", "err", err)
 						continue
 					}
-					fmt.Println(string(jsonbyte))
-					fmt.Println("=========================================")
+					debugPrintln(string(jsonbyte))
+					debugPrintln("=========================================")
 
 					if nic.IpNetworkId != nil && nic.Address != nil {
 						if err := c.marmot.Db.ReleaseIP(nic.Networkid, *nic.IpNetworkId, *nic.Address); err != nil {

--- a/pkg/db/db-image.go
+++ b/pkg/db/db-image.go
@@ -666,12 +666,12 @@ func (d *Database) UpdateImage(id string, spec api.Image) error {
 		break
 	}
 
-	fmt.Println("=== 書き込みデータの情報確認 ===", "image Id", id)
+	debugPrintln("=== 書き込みデータの情報確認 ===", "image Id", id)
 	data3, err := json.MarshalIndent(spec, "", "  ")
 	if err != nil {
 		slog.Error("json.MarshalIndent()", "err", err)
 	} else {
-		fmt.Println("イメージ情報(image): ", string(data3))
+		debugPrintln("イメージ情報(image): ", string(data3))
 	}
 
 	return nil

--- a/pkg/db/db-job.go
+++ b/pkg/db/db-job.go
@@ -254,7 +254,7 @@ func (d *Job) RunJob(job api.Job) error {
 	}
 
 	// ジョブの実行
-	fmt.Println("===", (*job.Spec.Command)[0], (*job.Spec.Command)[1:], "===")
+	debugPrintln("===", (*job.Spec.Command)[0], (*job.Spec.Command)[1:], "===")
 	cmd := exec.Command((*job.Spec.Command)[0], (*job.Spec.Command)[1:]...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/pkg/db/db-servers.go
+++ b/pkg/db/db-servers.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -151,12 +150,12 @@ func (d *Database) UpdateServer(id string, spec api.Server) error {
 		break
 	}
 
-	fmt.Println("=== 書き込みデータの情報確認 ===", "server Id", id)
+	debugPrintln("=== 書き込みデータの情報確認 ===", "server Id", id)
 	data, err := json.MarshalIndent(spec, "", "  ")
 	if err != nil {
 		slog.Error("json.MarshalIndent()", "err", err)
 	} else {
-		fmt.Println("サーバー情報(server): ", string(data))
+		debugPrintln("サーバー情報(server): ", string(data))
 	}
 
 	return nil

--- a/pkg/db/db-virtual_network.go
+++ b/pkg/db/db-virtual_network.go
@@ -313,12 +313,12 @@ func (d *Database) UpdateVirtualNetworkById(vnetId string, spec api.VirtualNetwo
 		break
 	}
 
-	fmt.Println("=== 書き込みデータの情報確認 ===", "network Id", vnetId)
+	debugPrintln("=== 書き込みデータの情報確認 ===", "network Id", vnetId)
 	data3, err := json.MarshalIndent(spec, "", "  ")
 	if err != nil {
 		slog.Error("json.MarshalIndent()", "err", err)
 	} else {
-		fmt.Println("仮想ネットワーク情報(network): ", string(data3))
+		debugPrintln("仮想ネットワーク情報(network): ", string(data3))
 	}
 
 	return nil

--- a/pkg/db/db-volumes.go
+++ b/pkg/db/db-volumes.go
@@ -133,7 +133,7 @@ func (d *Database) CreateVolumeOnDB2(inputVol api.Volume) (*api.Volume, error) {
 	}
 
 	byteData, _ := json.MarshalIndent(volume, "", "    ")
-	fmt.Println("Volume to be created:", string(byteData))
+	debugPrintln("Volume to be created:", string(byteData))
 
 	// データベースに登録
 	if err := d.PutJSON(key, volume); err != nil {

--- a/pkg/db/debug.go
+++ b/pkg/db/debug.go
@@ -1,0 +1,27 @@
+package db
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+var debugModeEnabled atomic.Bool
+
+// SetDebugMode toggles debug-only prints in pkg/db.
+func SetDebugMode(enabled bool) {
+	debugModeEnabled.Store(enabled)
+}
+
+func debugPrintln(a ...interface{}) {
+	if !debugModeEnabled.Load() {
+		return
+	}
+	fmt.Println(a...)
+}
+
+func debugPrintf(format string, a ...interface{}) {
+	if !debugModeEnabled.Load() {
+		return
+	}
+	fmt.Printf(format, a...)
+}

--- a/pkg/marmotd/api-network.go
+++ b/pkg/marmotd/api-network.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -42,7 +41,7 @@ func (s *Server) ApiCreateNetwork(ctx echo.Context) error {
 		slog.Error("failed to marshal request body", "err", err)
 		return echo.NewHTTPError(500, "failed to marshal request body")
 	}
-	fmt.Println("request body", "body", string(jsonbytes))
+	debugPrintln("request body", "body", string(jsonbytes))
 
 	// 仮想ネットワークを作成する
 	network, err := s.Ma.Db.CreateVirtualNetwork(spec)

--- a/pkg/marmotd/debug.go
+++ b/pkg/marmotd/debug.go
@@ -1,0 +1,27 @@
+package marmotd
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+var debugModeEnabled atomic.Bool
+
+// SetDebugMode toggles debug-only prints in pkg/marmotd.
+func SetDebugMode(enabled bool) {
+	debugModeEnabled.Store(enabled)
+}
+
+func debugPrintln(a ...interface{}) {
+	if !debugModeEnabled.Load() {
+		return
+	}
+	fmt.Println(a...)
+}
+
+func debugPrintf(format string, a ...interface{}) {
+	if !debugModeEnabled.Load() {
+		return
+	}
+	fmt.Printf(format, a...)
+}

--- a/pkg/marmotd/network.go
+++ b/pkg/marmotd/network.go
@@ -67,7 +67,7 @@ func (m *Marmot) GetVirtualNetworksAndPutDB() ([]api.VirtualNetwork, error) {
 			slog.Error("Failed to get virtual network XML", "err", err)
 			continue
 		}
-		fmt.Println(string(xml))
+		debugPrintln(string(xml))
 
 		// libvirt XMLをパースして、APIのVirtualNetworkに変換る
 		var libnet libvirtxml.Network
@@ -212,12 +212,12 @@ func (m *Marmot) DeleteVirtualNetwork(networkId string) error {
 		return err
 	}
 
-	fmt.Println("==== Deleting virtual network:", vnet.Metadata.Name, "====")
+	debugPrintln("==== Deleting virtual network:", vnet.Metadata.Name, "====")
 	jsonBytes, err := json.MarshalIndent(vnet, "", "  ")
 	if err != nil {
 		slog.Error("Failed to marshal virtual network for deletion", "err", err)
 	} else {
-		fmt.Println(string(jsonBytes))
+		debugPrintln(string(jsonBytes))
 	}
 
 	// 仮想ネットワークに関連付いているIPネットワークをチェックして、使用していれば消せないエラーを返す

--- a/pkg/marmotd/ovn_bootstrap.go
+++ b/pkg/marmotd/ovn_bootstrap.go
@@ -15,6 +15,12 @@ const ovnBootstrapCommandTimeout = 5 * time.Second
 
 var ovnNBCTLBootstrapLookPath = exec.LookPath
 var ovnSBCTLBootstrapLookPath = exec.LookPath
+var ovnNBCTLBootstrapDebugLogging = false
+
+// SetOVNBootstrapDebugLogging toggles ovn-nbctl verbosity in bootstrap path.
+func SetOVNBootstrapDebugLogging(enabled bool) {
+	ovnNBCTLBootstrapDebugLogging = enabled
+}
 
 // EnsureOVNRuntimeBootstrap は marmotd 起動時に OVS external_ids と OVN central listener を整合させる。
 func EnsureOVNRuntimeBootstrap(ma *Marmot, cfg *MarmotdConfig) error {
@@ -235,7 +241,12 @@ func runOVNDBControl(command string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), ovnBootstrapCommandTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, command, args...)
+	resolvedArgs := args
+	if strings.EqualFold(command, "ovn-nbctl") && !ovnNBCTLBootstrapDebugLogging {
+		resolvedArgs = append([]string{"--verbose=ovn_dbctl:syslog:off"}, resolvedArgs...)
+	}
+
+	cmd := exec.CommandContext(ctx, command, resolvedArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%s failed: %w (output=%s)", command, err, strings.TrimSpace(string(output)))

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -427,7 +427,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 			if err != nil {
 				slog.Error("failed to marshal network interface", "err", err)
 			} else {
-				fmt.Println("=== ネットワークインターフェースの情報 ===", "ni", string(jsonBytes0))
+				debugPrintln("=== ネットワークインターフェースの情報 ===", "ni", string(jsonBytes0))
 			}
 
 			reqNic.Networkid = api.VirtualNetworkID(vnet) // ネットワークIDをセット
@@ -566,14 +566,14 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 				ni.Nameservers = defaultNameserversFromConfig()
 			}
 
-			fmt.Println("=== ネットワークインターフェースの情報確認 ===", "network interface", "ipaddr", ipaddr, "bitmask", bitmask)
+			debugPrintln("=== ネットワークインターフェースの情報確認 ===", "network interface", "ipaddr", ipaddr, "bitmask", bitmask)
 
 			// DEBUG
 			jsonBytes, err := json.MarshalIndent(ni, "", "  ")
 			if err != nil {
 				slog.Error("failed to marshal network interface", "err", err)
 			} else {
-				fmt.Println("ネットワークインターフェースの情報", "ni", string(jsonBytes))
+				debugPrintln("ネットワークインターフェースの情報", "ni", string(jsonBytes))
 			}
 
 			// DEBUG
@@ -581,7 +581,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 			if err != nil {
 				slog.Error("failed to marshal requested network interface", "err", err)
 			} else {
-				fmt.Println("要求されたネットワークインターフェースの情報", "reqNic", string(jsonBytes2))
+				debugPrintln("要求されたネットワークインターフェースの情報", "reqNic", string(jsonBytes2))
 			}
 
 			// netplanで静的IPアドレスを設定する場合のために、IPアドレス情報もサーバーに保存しておく
@@ -591,7 +591,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 				if err != nil {
 					slog.Error("failed to marshal IP network", "err", err)
 				} else {
-					fmt.Println("IPネットワークの情報", "ipnet", string(jsonBytes3))
+					debugPrintln("IPネットワークの情報", "ipnet", string(jsonBytes3))
 				}
 
 				if ipnet.Netmasklen != nil {
@@ -701,12 +701,12 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 		}
 	}
 
-	fmt.Println("=== データボリュームの情報確認2 ===", "server Id", api.ServerID(serverConfig))
+	debugPrintln("=== データボリュームの情報確認2 ===", "server Id", api.ServerID(serverConfig))
 	data3, err := json.MarshalIndent(serverConfig, "", "  ")
 	if err != nil {
 		slog.Error("json.MarshalIndent()", "err", err)
 	} else {
-		fmt.Println("サーバー情報(serverConfig): ", string(data3))
+		debugPrintln("サーバー情報(serverConfig): ", string(data3))
 	}
 
 	// データボリュームのIDをサーバーに設定
@@ -892,7 +892,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 
 	dom := virt.CreateDomainXML(virtSpec)
 	xml, err := dom.Marshal()
-	fmt.Println("Generated", "libvirt XML:\n", string(xml))
+	debugPrintln("Generated", "libvirt XML:\n", string(xml))
 
 	l, err := virt.NewLibVirtEp("qemu:///system")
 	if err != nil {
@@ -930,7 +930,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 		if fallbackApplied {
 			dom = virt.CreateDomainXML(virtSpec)
 			if xml2, marshalErr := dom.Marshal(); marshalErr == nil {
-				fmt.Println("Generated", "libvirt XML (fallback):\n", string(xml2))
+				debugPrintln("Generated", "libvirt XML (fallback):\n", string(xml2))
 			}
 			consolePath, err = l.DefineAndStartVM(*dom)
 		}

--- a/pkg/marmotd/test-helper.go
+++ b/pkg/marmotd/test-helper.go
@@ -33,7 +33,7 @@ func StartMockServer(ctx context.Context, marmotPort int, etcdPort int) (*Server
 		// サーバー起動
 		go func() {
 			if err := e.Start("0.0.0.0:" + fmt.Sprintf("%d", marmotPort)); err != nil && err != http.ErrServerClosed {
-				fmt.Println("server error:", err)
+				debugPrintln("server error:", err)
 			}
 		}()
 
@@ -47,7 +47,7 @@ func StartMockServer(ctx context.Context, marmotPort int, etcdPort int) (*Server
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := e.Shutdown(shutdownCtx); err != nil {
-			fmt.Println("shutdown error:", err)
+			debugPrintln("shutdown error:", err)
 		}
 	}()
 

--- a/pkg/networkfabric/ovn.go
+++ b/pkg/networkfabric/ovn.go
@@ -28,10 +28,17 @@ var runOVSVSCTLCommand = runOVSVSCTL
 var ovnNBCTLLookPath = exec.LookPath
 var ovnSBCTLLookPath = exec.LookPath
 var enableGeneveOVSTunnelMesh = true
+var ovnNBCTLDebugLogging = false
 
 // NewOVNFabric は OVNFabric インスタンスを生成する。
 func NewOVNFabric() *OVNFabric {
 	return &OVNFabric{ovs: NewOVSFabric()}
+}
+
+// SetOVNNBCTLDebugLogging enables/disables ovn-nbctl syslog verbosity for this package.
+// When disabled, ovn-nbctl "Called as ..." INFO logs are suppressed.
+func SetOVNNBCTLDebugLogging(enabled bool) {
+	ovnNBCTLDebugLogging = enabled
 }
 
 func (o *OVNFabric) EnsureBridge(vnet *api.VirtualNetwork) error {
@@ -297,6 +304,9 @@ func runOVNNBCTL(args ...string) (string, error) {
 	defer cancel()
 
 	resolvedArgs := appendOVNDBTargetArgs(args, ovnNorthboundDBTarget())
+	if !ovnNBCTLDebugLogging {
+		resolvedArgs = append([]string{"--verbose=ovn_dbctl:syslog:off"}, resolvedArgs...)
+	}
 	cmd := exec.CommandContext(ctx, "ovn-nbctl", resolvedArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -386,7 +396,7 @@ func runOVSVSCTL(args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), ovnCommandTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "ovs-vsctl", args...)
+	cmd := ovsVSCTLCmdCtx(ctx, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {

--- a/pkg/networkfabric/ovs.go
+++ b/pkg/networkfabric/ovs.go
@@ -28,6 +28,29 @@ const (
 
 const bridgeDeviceWaitTimeout = 10 * time.Second
 
+var ovsVSCTLDebugLogging = false
+
+// SetOVSVSCTLDebugLogging enables/disables ovs-vsctl syslog verbosity.
+// When disabled, ovs-vsctl "Called as ..." INFO logs are suppressed.
+func SetOVSVSCTLDebugLogging(enabled bool) {
+	ovsVSCTLDebugLogging = enabled
+}
+
+func ovsVSCTLArgs(args ...string) []string {
+	if !ovsVSCTLDebugLogging {
+		return append([]string{"--verbose=vsctl:syslog:off"}, args...)
+	}
+	return args
+}
+
+func ovsVSCTLCmd(args ...string) *exec.Cmd {
+	return exec.Command("ovs-vsctl", ovsVSCTLArgs(args...)...)
+}
+
+func ovsVSCTLCmdCtx(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "ovs-vsctl", ovsVSCTLArgs(args...)...)
+}
+
 // NewOVSFabric は OVSFabric インスタンスを生成する。
 func NewOVSFabric() *OVSFabric {
 	return &OVSFabric{}
@@ -44,7 +67,7 @@ func (o *OVSFabric) EnsureBridge(vnet *api.VirtualNetwork) error {
 	// ブリッジ存在確認
 	checkCtx, checkCancel := context.WithTimeout(context.Background(), ovsCommandTimeout)
 	defer checkCancel()
-	cmd := exec.CommandContext(checkCtx, "ovs-vsctl", "br-exists", bridgeName)
+	cmd := ovsVSCTLCmdCtx(checkCtx, "br-exists", bridgeName)
 	if err := cmd.Run(); err == nil {
 		// OVS DB 上にあっても Linux 側デバイスが無いケースがあるため確認する。
 		if waitLinuxBridgeDeviceReady(bridgeName, bridgeDeviceWaitTimeout) {
@@ -68,13 +91,13 @@ func (o *OVSFabric) EnsureBridge(vnet *api.VirtualNetwork) error {
 	// ブリッジ作成
 	addCtx, addCancel := context.WithTimeout(context.Background(), ovsCommandTimeout)
 	defer addCancel()
-	cmd = exec.CommandContext(addCtx, "ovs-vsctl", "--may-exist", "add-br", bridgeName)
+	cmd = ovsVSCTLCmdCtx(addCtx, "--may-exist", "add-br", bridgeName)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		if addCtx.Err() == context.DeadlineExceeded {
 			// タイムアウトでも作成完了している場合があるため、再確認して存在すれば成功扱いにする。
 			recheckCtx, recheckCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer recheckCancel()
-			recheckCmd := exec.CommandContext(recheckCtx, "ovs-vsctl", "br-exists", bridgeName)
+			recheckCmd := ovsVSCTLCmdCtx(recheckCtx, "br-exists", bridgeName)
 			if recheckErr := recheckCmd.Run(); recheckErr == nil {
 				slog.Warn("OVS bridge create timed out but bridge exists", "bridge", bridgeName)
 				return nil
@@ -85,7 +108,7 @@ func (o *OVSFabric) EnsureBridge(vnet *api.VirtualNetwork) error {
 		// エラーでも競合で既存化している場合があるため再確認する。
 		recheckCtx, recheckCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer recheckCancel()
-		recheckCmd := exec.CommandContext(recheckCtx, "ovs-vsctl", "br-exists", bridgeName)
+		recheckCmd := ovsVSCTLCmdCtx(recheckCtx, "br-exists", bridgeName)
 		if recheckErr := recheckCmd.Run(); recheckErr == nil {
 			slog.Warn("OVS bridge create returned error but bridge exists", "bridge", bridgeName, "err", err, "output", string(output))
 			return nil
@@ -106,7 +129,7 @@ func (o *OVSFabric) EnsureBridge(vnet *api.VirtualNetwork) error {
 func recreateBridge(bridgeName string) error {
 	delCtx, delCancel := context.WithTimeout(context.Background(), ovsCommandTimeout)
 	defer delCancel()
-	delCmd := exec.CommandContext(delCtx, "ovs-vsctl", "--if-exists", "del-br", bridgeName)
+	delCmd := ovsVSCTLCmdCtx(delCtx, "--if-exists", "del-br", bridgeName)
 	if output, err := delCmd.CombinedOutput(); err != nil {
 		if delCtx.Err() == context.DeadlineExceeded {
 			return fmt.Errorf("timeout while deleting stale bridge %s", bridgeName)
@@ -116,7 +139,7 @@ func recreateBridge(bridgeName string) error {
 
 	addCtx, addCancel := context.WithTimeout(context.Background(), ovsCommandTimeout)
 	defer addCancel()
-	addCmd := exec.CommandContext(addCtx, "ovs-vsctl", "--may-exist", "add-br", bridgeName)
+	addCmd := ovsVSCTLCmdCtx(addCtx, "--may-exist", "add-br", bridgeName)
 	if output, err := addCmd.CombinedOutput(); err != nil {
 		if addCtx.Err() == context.DeadlineExceeded {
 			return fmt.Errorf("timeout while recreating bridge %s", bridgeName)
@@ -200,7 +223,7 @@ func (o *OVSFabric) EnsureOverlayMesh(vnet *api.VirtualNetwork, peers []string) 
 		}
 
 		if !exists {
-			createCmd := exec.Command("ovs-vsctl", "add-port", bridgeName, tunnelName)
+			createCmd := ovsVSCTLCmd("add-port", bridgeName, tunnelName)
 			if output, err := createCmd.CombinedOutput(); err != nil {
 				slog.Error("failed to add VXLAN port", "bridge", bridgeName, "tunnel", tunnelName, "peer", peerIP, "err", err, "output", string(output))
 				return fmt.Errorf("failed to add tunnel port %s to %s: %w (output=%s)", tunnelName, peerIP, err, strings.TrimSpace(string(output)))
@@ -218,7 +241,7 @@ func (o *OVSFabric) EnsureOverlayMesh(vnet *api.VirtualNetwork, peers []string) 
 			args = append(args, fmt.Sprintf("options:local_ip=%s", localIP))
 		}
 
-		setCmd := exec.Command("ovs-vsctl", args...)
+		setCmd := ovsVSCTLCmd(args...)
 		if output, err := setCmd.CombinedOutput(); err != nil {
 			slog.Error("failed to configure VXLAN tunnel", "bridge", bridgeName, "tunnel", tunnelName, "peer", peerIP, "err", err, "output", string(output))
 			return fmt.Errorf("failed to configure tunnel %s to %s: %w (output=%s)", tunnelName, peerIP, err, strings.TrimSpace(string(output)))
@@ -250,7 +273,7 @@ func tunnelNameForPeer(bridgeName, peerIP string) string {
 }
 
 func portExistsOnBridge(bridgeName, portName string) (bool, error) {
-	cmd := exec.Command("ovs-vsctl", "list-ports", bridgeName)
+	cmd := ovsVSCTLCmd("list-ports", bridgeName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, fmt.Errorf("ovs-vsctl list-ports %s failed: %w (output=%s)", bridgeName, err, strings.TrimSpace(string(output)))
@@ -310,7 +333,7 @@ func (o *OVSFabric) PruneOverlayMesh(vnet *api.VirtualNetwork, remainPeers []str
 	bridgeName := *vnet.Spec.BridgeName
 
 	// 現在のトンネル一覧を取得
-	cmd := exec.Command("ovs-vsctl", "list-ports", bridgeName)
+	cmd := ovsVSCTLCmd("list-ports", bridgeName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		slog.Error("failed to list ports", "bridge", bridgeName, "err", err)
@@ -334,7 +357,7 @@ func (o *OVSFabric) PruneOverlayMesh(vnet *api.VirtualNetwork, remainPeers []str
 		port = strings.TrimSpace(port)
 		isVxlanPort := strings.HasPrefix(port, "vxlan-") || strings.HasPrefix(port, "vx-")
 		if isVxlanPort && !keepTunnels[port] {
-			delCmd := exec.Command("ovs-vsctl", "del-port", bridgeName, port)
+			delCmd := ovsVSCTLCmd("del-port", bridgeName, port)
 			if output, err := delCmd.CombinedOutput(); err != nil {
 				slog.Warn("failed to delete VXLAN tunnel", "bridge", bridgeName, "tunnel", port, "err", err, "output", string(output))
 			} else {
@@ -505,7 +528,7 @@ func flowSetsEqual(a, b []string) bool {
 }
 
 func listAccessPortsOnBridge(bridgeName string) ([]string, error) {
-	cmd := exec.Command("ovs-vsctl", "list-ports", bridgeName)
+	cmd := ovsVSCTLCmd("list-ports", bridgeName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("ovs-vsctl list-ports %s failed: %w (output=%s)", bridgeName, err, strings.TrimSpace(string(output)))
@@ -518,7 +541,7 @@ func listAccessPortsOnBridge(bridgeName string) ([]string, error) {
 		if port == "" {
 			continue
 		}
-		typeCmd := exec.Command("ovs-vsctl", "get", "interface", port, "type")
+		typeCmd := ovsVSCTLCmd("get", "interface", port, "type")
 		typeOut, typeErr := typeCmd.CombinedOutput()
 		if typeErr != nil {
 			return nil, fmt.Errorf("ovs-vsctl get interface %s type failed: %w (output=%s)", port, typeErr, strings.TrimSpace(string(typeOut)))
@@ -533,7 +556,7 @@ func listAccessPortsOnBridge(bridgeName string) ([]string, error) {
 }
 
 func listVxlanPortsOnBridge(bridgeName string) ([]string, error) {
-	cmd := exec.Command("ovs-vsctl", "list-ports", bridgeName)
+	cmd := ovsVSCTLCmd("list-ports", bridgeName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("ovs-vsctl list-ports %s failed: %w (output=%s)", bridgeName, err, strings.TrimSpace(string(output)))
@@ -547,7 +570,7 @@ func listVxlanPortsOnBridge(bridgeName string) ([]string, error) {
 			continue
 		}
 
-		typeCmd := exec.Command("ovs-vsctl", "get", "interface", port, "type")
+		typeCmd := ovsVSCTLCmd("get", "interface", port, "type")
 		typeOut, typeErr := typeCmd.CombinedOutput()
 		if typeErr != nil {
 			return nil, fmt.Errorf("ovs-vsctl get interface %s type failed: %w (output=%s)", port, typeErr, strings.TrimSpace(string(typeOut)))
@@ -574,7 +597,7 @@ func getInterfaceOfport(portName string) (int, error) {
 }
 
 func getInterfaceOfportIfReady(portName string) (int, bool, error) {
-	cmd := exec.Command("ovs-vsctl", "get", "interface", portName, "ofport")
+	cmd := ovsVSCTLCmd("get", "interface", portName, "ofport")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return 0, false, fmt.Errorf("ovs-vsctl get interface %s ofport failed: %w (output=%s)", portName, err, strings.TrimSpace(string(output)))
@@ -628,7 +651,7 @@ func (o *OVSFabric) DeleteBridge(vnet *api.VirtualNetwork) error {
 	bridgeName := *vnet.Spec.BridgeName
 
 	// ブリッジ存在確認
-	checkCmd := exec.Command("ovs-vsctl", "br-exists", bridgeName)
+	checkCmd := ovsVSCTLCmd("br-exists", bridgeName)
 	if err := checkCmd.Run(); err != nil {
 		// 既に存在しない
 		slog.Debug("OVS bridge does not exist, skipping delete", "bridge", bridgeName)
@@ -636,7 +659,7 @@ func (o *OVSFabric) DeleteBridge(vnet *api.VirtualNetwork) error {
 	}
 
 	// ブリッジ削除
-	cmd := exec.Command("ovs-vsctl", "del-br", bridgeName)
+	cmd := ovsVSCTLCmd("del-br", bridgeName)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		slog.Error("failed to delete OVS bridge", "bridge", bridgeName, "err", err, "output", string(output))
 		return fmt.Errorf("failed to delete bridge %s: %w", bridgeName, err)
@@ -655,13 +678,13 @@ func (o *OVSFabric) GetBridgeStatus(vnet *api.VirtualNetwork) (bool, int, error)
 	bridgeName := *vnet.Spec.BridgeName
 
 	// ブリッジ存在確認
-	checkCmd := exec.Command("ovs-vsctl", "br-exists", bridgeName)
+	checkCmd := ovsVSCTLCmd("br-exists", bridgeName)
 	if err := checkCmd.Run(); err != nil {
 		return false, 0, nil
 	}
 
 	// ポート数を取得
-	listCmd := exec.Command("ovs-vsctl", "list-ports", bridgeName)
+	listCmd := ovsVSCTLCmd("list-ports", bridgeName)
 	output, err := listCmd.CombinedOutput()
 	if err != nil {
 		return true, 0, err

--- a/pkg/util/debug.go
+++ b/pkg/util/debug.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+var debugModeEnabled atomic.Bool
+
+// SetDebugMode toggles debug-only prints in pkg/util.
+func SetDebugMode(enabled bool) {
+	debugModeEnabled.Store(enabled)
+}
+
+func debugPrintln(a ...interface{}) {
+	if !debugModeEnabled.Load() {
+		return
+	}
+	fmt.Println(a...)
+}

--- a/pkg/util/setup-linux.go
+++ b/pkg/util/setup-linux.go
@@ -322,7 +322,7 @@ func MountVolume(v api.Volume) (string, string, error) {
 		mountCandidates := []string{fmt.Sprintf("%sp1", nbdDevice), nbdDevice}
 		mounted := false
 		for _, dev := range mountCandidates {
-			fmt.Println("Mounting", "mount", "-t", "ext4", dev, mountPoint)
+			debugPrintln("Mounting", "mount", "-t", "ext4", dev, mountPoint)
 			cmd = exec.Command("mount", "-t", "ext4", dev, mountPoint)
 			err = cmd.Run()
 			if err == nil {
@@ -502,14 +502,14 @@ func CreateNetplanInterfaces(requestConfig []api.NetworkInterface, mountPoint st
 			slog.Debug("Configuring interface", "index", idx, "ifaceName", ifaceName, "nic", nic)
 
 			// IPアドレスの設定が無ければ、DHCPでIPアドレスを取得する設定にする
-			fmt.Println("DEBUG ===============================================================")
+			debugPrintln("DEBUG ===============================================================")
 			json, err := json.MarshalIndent(nic, "", "  ")
 			if err != nil {
 				slog.Error("json.MarshalIndent()", "err", err)
 			} else {
-				fmt.Println("NIC情報(nic): ", string(json))
+				debugPrintln("NIC情報(nic): ", string(json))
 			}
-			fmt.Println("=====================================================================")
+			debugPrintln("=====================================================================")
 
 			// IPアドレスとネットマスク長があれば、DHCPは無効にする
 			if nic.Address != nil && nic.Netmasklen != nil {
@@ -585,7 +585,7 @@ func CreateNetplanInterfaces(requestConfig []api.NetworkInterface, mountPoint st
 		return fmt.Errorf("write netplan config failed: %w", err)
 	}
 
-	fmt.Printf("Generated %s successfully:\n\n%s", filePath, string(data))
+	debugPrintln(fmt.Sprintf("Generated %s successfully:\n\n%s", filePath, string(data)))
 
 	return nil
 }

--- a/pkg/virt/debug.go
+++ b/pkg/virt/debug.go
@@ -1,0 +1,20 @@
+package virt
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+var debugModeEnabled atomic.Bool
+
+// SetDebugMode toggles debug-only prints in pkg/virt.
+func SetDebugMode(enabled bool) {
+	debugModeEnabled.Store(enabled)
+}
+
+func debugPrintln(a ...interface{}) {
+	if !debugModeEnabled.Load() {
+		return
+	}
+	fmt.Println(a...)
+}

--- a/pkg/virt/virt_net.go
+++ b/pkg/virt/virt_net.go
@@ -219,7 +219,7 @@ func (l *LibVirtEp) DefineAndStartVirtualNetwork(network libvirtxml.Network) err
 		return err
 	}
 
-	fmt.Println("Generated Network XML:", string(xmlString))
+	debugPrintln("Generated Network XML:", string(xmlString))
 
 	// Create Network
 	net, err := l.Com.NetworkDefineXML(xmlString)


### PR DESCRIPTION
## 概要
debugMode=false の通常運用時に、デバッグ目的の標準出力や OVS/OVN の冗長ログが syslog に大量出力される問題を解消しました。  
debugMode=true のときのみ詳細ログを出し、通常時は必要な運用ログを中心に保つようにしました。

## 背景
- サーバー作成やネットワーク設定時に、NIC ダンプや netplan 生成内容などのデバッグ出力が常時表示されていた
- ovs-vsctl / ovn-nbctl の Called as ... 系 INFO ログが通常モードでも出力され、運用ログの可読性を下げていた

## 変更内容
- 各パッケージに debug 出力ゲートを導入し、println/printf 系のデバッグ出力を debugMode=true の時のみ有効化
- marmotd 起動時に debugMode を各パッケージへ注入するよう統一
- ovs-vsctl 実行時に、debugMode=false では syslog verbosity を抑制
- 既存の ovn-nbctl 側抑制方針と同様の挙動に揃えて一貫化
- NIC 情報ダンプ、Generated Network XML、Mounting ...、Generated netplan ... などの出力を debug 制御下へ移動

## 期待される効果
- 通常運用時の syslog ノイズを大幅削減
- 障害解析時は debugMode=true にすることで従来どおり詳細情報を取得可能
- ログ出力ポリシーを package 横断で統一し、今後の保守性を向上

## 動作確認
- コンパイル確認: go test ./... -run '^$' が成功
- debugMode=false:
  - デバッグ向け標準出力が出ないこと
  - ovs-vsctl / ovn-nbctl の冗長 INFO が抑制されること
- debugMode=true:
  - デバッグ向け出力が有効になること

## 影響範囲
- 変更は主にログ出力制御
- API 仕様やデータモデルには変更なし
- 機能挙動は非変更（ログ出力条件のみ変更）