### PR TITLE
サーバー変更の実装

### DIFF
--- a/api/marmot-api-v1.yaml
+++ b/api/marmot-api-v1.yaml
@@ -1510,8 +1510,8 @@ components:
     ServerSpec:
       type: object
       properties:
-        ansible:
-          $ref: "#/components/schemas/ServerAnsible"
+        ansible-playbook:
+          type: string
         cpu:
           type: integer
           format: int
@@ -1538,20 +1538,6 @@ components:
           $ref: "#/components/schemas/Volume"
         auth:
           $ref: "#/components/schemas/Auth"
-    ServerAnsible:
-      type: object
-      required:
-        - playbook
-        - inventory
-      properties:
-        playbook:
-          type: string
-        inventory:
-          type: string
-        extra-args:
-          type: array
-          items:
-            type: string
     VirtualNetwork:
       type: object
       required:

--- a/cmd/mactl/cmd/apply.go
+++ b/cmd/mactl/cmd/apply.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"os"
+	"reflect"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -119,6 +122,18 @@ func applyServer(manifest map[string]interface{}) error {
 
 	var byteBody []byte
 	if exists {
+		existingBody, _, getErr := m.GetServerById(existingId)
+		if getErr != nil {
+			return fmt.Errorf("failed to get existing server: %w", getErr)
+		}
+		var existingServer api.Server
+		if unmarshalErr := json.Unmarshal(existingBody, &existingServer); unmarshalErr != nil {
+			return fmt.Errorf("failed to parse existing server: %w", unmarshalErr)
+		}
+		if err := validateServerApplyForbiddenChanges(existingServer, *server); err != nil {
+			return err
+		}
+
 		// 更新
 		api.SetServerID(server, existingId)
 		byteBody, _, err = m.UpdateServerById(existingId, *server)
@@ -143,6 +158,23 @@ func applyServer(manifest map[string]interface{}) error {
 		}
 	}
 	return nil
+}
+
+func confirmDowntimeForServerApply(serverName string) (bool, error) {
+	displayName := strings.TrimSpace(serverName)
+	if displayName == "" {
+		displayName = "(unknown)"
+	}
+
+	fmt.Printf("Warning: server %s will be stopped and restarted to apply changes. Continue? [y/N]: ", displayName)
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	answer := strings.ToLower(strings.TrimSpace(input))
+	return answer == "y" || answer == "yes", nil
 }
 
 func applyImage(manifest map[string]interface{}) error {
@@ -323,6 +355,188 @@ func applyNetwork(manifest map[string]interface{}) error {
 	}
 
 	return processApplyResponse(byteBody, exists)
+}
+
+func validateServerApplyForbiddenChanges(existing api.Server, desired api.Server) error {
+	forbidden := make([]string, 0, 16)
+
+	if desired.ApiVersion != "" && desired.ApiVersion != existing.ApiVersion {
+		forbidden = append(forbidden, "apiVersion")
+	}
+	if desired.Kind != "" && desired.Kind != existing.Kind {
+		forbidden = append(forbidden, "kind")
+	}
+
+	if desired.Metadata.Id != "" && desired.Metadata.Id != existing.Metadata.Id {
+		forbidden = append(forbidden, "metadata.id")
+	}
+	if desired.Metadata.Name != "" && desired.Metadata.Name != existing.Metadata.Name {
+		forbidden = append(forbidden, "metadata.name")
+	}
+	if desired.Metadata.InstanceName != nil && !reflect.DeepEqual(desired.Metadata.InstanceName, existing.Metadata.InstanceName) {
+		forbidden = append(forbidden, "metadata.instanceName")
+	}
+	if desired.Metadata.Key != nil && !reflect.DeepEqual(desired.Metadata.Key, existing.Metadata.Key) {
+		forbidden = append(forbidden, "metadata.key")
+	}
+	if desired.Metadata.NodeName != nil && !reflect.DeepEqual(desired.Metadata.NodeName, existing.Metadata.NodeName) {
+		forbidden = append(forbidden, "metadata.nodeName")
+	}
+	if desired.Metadata.Uuid != nil && !reflect.DeepEqual(desired.Metadata.Uuid, existing.Metadata.Uuid) {
+		forbidden = append(forbidden, "metadata.uuid")
+	}
+
+	if desired.Spec.Ansible != nil && !reflect.DeepEqual(desired.Spec.Ansible, existing.Spec.Ansible) {
+		forbidden = append(forbidden, "spec.ansible")
+	}
+	if desired.Spec.Auth != nil && !reflect.DeepEqual(desired.Spec.Auth, existing.Spec.Auth) {
+		forbidden = append(forbidden, "spec.auth")
+	}
+	if desired.Spec.BootVolume != nil && !reflect.DeepEqual(desired.Spec.BootVolume, existing.Spec.BootVolume) {
+		forbidden = append(forbidden, "spec.bootVolume")
+	}
+	if desired.Spec.NetworkInterface != nil && !reflect.DeepEqual(desired.Spec.NetworkInterface, existing.Spec.NetworkInterface) {
+		if !networkInterfacesMatchRequested(existing.Spec.NetworkInterface, desired.Spec.NetworkInterface) {
+			forbidden = append(forbidden, "spec.networkInterface")
+		}
+	}
+	if desired.Spec.OsLv != nil && !reflect.DeepEqual(desired.Spec.OsLv, existing.Spec.OsLv) {
+		forbidden = append(forbidden, "spec.osLv")
+	}
+	if desired.Spec.OsVariant != nil && !reflect.DeepEqual(desired.Spec.OsVariant, existing.Spec.OsVariant) {
+		forbidden = append(forbidden, "spec.osVariant")
+	}
+	if desired.Spec.OsVg != nil && !reflect.DeepEqual(desired.Spec.OsVg, existing.Spec.OsVg) {
+		forbidden = append(forbidden, "spec.osVg")
+	}
+	if desired.Spec.Storage != nil && !reflect.DeepEqual(desired.Spec.Storage, existing.Spec.Storage) {
+		forbidden = append(forbidden, "spec.storage")
+	}
+
+	if desired.Status != nil && !reflect.DeepEqual(desired.Status, existing.Status) {
+		forbidden = append(forbidden, "status")
+	}
+
+	if len(forbidden) > 0 {
+		return fmt.Errorf("%s の変更は許可されていません", strings.Join(forbidden, ", "))
+	}
+
+	return nil
+}
+
+func networkInterfacesMatchRequested(existingPtr, desiredPtr *[]api.NetworkInterface) bool {
+	if desiredPtr == nil {
+		return true
+	}
+	if existingPtr == nil {
+		return false
+	}
+
+	existing := *existingPtr
+	desired := *desiredPtr
+	if len(existing) != len(desired) {
+		return false
+	}
+
+	for i := range desired {
+		if !networkInterfaceMatchesRequested(existing[i], desired[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func networkInterfaceMatchesRequested(existing, desired api.NetworkInterface) bool {
+	if strings.TrimSpace(desired.Networkname) != "" && desired.Networkname != existing.Networkname {
+		return false
+	}
+	if strings.TrimSpace(desired.Networkid) != "" && desired.Networkid != existing.Networkid {
+		return false
+	}
+
+	if !stringPtrFieldMatchesRequested(existing.Address, desired.Address) {
+		return false
+	}
+	if !stringPtrFieldMatchesRequested(existing.Ethernet, desired.Ethernet) {
+		return false
+	}
+	if !stringPtrFieldMatchesRequested(existing.IpGateway, desired.IpGateway) {
+		return false
+	}
+	if !stringPtrFieldMatchesRequested(existing.IpNetworkId, desired.IpNetworkId) {
+		return false
+	}
+	if !stringPtrFieldMatchesRequested(existing.Mac, desired.Mac) {
+		return false
+	}
+	if !stringPtrFieldMatchesRequested(existing.Netmask, desired.Netmask) {
+		return false
+	}
+	if !stringPtrFieldMatchesRequested(existing.Portgroup, desired.Portgroup) {
+		return false
+	}
+	if !stringPtrFieldMatchesRequested(existing.Uuid, desired.Uuid) {
+		return false
+	}
+
+	if !boolPtrFieldMatchesRequested(existing.Dhcp4, desired.Dhcp4) {
+		return false
+	}
+	if !boolPtrFieldMatchesRequested(existing.Dhcp6, desired.Dhcp6) {
+		return false
+	}
+	if !intPtrFieldMatchesRequested(existing.Netmasklen, desired.Netmasklen) {
+		return false
+	}
+
+	if desired.Nameservers != nil {
+		if existing.Nameservers == nil || !reflect.DeepEqual(existing.Nameservers, desired.Nameservers) {
+			return false
+		}
+	}
+	if desired.Routes != nil {
+		if existing.Routes == nil || !reflect.DeepEqual(existing.Routes, desired.Routes) {
+			return false
+		}
+	}
+	if desired.Vlans != nil {
+		if existing.Vlans == nil || !reflect.DeepEqual(existing.Vlans, desired.Vlans) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func stringPtrFieldMatchesRequested(existing, desired *string) bool {
+	if desired == nil {
+		return true
+	}
+	if existing == nil {
+		return false
+	}
+	return *existing == *desired
+}
+
+func boolPtrFieldMatchesRequested(existing, desired *bool) bool {
+	if desired == nil {
+		return true
+	}
+	if existing == nil {
+		return false
+	}
+	return *existing == *desired
+}
+
+func intPtrFieldMatchesRequested(existing, desired *int) bool {
+	if desired == nil {
+		return true
+	}
+	if existing == nil {
+		return false
+	}
+	return *existing == *desired
 }
 
 func applyGateway(manifest map[string]interface{}) error {

--- a/cmd/mactl/cmd/apply_confirm_test.go
+++ b/cmd/mactl/cmd/apply_confirm_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestConfirmDowntimeForServerApplyYes(t *testing.T) {
+	origStdin := os.Stdin
+	defer func() { os.Stdin = origStdin }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() failed: %v", err)
+	}
+	defer r.Close()
+
+	os.Stdin = r
+	if _, err := w.WriteString("Y\n"); err != nil {
+		t.Fatalf("WriteString() failed: %v", err)
+	}
+	_ = w.Close()
+
+	ok, err := confirmDowntimeForServerApply("server-1")
+	if err != nil {
+		t.Fatalf("confirmDowntimeForServerApply() unexpected err: %v", err)
+	}
+	if !ok {
+		t.Fatalf("confirmDowntimeForServerApply() = false, want true")
+	}
+}
+
+func TestConfirmDowntimeForServerApplyNo(t *testing.T) {
+	origStdin := os.Stdin
+	defer func() { os.Stdin = origStdin }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() failed: %v", err)
+	}
+	defer r.Close()
+
+	os.Stdin = r
+	if _, err := w.WriteString("n\n"); err != nil {
+		t.Fatalf("WriteString() failed: %v", err)
+	}
+	_ = w.Close()
+
+	ok, err := confirmDowntimeForServerApply("server-1")
+	if err != nil {
+		t.Fatalf("confirmDowntimeForServerApply() unexpected err: %v", err)
+	}
+	if ok {
+		t.Fatalf("confirmDowntimeForServerApply() = true, want false")
+	}
+}

--- a/cmd/mactl/cmd/apply_server_forbidden_changes_test.go
+++ b/cmd/mactl/cmd/apply_server_forbidden_changes_test.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestValidateServerApplyForbiddenChanges(t *testing.T) {
+	baseLabels := map[string]interface{}{"env": "dev"}
+	existing := api.Server{
+		ApiVersion: "v1",
+		Kind:       "Server",
+		Metadata: api.Metadata{
+			Id:      "srv01",
+			Name:    "server-1",
+			Comment: util.StringPtr("old-comment"),
+			Labels:  &baseLabels,
+		},
+		Spec: api.ServerSpec{
+			Cpu:    util.IntPtrInt(2),
+			Memory: util.IntPtrInt(2048),
+			OsVg:   util.StringPtr("vg1"),
+		},
+	}
+
+	t.Run("allow when non-controlled fields omitted", func(t *testing.T) {
+		desired := api.Server{}
+		if err := validateServerApplyForbiddenChanges(existing, desired); err != nil {
+			t.Fatalf("validateServerApplyForbiddenChanges() unexpected err: %v", err)
+		}
+	})
+
+	t.Run("allow metadata.labels change", func(t *testing.T) {
+		newLabels := map[string]interface{}{"env": "prod"}
+		desired := api.Server{Metadata: api.Metadata{Labels: &newLabels}}
+		if err := validateServerApplyForbiddenChanges(existing, desired); err != nil {
+			t.Fatalf("validateServerApplyForbiddenChanges() unexpected err: %v", err)
+		}
+	})
+
+	t.Run("allow metadata.comment change", func(t *testing.T) {
+		desired := api.Server{Metadata: api.Metadata{Comment: util.StringPtr("new-comment")}}
+		if err := validateServerApplyForbiddenChanges(existing, desired); err != nil {
+			t.Fatalf("validateServerApplyForbiddenChanges() unexpected err: %v", err)
+		}
+	})
+
+	t.Run("allow spec.memory change", func(t *testing.T) {
+		desired := api.Server{Spec: api.ServerSpec{Memory: util.IntPtrInt(4096)}}
+		if err := validateServerApplyForbiddenChanges(existing, desired); err != nil {
+			t.Fatalf("validateServerApplyForbiddenChanges() unexpected err: %v", err)
+		}
+	})
+
+	t.Run("allow spec.cpu change", func(t *testing.T) {
+		desired := api.Server{Spec: api.ServerSpec{Cpu: util.IntPtrInt(4)}}
+		if err := validateServerApplyForbiddenChanges(existing, desired); err != nil {
+			t.Fatalf("validateServerApplyForbiddenChanges() unexpected err: %v", err)
+		}
+	})
+
+	t.Run("allow cpu change with minimal networkInterface request", func(t *testing.T) {
+		existingWithNIC := existing
+		existingWithNIC.Spec.NetworkInterface = &[]api.NetworkInterface{
+			{
+				Networkname: "host-bridge",
+				Networkid:   "default",
+				Address:     util.StringPtr("192.168.1.20"),
+				IpNetworkId: util.StringPtr("ip-0001"),
+			},
+		}
+
+		desired := api.Server{
+			Spec: api.ServerSpec{
+				Cpu: util.IntPtrInt(2),
+				NetworkInterface: &[]api.NetworkInterface{
+					{
+						Networkname: "host-bridge",
+					},
+				},
+			},
+		}
+
+		if err := validateServerApplyForbiddenChanges(existingWithNIC, desired); err != nil {
+			t.Fatalf("validateServerApplyForbiddenChanges() unexpected err: %v", err)
+		}
+	})
+
+	t.Run("reject networkInterface networkname change", func(t *testing.T) {
+		existingWithNIC := existing
+		existingWithNIC.Spec.NetworkInterface = &[]api.NetworkInterface{
+			{
+				Networkname: "host-bridge",
+			},
+		}
+
+		desired := api.Server{
+			Spec: api.ServerSpec{
+				NetworkInterface: &[]api.NetworkInterface{
+					{
+						Networkname: "another-network",
+					},
+				},
+			},
+		}
+
+		err := validateServerApplyForbiddenChanges(existingWithNIC, desired)
+		if err == nil {
+			t.Fatalf("validateServerApplyForbiddenChanges() expected error")
+		}
+		if !strings.Contains(err.Error(), "spec.networkInterface") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("reject spec.osVg change", func(t *testing.T) {
+		desired := api.Server{Spec: api.ServerSpec{OsVg: util.StringPtr("vg2")}}
+		err := validateServerApplyForbiddenChanges(existing, desired)
+		if err == nil {
+			t.Fatalf("validateServerApplyForbiddenChanges() expected error")
+		}
+		if !strings.Contains(err.Error(), "spec.osVg") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("reject metadata.nodeName change", func(t *testing.T) {
+		desired := api.Server{Metadata: api.Metadata{NodeName: util.StringPtr("node-2")}}
+		err := validateServerApplyForbiddenChanges(existing, desired)
+		if err == nil {
+			t.Fatalf("validateServerApplyForbiddenChanges() expected error")
+		}
+		if !strings.Contains(err.Error(), "metadata.nodeName") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("reject multiple non-allowed changes", func(t *testing.T) {
+		desired := api.Server{
+			Metadata: api.Metadata{
+				NodeName: util.StringPtr("node-2"),
+			},
+			Spec: api.ServerSpec{
+				OsVg: util.StringPtr("vg2"),
+			},
+		}
+		err := validateServerApplyForbiddenChanges(existing, desired)
+		if err == nil {
+			t.Fatalf("validateServerApplyForbiddenChanges() expected error")
+		}
+		for _, field := range []string{"metadata.nodeName", "spec.osVg"} {
+			if !strings.Contains(err.Error(), field) {
+				t.Fatalf("error does not include %s: %v", field, err)
+			}
+		}
+	})
+}

--- a/cmd/mactl/mactl-vm-deploy-1_test.go
+++ b/cmd/mactl/mactl-vm-deploy-1_test.go
@@ -27,18 +27,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, opts))
 		slog.SetDefault(logger)
 		cleanupTestEnvironment()
+		if err := ensureMactlTestBinary(); err != nil {
+			Fail(fmt.Sprintf("Failed to build mactl test binary: %v", err))
+		}
 
 		By("モックサーバー用etcdの起動")
-		cmd := exec.Command("docker", "run", "-d", "--rm", "-p", "3379:2379", "ghcr.io/takara9/etcd:3.6.5")
-		output, err := cmd.CombinedOutput()
+		var etcdEp string
+		var err error
+		containerID, etcdEp, err = startEtcdContainer()
 		if err != nil {
-			Fail(fmt.Sprintf("Failed to start container: %s, %v", string(output), err))
+			Fail(fmt.Sprintf("Failed to start container: %v", err))
 		}
-		containerID = string(output[:12]) // 最初の12文字をIDとして取得
 		fmt.Printf("Container started with ID: %s\n", containerID)
 
 		By("モックサーバーの起動")
-		mockServer, err = startMockServer()
+		mockServer, err = startMockServer(etcdEp)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/cmd/mactl/mactl-vm-deploy-2_test.go
+++ b/cmd/mactl/mactl-vm-deploy-2_test.go
@@ -29,18 +29,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, opts))
 		slog.SetDefault(logger)
 		cleanupTestEnvironment()
+		if err := ensureMactlTestBinary(); err != nil {
+			Fail(fmt.Sprintf("Failed to build mactl test binary: %v", err))
+		}
 
 		By("モックサーバー用etcdの起動")
-		cmd := exec.Command("docker", "run", "-d", "--rm", "-p", "3379:2379", "ghcr.io/takara9/etcd:3.6.5")
-		output, err := cmd.CombinedOutput()
+		var etcdEp string
+		var err error
+		containerID, etcdEp, err = startEtcdContainer()
 		if err != nil {
-			Fail(fmt.Sprintf("Failed to start container: %s, %v", string(output), err))
+			Fail(fmt.Sprintf("Failed to start container: %v", err))
 		}
-		containerID = string(output[:12]) // 最初の12文字をIDとして取得
 		fmt.Printf("Container started with ID: %s\n", containerID)
 
 		By("モックサーバーの起動")
-		mockServer, err = startMockServer()
+		mockServer, err = startMockServer(etcdEp)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/cmd/mactl/mactl-vm-deploy-3_test.go
+++ b/cmd/mactl/mactl-vm-deploy-3_test.go
@@ -28,18 +28,21 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, opts))
 		slog.SetDefault(logger)
 		cleanupTestEnvironment()
+		if err := ensureMactlTestBinary(); err != nil {
+			Fail(fmt.Sprintf("Failed to build mactl test binary: %v", err))
+		}
 
 		By("モックサーバー用etcdの起動")
-		cmd := exec.Command("docker", "run", "-d", "--rm", "-p", "3379:2379", "ghcr.io/takara9/etcd:3.6.5")
-		output, err := cmd.CombinedOutput()
+		var etcdEp string
+		var err error
+		containerID, etcdEp, err = startEtcdContainer()
 		if err != nil {
-			Fail(fmt.Sprintf("Failed to start container: %s, %v", string(output), err))
+			Fail(fmt.Sprintf("Failed to start container: %v", err))
 		}
-		containerID = string(output[:12]) // 最初の12文字をIDとして取得
 		fmt.Printf("Container started with ID: %s\n", containerID)
 
 		By("モックサーバーの起動")
-		mockServer, err = startMockServer()
+		mockServer, err = startMockServer(etcdEp)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/cmd/mactl/mactl_suite_test.go
+++ b/cmd/mactl/mactl_suite_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestUtil(t *testing.T) {
+	if err := ensureMactlTestBinary(); err != nil {
+		t.Fatalf("failed to prepare mactl test binary: %v", err)
+	}
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Util Suite")
 }

--- a/cmd/mactl/mactl_test.go
+++ b/cmd/mactl/mactl_test.go
@@ -29,18 +29,21 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, opts))
 		slog.SetDefault(logger)
 		cleanupTestEnvironment()
+		if err := ensureMactlTestBinary(); err != nil {
+			Fail(fmt.Sprintf("Failed to build mactl test binary: %v", err))
+		}
 
 		By("モックサーバー用etcdの起動")
-		cmd := exec.Command("docker", "run", "-d", "--name", "etcd0", "-p", "3379:2379", "-p", "3380:2380", "ghcr.io/takara9/etcd:3.6.5")
-		output, err := cmd.CombinedOutput()
+		var etcdEp string
+		var err error
+		containerID, etcdEp, err = startEtcdContainer()
 		if err != nil {
-			Fail(fmt.Sprintf("Failed to start container: %s, %v", string(output), err))
+			Fail(fmt.Sprintf("Failed to start container: %v", err))
 		}
-		containerID = string(output[:12]) // 最初の12文字をIDとして取得
 		fmt.Printf("Container started with ID: %s\n", containerID)
 
 		By("モックサーバーの起動")
-		mockServer, err = startMockServer()
+		mockServer, err = startMockServer(etcdEp)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/cmd/mactl/test-helper.go
+++ b/cmd/mactl/test-helper.go
@@ -6,7 +6,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
+	"os"
+	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,7 +27,47 @@ type mockServerHandle struct {
 	once   sync.Once
 }
 
-func startMockServer() (*mockServerHandle, error) {
+func ensureMactlTestBinary() error {
+	if _, err := os.Stat("bin/mactl-test"); err == nil {
+		return nil
+	}
+
+	if err := os.MkdirAll("bin", 0755); err != nil {
+		return fmt.Errorf("failed to create bin directory: %w", err)
+	}
+
+	cmd := exec.Command("go", "build", "-o", "bin/mactl-test", ".")
+	cmd.Dir = "."
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to build bin/mactl-test: %w (output=%s)", err, string(output))
+	}
+
+	return nil
+}
+
+func startEtcdContainer() (string, string, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to allocate free port: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	_ = listener.Close()
+
+	cmd := exec.Command("docker", "run", "-d", "--rm", "-p", fmt.Sprintf("%d:2379", port), "ghcr.io/takara9/etcd:3.6.5")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to start etcd container: %s, %w", string(output), err)
+	}
+
+	containerID := strings.TrimSpace(string(output))
+	if len(containerID) > 12 {
+		containerID = containerID[:12]
+	}
+	return containerID, fmt.Sprintf("http://127.0.0.1:%d", port), nil
+}
+
+func startMockServer(etcdEp string) (*mockServerHandle, error) {
 	// 個別にログを確認したい場合はコメントアウトを外す
 	//opts := &slog.HandlerOptions{
 	//	AddSource: true,
@@ -39,10 +83,9 @@ func startMockServer() (*mockServerHandle, error) {
 	}
 
 	nodeName := "hvc"
-	etcdEp := "http://127.0.0.1:3379"
 
 	e := echo.New()
-	server := marmotd.NewServer(nodeName, etcdEp)
+	server := marmotd.NewServerWithOptions(nodeName, etcdEp, true)
 	h.server = server
 
 	readyCh := make(chan struct{})

--- a/cmd/mactl/test-helper.go
+++ b/cmd/mactl/test-helper.go
@@ -42,7 +42,7 @@ func startMockServer() (*mockServerHandle, error) {
 	etcdEp := "http://127.0.0.1:3379"
 
 	e := echo.New()
-	server := marmotd.NewServerWithOptions(nodeName, etcdEp, true)
+	server := marmotd.NewServer(nodeName, etcdEp)
 	h.server = server
 
 	readyCh := make(chan struct{})

--- a/cmd/marmotd/marmotd-main.go
+++ b/cmd/marmotd/marmotd-main.go
@@ -8,17 +8,12 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/takara9/marmot/pkg/controller"
-	"github.com/takara9/marmot/pkg/db"
 	internaldns "github.com/takara9/marmot/pkg/internal-dns"
 	"github.com/takara9/marmot/pkg/marmotd"
-	"github.com/takara9/marmot/pkg/networkfabric"
 	"github.com/takara9/marmot/pkg/util"
-	"github.com/takara9/marmot/pkg/virt"
 )
 
-var debugMode bool = false
-
-//var controllerCounter uint64 = 0
+var controllerCounter uint64 = 0
 
 // 定期的に実行したい関数
 //func dispatchJobTask() {
@@ -64,14 +59,6 @@ func main() {
 		cfg.NodeName = hostname
 	}
 	marmotd.SetRuntimeConfig(cfg)
-	db.SetDebugMode(debugMode)
-	controller.SetDebugMode(debugMode)
-	marmotd.SetDebugMode(debugMode)
-	networkfabric.SetOVNNBCTLDebugLogging(debugMode)
-	networkfabric.SetOVSVSCTLDebugLogging(debugMode)
-	marmotd.SetOVNBootstrapDebugLogging(debugMode)
-	util.SetDebugMode(debugMode)
-	virt.SetDebugMode(debugMode)
 	if err := marmotd.EnsureGatewayRuntimeAssets(); err != nil {
 		slog.Error("Failed to initialize gateway runtime assets", "err", err)
 		return

--- a/pkg/controller/server-controller.go
+++ b/pkg/controller/server-controller.go
@@ -193,6 +193,13 @@ func (c *controller) serverControllerLoop() {
 			}
 		case db.SERVER_RUNNING:
 			slog.Debug("稼働中のサーバー検出", "SERVER", api.ServerID(spec))
+			if err := c.marmot.SyncServerResourcesManage(api.ServerID(spec)); err != nil {
+				slog.Error("SyncServerResourcesManage()", "serverId", api.ServerID(spec), "err", err)
+				msg := fmt.Sprintf("サーバー設定(CPU/Memory)の反映に失敗: %v", err)
+				if dbErr := c.marmot.Db.UpdateServerStatus(api.ServerID(spec), db.SERVER_ERROR, msg); dbErr != nil {
+					slog.Error("UpdateServerStatus() failed", "serverId", api.ServerID(spec), "err", dbErr)
+				}
+			}
 		case db.SERVER_STOPPING:
 			slog.Debug("停止要求のサーバー検出", "SERVER", api.ServerID(spec))
 			if err := c.marmot.StopServerManage(api.ServerID(spec)); err != nil {

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -1471,6 +1471,64 @@ func (m *Marmot) UpdateServerById(id string, serverSpec api.Server) error {
 	return nil
 }
 
+// SyncServerResourcesManage reconciles CPU/Memory spec against libvirt domain settings.
+func (m *Marmot) SyncServerResourcesManage(id string) error {
+	sv, err := m.Db.GetServerById(id)
+	if err != nil {
+		slog.Error("GetServerById()", "err", err)
+		return err
+	}
+
+	if sv.Metadata.InstanceName == nil || strings.TrimSpace(*sv.Metadata.InstanceName) == "" {
+		return fmt.Errorf("server %s has no instance name", id)
+	}
+
+	if sv.Spec.Cpu == nil && sv.Spec.Memory == nil {
+		return nil
+	}
+
+	liveCheck, err := virt.NewLibVirtEp("qemu:///system")
+	if err != nil {
+		slog.Error("NewLibVirtEp()", "err", err)
+		return err
+	}
+	needsUpdate, err := liveCheck.HasDomainResourceDrift(*sv.Metadata.InstanceName, sv.Spec.Cpu, sv.Spec.Memory)
+	liveCheck.Close()
+	if err != nil {
+		return err
+	}
+	if !needsUpdate {
+		return nil
+	}
+
+	if err := m.StopServerManage(id); err != nil {
+		return fmt.Errorf("failed to stop server before applying resource changes: %w", err)
+	}
+
+	l, err := virt.NewLibVirtEp("qemu:///system")
+	if err != nil {
+		slog.Error("NewLibVirtEp()", "err", err)
+		return err
+	}
+	changed, syncErr := l.SyncDomainResources(*sv.Metadata.InstanceName, sv.Spec.Cpu, sv.Spec.Memory)
+	l.Close()
+	if syncErr != nil {
+		if startErr := m.StartServerManage(id); startErr != nil {
+			return fmt.Errorf("failed to apply persistent resource changes: %v; additionally failed to restart server: %w", syncErr, startErr)
+		}
+		return fmt.Errorf("failed to apply persistent resource changes: %w", syncErr)
+	}
+
+	if err := m.StartServerManage(id); err != nil {
+		return fmt.Errorf("resource changes applied but failed to restart server: %w", err)
+	}
+	if changed {
+		slog.Info("server resource settings reconciled with downtime workflow", "serverId", id, "instanceName", *sv.Metadata.InstanceName)
+	}
+
+	return nil
+}
+
 // ボリュームリクエストに基づいて、新しいボリュームを作成する
 func (m *Marmot) CreateNewVolumeWithWait(volReq api.Volume) (api.Volume, error) {
 	slog.Debug("===CreateNewVolume is called===", "volume request", volReq)

--- a/pkg/virt/libvirtXml2.go
+++ b/pkg/virt/libvirtXml2.go
@@ -611,3 +611,220 @@ func (l *LibVirtEp) StartDomain(vmname string) error {
 
 	return nil
 }
+
+func memoryToKiB(value uint, unit string) uint64 {
+	u := strings.ToLower(strings.TrimSpace(unit))
+	if u == "" || u == "kib" || u == "kb" || u == "k" {
+		return uint64(value)
+	}
+
+	mul := uint64(1)
+	switch u {
+	case "mib", "mb", "m":
+		mul = 1024
+	case "gib", "gb", "g":
+		mul = 1024 * 1024
+	case "tib", "tb", "t":
+		mul = 1024 * 1024 * 1024
+	case "b", "bytes":
+		mul = 1
+		value = value / 1024
+	default:
+		if strings.HasSuffix(u, "ib") {
+			prefix := strings.TrimSuffix(u, "ib")
+			pow := 0
+			switch prefix {
+			case "k":
+				pow = 1
+			case "m":
+				pow = 2
+			case "g":
+				pow = 3
+			case "t":
+				pow = 4
+			case "p":
+				pow = 5
+			case "e":
+				pow = 6
+			}
+			if pow > 0 {
+				mul = 1
+				for i := 1; i < pow; i++ {
+					mul *= 1024
+				}
+			}
+		}
+	}
+
+	return uint64(value) * mul
+}
+
+func memoryMBToKiB(memoryMB int) uint64 {
+	if memoryMB <= 0 {
+		return 0
+	}
+	return uint64(memoryMB) * 1024
+}
+
+func domainResourceDrift(cfg libvirtxml.Domain, cpu *int, memoryMB *int) bool {
+	if cpu != nil && *cpu > 0 {
+		currentVCPU := uint(0)
+		if cfg.VCPU != nil {
+			currentVCPU = cfg.VCPU.Value
+		}
+		if currentVCPU != uint(*cpu) {
+			return true
+		}
+	}
+
+	if memoryMB != nil && *memoryMB > 0 {
+		currentMemKiB := uint64(0)
+		if cfg.Memory != nil {
+			currentMemKiB = memoryToKiB(cfg.Memory.Value, cfg.Memory.Unit)
+		}
+		if currentMemKiB != memoryMBToKiB(*memoryMB) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isDomainLive(state libvirt.DomainState) bool {
+	switch state {
+	case libvirt.DOMAIN_RUNNING, libvirt.DOMAIN_BLOCKED, libvirt.DOMAIN_PAUSED, libvirt.DOMAIN_PMSUSPENDED:
+		return true
+	default:
+		return false
+	}
+}
+
+// HasDomainResourceDrift reports whether desired CPU/Memory differs from persistent domain XML.
+func (l *LibVirtEp) HasDomainResourceDrift(vmname string, cpu *int, memoryMB *int) (bool, error) {
+	if cpu == nil && memoryMB == nil {
+		return false, nil
+	}
+
+	domain, err := l.Com.LookupDomainByName(vmname)
+	if err != nil {
+		return false, err
+	}
+	defer domain.Free()
+
+	xml, err := domain.GetXMLDesc(0)
+	if err != nil {
+		return false, err
+	}
+
+	var cfg libvirtxml.Domain
+	if err := cfg.Unmarshal(xml); err != nil {
+		return false, err
+	}
+
+	return domainResourceDrift(cfg, cpu, memoryMB), nil
+}
+
+func (l *LibVirtEp) syncDomainVCPU(domain *libvirt.Domain, current uint, desired uint, live bool) (bool, error) {
+	if desired == 0 || current == desired {
+		return false, nil
+	}
+
+	if err := domain.SetVcpusFlags(desired, libvirt.DOMAIN_VCPU_CONFIG); err != nil {
+		// libvirt のエラーメッセージ文言に依存せず、max vcpu 更新後に再試行する。
+		if maxErr := domain.SetVcpusFlags(desired, libvirt.DOMAIN_VCPU_CONFIG|libvirt.DOMAIN_VCPU_MAXIMUM); maxErr != nil {
+			return false, err
+		}
+		if retryErr := domain.SetVcpusFlags(desired, libvirt.DOMAIN_VCPU_CONFIG); retryErr != nil {
+			return false, retryErr
+		}
+	}
+
+	if live {
+		if err := domain.SetVcpusFlags(desired, libvirt.DOMAIN_VCPU_LIVE); err != nil {
+			slog.Warn("failed to apply live vcpu change; config is updated and will apply on reboot", "desired", desired, "err", err)
+		}
+	}
+
+	return true, nil
+}
+
+func (l *LibVirtEp) syncDomainMemory(domain *libvirt.Domain, currentKiB uint64, desiredKiB uint64, live bool) (bool, error) {
+	if desiredKiB == 0 || currentKiB == desiredKiB {
+		return false, nil
+	}
+
+	desired := desiredKiB
+
+	if err := domain.SetMemoryFlags(desired, libvirt.DOMAIN_MEM_CONFIG|libvirt.DOMAIN_MEM_MAXIMUM); err != nil {
+		slog.Warn("failed to set persistent max memory; trying current memory only", "desiredKiB", desiredKiB, "err", err)
+	}
+	if err := domain.SetMemoryFlags(desired, libvirt.DOMAIN_MEM_CONFIG); err != nil {
+		return false, err
+	}
+
+	if live {
+		if err := domain.SetMemoryFlags(desired, libvirt.DOMAIN_MEM_LIVE); err != nil {
+			slog.Warn("failed to apply live memory change; config is updated and will apply on reboot", "desiredKiB", desiredKiB, "err", err)
+		}
+	}
+
+	return true, nil
+}
+
+// SyncDomainResources compares desired CPU/Memory with current libvirt domain config and applies drift.
+func (l *LibVirtEp) SyncDomainResources(vmname string, cpu *int, memoryMB *int) (bool, error) {
+	if cpu == nil && memoryMB == nil {
+		return false, nil
+	}
+
+	domain, err := l.Com.LookupDomainByName(vmname)
+	if err != nil {
+		return false, err
+	}
+	defer domain.Free()
+
+	xml, err := domain.GetXMLDesc(0)
+	if err != nil {
+		return false, err
+	}
+
+	var cfg libvirtxml.Domain
+	if err := cfg.Unmarshal(xml); err != nil {
+		return false, err
+	}
+
+	state, _, err := domain.GetState()
+	if err != nil {
+		return false, err
+	}
+	live := isDomainLive(state)
+
+	changed := false
+
+	if cpu != nil && *cpu > 0 {
+		currentVCPU := uint(0)
+		if cfg.VCPU != nil {
+			currentVCPU = cfg.VCPU.Value
+		}
+		vcpuChanged, err := l.syncDomainVCPU(domain, currentVCPU, uint(*cpu), live)
+		if err != nil {
+			return changed, err
+		}
+		changed = changed || vcpuChanged
+	}
+
+	if memoryMB != nil && *memoryMB > 0 {
+		currentMemKiB := uint64(0)
+		if cfg.Memory != nil {
+			currentMemKiB = memoryToKiB(cfg.Memory.Value, cfg.Memory.Unit)
+		}
+		desiredMemKiB := memoryMBToKiB(*memoryMB)
+		memoryChanged, err := l.syncDomainMemory(domain, currentMemKiB, desiredMemKiB, live)
+		if err != nil {
+			return changed, err
+		}
+		changed = changed || memoryChanged
+	}
+
+	return changed, nil
+}


### PR DESCRIPTION
**概要**
`mactl apply` で既存の Server を更新する際の変更可否を見直しました。  
`metadata.labels`、`metadata.comment`、`spec.cpu`、`spec.memory` の変更は許可し、それ以外の変更は拒否します。あわせて、`spec.networkInterface` の誤検知で CPU 更新が失敗する問題も修正しました。

**変更内容**
- Server 更新時に既存リソースとの差分を取得して検証するように変更
- 許可される変更は以下の4項目のみ
  - `metadata.labels`
  - `metadata.comment`
  - `spec.cpu`
  - `spec.memory`
- それ以外の差分がある場合は `変更は許可されていません` を返す
- `spec.networkInterface` は、マニフェストで明示された項目だけを比較するようにして誤検知を回避
- 既存の `confirmDowntimeForServerApply` 参照不整合も復旧

**確認**
- `go test ./cmd/mactl/cmd -run TestValidateServerApplyForbiddenChanges -count=1`
- `go test ./pkg/controller ./cmd/mactl/cmd && go test ./pkg/marmotd -run TestValidateServerAuthSpecRejectsUserAndUsersTogether -count=1 && go test ./pkg/virt -run TestNonExistent -count=1`

