### PR TITLE
Gateway デグレ対応

### DIFF
--- a/docs/HOWTO-gateway-spec.md
+++ b/docs/HOWTO-gateway-spec.md
@@ -1,0 +1,25 @@
+Gateway の仕様
+
+1. 外部公開IPで受けた通信を、内部ネットワーク上の特定サーバーへ転送する
+2. 転送ルールは Gateway の serverPorts に従って作る
+3. 転送元の許可範囲は remoteCIDR または remoteCIDRs で制御する
+4. 実際の通信制御は Gateway 用VM上の iptables で実施する
+5. コントローラーが状態遷移しながら自動適用する
+PENDING → PROVISIONING → CONFIGURING → ACTIVE
+失敗が続くと FAILED
+
+iptables 側でやっていること
+1. IPv4フォワードを有効化
+2. 専用チェーンを作成して INPUT と FORWARD と PREROUTING を接続
+3. 許可CIDRからの通信だけ通す
+4. 指定ポートを内部ターゲットIPへ DNAT
+5. 戻り通信のため POSTROUTING で MASQUERADE
+
+つまり「Marmot の Gateway は、iptables ベースの簡易L3/L4ゲートウェイ兼ポートフォワーダ」です。
+
+仕様の実装位置
+1. Gateway コントローラー本体: gateway-controller.go
+2. iptables playbook 実行: gateway-ansible.go
+3. 実際の playbook テンプレート: gateway-iptables.yaml.tmpl
+4. 仕様メモ: MEMO-internet-gateway.md
+

--- a/pkg/controller/gateway-ansible.go
+++ b/pkg/controller/gateway-ansible.go
@@ -29,11 +29,16 @@ const (
 //go:embed gateway-playbooks/gateway-iptables.yaml.tmpl
 var gatewayPlaybookTemplate string
 
+//go:embed gateway-playbooks/gateway-iptables-pessistence.yaml.tmpl
+var gatewayPersistencePlaybook string
+
 var (
 	gatewayPlaybookDir    = gatewayAnsiblePlaybookDir
 	gatewayPrivateKeyPath = marmotd.GatewayPrivateKeyPath()
 	gatewayPublicKeyPath  = marmotd.GatewayPublicKeyPath()
 	runGatewayPlaybook    = runGatewayPlaybookCommand
+	runGatewayPing        = waitForGatewayAnsiblePing
+	runGatewayBecomeCheck = waitForGatewayAnsibleBecome
 )
 
 type gatewayPortRule struct {
@@ -118,6 +123,20 @@ func renderGatewayPlaybook(playbookPath string, targetIP string, serverPorts []s
 	return os.WriteFile(playbookPath, buf.Bytes(), 0o644)
 }
 
+func renderGatewayPersistencePlaybook(playbookPath string) error {
+	if strings.TrimSpace(playbookPath) == "" {
+		return fmt.Errorf("playbook path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(playbookPath), 0o755); err != nil {
+		return err
+	}
+	content := strings.TrimSpace(gatewayPersistencePlaybook)
+	if content == "" {
+		return fmt.Errorf("gateway persistence playbook template is empty")
+	}
+	return os.WriteFile(playbookPath, []byte(content+"\n"), 0o644)
+}
+
 func gatewayRemoteCIDRs(spec api.GatewaySpec) []string {
 	remoteCIDRs := make([]string, 0)
 	if spec.RemoteCIDRs != nil {
@@ -181,15 +200,12 @@ func runGatewayPlaybookCommand(playbookPath, gatewayAddress, privateKeyPath stri
 	}
 	defer os.Remove(inventoryPath)
 
-	if err := waitForGatewayAnsiblePing(address, key); err != nil {
-		return err
-	}
-
 	args := []string{
 		"-i", inventoryPath,
 		playbookPath,
 		"--private-key", key,
 		"-u", gatewayAnsibleDefaultUsername,
+		"-e", "ansible_become_timeout=60",
 	}
 	cmd := exec.Command("ansible-playbook", args...)
 	cmd.Env = append(os.Environ(), "ANSIBLE_HOST_KEY_CHECKING=False")
@@ -220,6 +236,53 @@ func waitForGatewayAnsiblePing(address, privateKeyPath string) error {
 		return fmt.Errorf("ansible ping failed before playbook: unknown error")
 	}
 	return fmt.Errorf("ansible ping failed before playbook (%d/%d): %w", gatewayAnsiblePingMaxRetry, gatewayAnsiblePingMaxRetry, lastErr)
+}
+
+func waitForGatewayAnsibleBecome(address, privateKeyPath string) error {
+	var lastErr error
+	for i := 1; i <= gatewayAnsiblePingMaxRetry; i++ {
+		if err := runGatewayAnsibleBecomeCheck(address, privateKeyPath); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if i < gatewayAnsiblePingMaxRetry {
+			time.Sleep(gatewayAnsiblePingRetryDelay)
+		}
+	}
+	if lastErr == nil {
+		return fmt.Errorf("ansible become check failed before playbook: unknown error")
+	}
+	return fmt.Errorf("ansible become check failed before playbook (%d/%d): %w", gatewayAnsiblePingMaxRetry, gatewayAnsiblePingMaxRetry, lastErr)
+}
+
+func runGatewayAnsibleBecomeCheck(address, privateKeyPath string) error {
+	inventoryPath, err := writeGatewayInventoryFile(address)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(inventoryPath)
+
+	args := []string{
+		"-i", inventoryPath,
+		"-b",
+		"-m", "command",
+		"-a", "true",
+		"all",
+		"--private-key", privateKeyPath,
+		"-u", gatewayAnsibleDefaultUsername,
+	}
+	cmd := exec.Command("ansible", args...)
+	cmd.Env = append(os.Environ(), "ANSIBLE_HOST_KEY_CHECKING=False")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(output))
+		if trimmed == "" {
+			return fmt.Errorf("ansible become check failed: %w", err)
+		}
+		return fmt.Errorf("ansible become check failed: %w: %s", err, trimmed)
+	}
+	return nil
 }
 
 func runGatewayAnsiblePing(address, privateKeyPath string) error {
@@ -258,7 +321,7 @@ func writeGatewayInventoryFile(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	content := "[all]\n" + trimmed + "\n"
+	content := "[all]\n" + trimmed + " ansible_ssh_common_args=\"-o ControlMaster=auto -o ControlPersist=60s\"\n"
 	if _, err := file.WriteString(content); err != nil {
 		_ = file.Close()
 		_ = os.Remove(file.Name())

--- a/pkg/controller/gateway-ansible.go
+++ b/pkg/controller/gateway-ansible.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/marmotd"
@@ -20,7 +21,9 @@ import (
 const (
 	gatewayAnsiblePlaybookDir     = "/var/lib/marmot/ansible-playbooks"
 	gatewayAnsibleMaxRetryCount   = 3
-	gatewayAnsibleDefaultUsername = "root"
+	gatewayAnsibleDefaultUsername = "ubuntu"
+	gatewayAnsiblePingMaxRetry    = 12
+	gatewayAnsiblePingRetryDelay  = 5 * time.Second
 )
 
 //go:embed gateway-playbooks/gateway-iptables.yaml.tmpl
@@ -29,6 +32,7 @@ var gatewayPlaybookTemplate string
 var (
 	gatewayPlaybookDir    = gatewayAnsiblePlaybookDir
 	gatewayPrivateKeyPath = marmotd.GatewayPrivateKeyPath()
+	gatewayPublicKeyPath  = marmotd.GatewayPublicKeyPath()
 	runGatewayPlaybook    = runGatewayPlaybookCommand
 )
 
@@ -126,7 +130,7 @@ func gatewayRemoteCIDRs(spec api.GatewaySpec) []string {
 		}
 	} else if spec.RemoteCIDR != nil {
 		if trimmed := strings.TrimSpace(*spec.RemoteCIDR); trimmed != "" {
-		remoteCIDRs = append(remoteCIDRs, trimmed)
+			remoteCIDRs = append(remoteCIDRs, trimmed)
 		}
 	}
 	if len(remoteCIDRs) == 0 {
@@ -171,15 +175,24 @@ func runGatewayPlaybookCommand(playbookPath, gatewayAddress, privateKeyPath stri
 	if _, err := os.Stat(key); err != nil {
 		return fmt.Errorf("private key is not available: %w", err)
 	}
+	inventoryPath, err := writeGatewayInventoryFile(address)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(inventoryPath)
+
+	if err := waitForGatewayAnsiblePing(address, key); err != nil {
+		return err
+	}
 
 	args := []string{
-		"-i", address + ",",
+		"-i", inventoryPath,
 		playbookPath,
 		"--private-key", key,
 		"-u", gatewayAnsibleDefaultUsername,
-		"--ssh-common-args", "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
 	}
 	cmd := exec.Command("ansible-playbook", args...)
+	cmd.Env = append(os.Environ(), "ANSIBLE_HOST_KEY_CHECKING=False")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		trimmed := strings.TrimSpace(string(output))
@@ -189,4 +202,71 @@ func runGatewayPlaybookCommand(playbookPath, gatewayAddress, privateKeyPath stri
 		return fmt.Errorf("ansible-playbook failed: %w: %s", err, trimmed)
 	}
 	return nil
+}
+
+func waitForGatewayAnsiblePing(address, privateKeyPath string) error {
+	var lastErr error
+	for i := 1; i <= gatewayAnsiblePingMaxRetry; i++ {
+		if err := runGatewayAnsiblePing(address, privateKeyPath); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if i < gatewayAnsiblePingMaxRetry {
+			time.Sleep(gatewayAnsiblePingRetryDelay)
+		}
+	}
+	if lastErr == nil {
+		return fmt.Errorf("ansible ping failed before playbook: unknown error")
+	}
+	return fmt.Errorf("ansible ping failed before playbook (%d/%d): %w", gatewayAnsiblePingMaxRetry, gatewayAnsiblePingMaxRetry, lastErr)
+}
+
+func runGatewayAnsiblePing(address, privateKeyPath string) error {
+	inventoryPath, err := writeGatewayInventoryFile(address)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(inventoryPath)
+
+	args := []string{
+		"-i", inventoryPath,
+		"--private-key", privateKeyPath,
+		"-u", gatewayAnsibleDefaultUsername,
+		"-m", "ping",
+		"all",
+	}
+	cmd := exec.Command("ansible", args...)
+	cmd.Env = append(os.Environ(), "ANSIBLE_HOST_KEY_CHECKING=False")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(output))
+		if trimmed == "" {
+			return fmt.Errorf("ansible ping failed: %w", err)
+		}
+		return fmt.Errorf("ansible ping failed: %w: %s", err, trimmed)
+	}
+	return nil
+}
+
+func writeGatewayInventoryFile(address string) (string, error) {
+	trimmed := strings.TrimSpace(address)
+	if trimmed == "" {
+		return "", fmt.Errorf("gateway address is empty")
+	}
+	file, err := os.CreateTemp("", "marmot-gateway-inventory-*.ini")
+	if err != nil {
+		return "", err
+	}
+	content := "[all]\n" + trimmed + "\n"
+	if _, err := file.WriteString(content); err != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(file.Name())
+		return "", err
+	}
+	return file.Name(), nil
 }

--- a/pkg/controller/gateway-controller.go
+++ b/pkg/controller/gateway-controller.go
@@ -115,11 +115,51 @@ func (c *controller) gatewayControllerLoop() {
 		case db.GATEWAY_DELETING:
 			c.reconcileGatewayDeleting(gateway)
 		case db.GATEWAY_FAILED:
-			slog.Debug("FAILED 状態のゲートウェイを検出", "gatewayId", gatewayID)
+			c.reconcileGatewayFailed(gateway)
 		default:
 			slog.Warn("不明なゲートウェイ状態", "gatewayId", gatewayID, "statusCode", gateway.Status.StatusCode)
 		}
 	}
+}
+
+func (c *controller) reconcileGatewayFailed(gateway api.Gateway) {
+	gatewayID := api.GatewayID(gateway)
+	serverID := strings.TrimSpace(gatewayManagedServerID(gateway))
+	if serverID == "" {
+		if err := c.recoverFailedGateway(gatewayID, "recovering failed gateway: missing server reference", func(labels map[string]interface{}) {
+			db.SetGatewayAnsibleRetries(labels, 0)
+			db.SetGatewayAppliedConfigHash(labels, "")
+		}); err != nil {
+			slog.Warn("recoverFailedGateway() failed", "gatewayId", gatewayID, "err", err)
+			return
+		}
+		return
+	}
+
+	if _, err := c.db.GetServerById(serverID); err != nil {
+		message := "gateway server not found, recreating"
+		if !errors.Is(err, db.ErrNotFound) {
+			message = fmt.Sprintf("gateway server lookup failed, recreating: %v", err)
+			slog.Warn("GetServerById() failed while reconciling failed gateway; forcing recovery", "gatewayId", gatewayID, "serverId", serverID, "err", err)
+		}
+		if err := c.recoverFailedGateway(gatewayID, message, func(labels map[string]interface{}) {
+			db.SetGatewayManagedServerID(labels, "")
+			db.SetGatewayAnsibleRetries(labels, 0)
+			db.SetGatewayAppliedConfigHash(labels, "")
+		}); err != nil {
+			slog.Warn("recoverFailedGateway() failed", "gatewayId", gatewayID, "err", err)
+		}
+		return
+	}
+
+	slog.Debug("FAILED 状態のゲートウェイを検出", "gatewayId", gatewayID)
+}
+
+func (c *controller) recoverFailedGateway(gatewayID string, message string, mutate func(labels map[string]interface{})) error {
+	if err := c.updateGatewayLabels(gatewayID, mutate); err != nil {
+		return err
+	}
+	return c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_PENDING, message)
 }
 
 func (c *controller) isGatewayInternalServerMissing(gateway api.Gateway) (bool, error) {
@@ -431,9 +471,11 @@ func (c *controller) buildGatewayServerSpec(gateway api.Gateway, serverName stri
 		NetworkInterface: &nics,
 	}
 
-	if key := readGatewayPublicKeyIfExists(); key != "" {
-		spec.Auth = &api.Auth{PublicKey: util.StringPtr(key), User: util.StringPtr("root")}
+	key := readGatewayPublicKeyIfExists()
+	if key == "" {
+		return api.Server{}, fmt.Errorf("gateway SSH public key is not available")
 	}
+	spec.Auth = &api.Auth{PublicKey: util.StringPtr(key), User: util.StringPtr(gatewayAnsibleDefaultUsername)}
 
 	return api.Server{ApiVersion: "v1", Kind: "Server", Metadata: meta, Spec: spec}, nil
 }
@@ -602,7 +644,11 @@ func gatewayServerName(gateway api.Gateway) string {
 }
 
 func readGatewayPublicKeyIfExists() string {
-	data, err := os.ReadFile("/etc/marmot/keys/public.key")
+	return readAuthorizedKeyFile(gatewayPublicKeyPath)
+}
+
+func readAuthorizedKeyFile(path string) string {
+	data, err := os.ReadFile(strings.TrimSpace(path))
 	if err != nil {
 		return ""
 	}

--- a/pkg/controller/gateway-controller.go
+++ b/pkg/controller/gateway-controller.go
@@ -108,6 +108,8 @@ func (c *controller) gatewayControllerLoop() {
 			c.reconcileGatewayPending(gateway)
 		case db.GATEWAY_PROVISIONING:
 			c.reconcileGatewayProvisioning(gateway)
+		case db.GATEWAY_WAITING_READY:
+			c.reconcileGatewayWaitOSUp(gateway)
 		case db.GATEWAY_CONFIGURING:
 			c.reconcileGatewayConfiguring(gateway)
 		case db.GATEWAY_ACTIVE:
@@ -129,6 +131,7 @@ func (c *controller) reconcileGatewayFailed(gateway api.Gateway) {
 		if err := c.recoverFailedGateway(gatewayID, "recovering failed gateway: missing server reference", func(labels map[string]interface{}) {
 			db.SetGatewayAnsibleRetries(labels, 0)
 			db.SetGatewayAppliedConfigHash(labels, "")
+			db.SetGatewayWaitOSUpReadyAt(labels, 0)
 		}); err != nil {
 			slog.Warn("recoverFailedGateway() failed", "gatewayId", gatewayID, "err", err)
 			return
@@ -146,6 +149,7 @@ func (c *controller) reconcileGatewayFailed(gateway api.Gateway) {
 			db.SetGatewayManagedServerID(labels, "")
 			db.SetGatewayAnsibleRetries(labels, 0)
 			db.SetGatewayAppliedConfigHash(labels, "")
+			db.SetGatewayWaitOSUpReadyAt(labels, 0)
 		}); err != nil {
 			slog.Warn("recoverFailedGateway() failed", "gatewayId", gatewayID, "err", err)
 		}
@@ -244,7 +248,14 @@ func (c *controller) reconcileGatewayProvisioning(gateway api.Gateway) {
 
 	switch server.Status.StatusCode {
 	case db.SERVER_RUNNING:
-		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_CONFIGURING, "gateway VM running, applying ansible")
+		if err := c.updateGatewayLabels(gatewayID, func(labels map[string]interface{}) {
+			db.SetGatewayAnsibleRetries(labels, 0)
+			db.SetGatewayWaitOSUpReadyAt(labels, 0)
+		}); err != nil {
+			_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_FAILED, err.Error())
+			return
+		}
+		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_WAITING_READY, "gateway VM running, waiting for OS readiness")
 	case db.SERVER_ERROR:
 		msg := "gateway server entered error state"
 		if server.Status.Message != nil && strings.TrimSpace(*server.Status.Message) != "" {
@@ -252,6 +263,63 @@ func (c *controller) reconcileGatewayProvisioning(gateway api.Gateway) {
 		}
 		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_FAILED, msg)
 	}
+}
+
+func (c *controller) reconcileGatewayWaitOSUp(gateway api.Gateway) {
+	gatewayID := api.GatewayID(gateway)
+	serverID := gatewayManagedServerID(gateway)
+	if strings.TrimSpace(serverID) == "" {
+		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_PENDING, "gateway server reference is missing")
+		return
+	}
+
+	server, err := c.db.GetServerById(serverID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_PENDING, "gateway server not found, recreating")
+			return
+		}
+		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_FAILED, err.Error())
+		return
+	}
+	if server.Status == nil || server.Status.StatusCode != db.SERVER_RUNNING {
+		return
+	}
+
+	readyAt := int64(0)
+	if gateway.Metadata.Labels != nil {
+		readyAt = db.GetGatewayWaitOSUpReadyAt(*gateway.Metadata.Labels)
+	}
+
+	if readyAt == 0 {
+		if err := runGatewayPing(gateway.Spec.BindPublicIpAddress, gatewayPrivateKeyPath); err != nil {
+			c.handleGatewayWaitOSUpFailure(gatewayID, err)
+			return
+		}
+		nextReadyAt := time.Now().Add(20 * time.Second).Unix()
+		if err := c.updateGatewayLabels(gatewayID, func(labels map[string]interface{}) {
+			db.SetGatewayWaitOSUpReadyAt(labels, nextReadyAt)
+		}); err != nil {
+			_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_FAILED, err.Error())
+			return
+		}
+		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_WAITING_READY, "gateway ping succeeded, waiting 20s before ansible apply")
+		return
+	}
+
+	remaining := readyAt - time.Now().Unix()
+	if remaining > 0 {
+			_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_WAITING_READY, fmt.Sprintf("gateway ping succeeded, waiting %ds before ansible apply", remaining))
+		return
+	}
+
+	if err := c.updateGatewayLabels(gatewayID, func(labels map[string]interface{}) {
+		db.SetGatewayWaitOSUpReadyAt(labels, 0)
+	}); err != nil {
+		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_FAILED, err.Error())
+		return
+	}
+	_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_CONFIGURING, "gateway OS is ready, applying ansible")
 }
 
 func (c *controller) reconcileGatewayConfiguring(gateway api.Gateway) {
@@ -282,11 +350,24 @@ func (c *controller) reconcileGatewayConfiguring(gateway api.Gateway) {
 	}
 	configHash := desiredGatewayConfigHash(gateway, targetIP)
 	playbookPath := filepath.Join(gatewayPlaybookDir, fmt.Sprintf("gateway-%s.yaml", gatewayID))
+	persistencePlaybookPath := filepath.Join(gatewayPlaybookDir, fmt.Sprintf("gateway-pessistence-%s.yaml", gatewayID))
 	if err := renderGatewayPlaybook(playbookPath, targetIP, gateway.Spec.ServerPorts, gatewayRemoteCIDRs(gateway.Spec)); err != nil {
 		c.handleGatewayConfigFailure(gatewayID, err)
 		return
 	}
+	if err := renderGatewayPersistencePlaybook(persistencePlaybookPath); err != nil {
+		c.handleGatewayConfigFailure(gatewayID, err)
+		return
+	}
 	if err := runGatewayPlaybook(playbookPath, gateway.Spec.BindPublicIpAddress, gatewayPrivateKeyPath); err != nil {
+		c.handleGatewayConfigFailure(gatewayID, err)
+		return
+	}
+	if err := runGatewayBecomeCheck(gateway.Spec.BindPublicIpAddress, gatewayPrivateKeyPath); err != nil {
+		c.handleGatewayConfigFailure(gatewayID, err)
+		return
+	}
+	if err := runGatewayPlaybook(persistencePlaybookPath, gateway.Spec.BindPublicIpAddress, gatewayPrivateKeyPath); err != nil {
 		c.handleGatewayConfigFailure(gatewayID, err)
 		return
 	}
@@ -333,11 +414,12 @@ func (c *controller) reconcileGatewayActive(gateway api.Gateway) {
 	if gatewayAppliedConfigHash(gateway) != desiredGatewayConfigHash(gateway, targetIP) {
 		if err := c.updateGatewayLabels(gatewayID, func(labels map[string]interface{}) {
 			db.SetGatewayAnsibleRetries(labels, 0)
+			db.SetGatewayWaitOSUpReadyAt(labels, 0)
 		}); err != nil {
 			_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_FAILED, err.Error())
 			return
 		}
-		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_CONFIGURING, "gateway configuration drift detected")
+		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_WAITING_READY, "gateway configuration drift detected; waiting for OS readiness")
 	}
 }
 
@@ -593,6 +675,23 @@ func (c *controller) handleGatewayConfigFailure(gatewayID string, err error) {
 		return
 	}
 	_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_CONFIGURING, message)
+}
+
+func (c *controller) handleGatewayWaitOSUpFailure(gatewayID string, err error) {
+	if err == nil {
+		return
+	}
+	retries, labelErr := c.incrementGatewayConfigRetries(gatewayID)
+	if labelErr != nil {
+		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_FAILED, labelErr.Error())
+		return
+	}
+	message := fmt.Sprintf("gateway ping failed before ansible apply (%d/%d): %v", retries, gatewayAnsibleMaxRetryCount, err)
+	if retries >= gatewayAnsibleMaxRetryCount {
+		_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_FAILED, message)
+		return
+	}
+	_ = c.db.UpdateGatewayStatusWithMessage(gatewayID, db.GATEWAY_WAITING_READY, message)
 }
 
 func (c *controller) incrementGatewayConfigRetries(gatewayID string) (int, error) {

--- a/pkg/controller/gateway-controller_test.go
+++ b/pkg/controller/gateway-controller_test.go
@@ -108,11 +108,37 @@ func TestGatewayControllerStateTransitions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetGatewayById() failed after provisioning reconcile: %v", err)
 	}
-	if gatewayAfterProvisioning.Status == nil || gatewayAfterProvisioning.Status.StatusCode != db.GATEWAY_CONFIGURING {
-		t.Fatalf("gateway status after provisioning reconcile = %v, want %d(CONFIGURING)", gatewayAfterProvisioning.Status, db.GATEWAY_CONFIGURING)
+	if gatewayAfterProvisioning.Status == nil || gatewayAfterProvisioning.Status.StatusCode != db.GATEWAY_WAITING_READY {
+		t.Fatalf("gateway status after provisioning reconcile = %v, want %d(WAITING_READY)", gatewayAfterProvisioning.Status, db.GATEWAY_WAITING_READY)
 	}
 
-	ctrl.reconcileGatewayConfiguring(gatewayAfterProvisioning)
+	ctrl.reconcileGatewayWaitOSUp(gatewayAfterProvisioning)
+	gatewayAfterWaitOSUpFirst, err := database.GetGatewayById(gatewayID)
+	if err != nil {
+		t.Fatalf("GetGatewayById() failed after first wait-os-up reconcile: %v", err)
+	}
+	if gatewayAfterWaitOSUpFirst.Status == nil || gatewayAfterWaitOSUpFirst.Status.StatusCode != db.GATEWAY_WAITING_READY {
+		t.Fatalf("gateway status after first wait-os-up reconcile = %v, want %d(WAITING_READY)", gatewayAfterWaitOSUpFirst.Status, db.GATEWAY_WAITING_READY)
+	}
+	if err := ctrl.updateGatewayLabels(gatewayID, func(labels map[string]interface{}) {
+		db.SetGatewayWaitOSUpReadyAt(labels, time.Now().Add(-1*time.Second).Unix())
+	}); err != nil {
+		t.Fatalf("updateGatewayLabels() failed for wait-os-up readiness: %v", err)
+	}
+	gatewayBeforeWaitOSUpSecond, err := database.GetGatewayById(gatewayID)
+	if err != nil {
+		t.Fatalf("GetGatewayById() failed before second wait-os-up reconcile: %v", err)
+	}
+	ctrl.reconcileGatewayWaitOSUp(gatewayBeforeWaitOSUpSecond)
+	gatewayAfterWaitOSUpSecond, err := database.GetGatewayById(gatewayID)
+	if err != nil {
+		t.Fatalf("GetGatewayById() failed after second wait-os-up reconcile: %v", err)
+	}
+	if gatewayAfterWaitOSUpSecond.Status == nil || gatewayAfterWaitOSUpSecond.Status.StatusCode != db.GATEWAY_CONFIGURING {
+		t.Fatalf("gateway status after second wait-os-up reconcile = %v, want %d(CONFIGURING)", gatewayAfterWaitOSUpSecond.Status, db.GATEWAY_CONFIGURING)
+	}
+
+	ctrl.reconcileGatewayConfiguring(gatewayAfterWaitOSUpSecond)
 
 	gatewayAfterConfiguring, err := database.GetGatewayById(gatewayID)
 	if err != nil {
@@ -167,21 +193,36 @@ func TestGatewayControllerLoopIntegration_CreateToActive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetGatewayById() failed after second loop: %v", err)
 	}
-	if gatewayAfterSecondLoop.Status == nil || gatewayAfterSecondLoop.Status.StatusCode != db.GATEWAY_CONFIGURING {
-		t.Fatalf("gateway status after second loop = %v, want %d(CONFIGURING)", gatewayAfterSecondLoop.Status, db.GATEWAY_CONFIGURING)
+	if gatewayAfterSecondLoop.Status == nil || gatewayAfterSecondLoop.Status.StatusCode != db.GATEWAY_WAITING_READY {
+		t.Fatalf("gateway status after second loop = %v, want %d(WAITING_READY)", gatewayAfterSecondLoop.Status, db.GATEWAY_WAITING_READY)
 	}
 
+	if err := ctrl.updateGatewayLabels(gatewayID, func(labels map[string]interface{}) {
+		db.SetGatewayWaitOSUpReadyAt(labels, time.Now().Add(-1*time.Second).Unix())
+	}); err != nil {
+		t.Fatalf("updateGatewayLabels() failed for integration wait-os-up readiness: %v", err)
+	}
 	ctrl.gatewayControllerLoop()
 
 	gatewayAfterThirdLoop, err := database.GetGatewayById(gatewayID)
 	if err != nil {
 		t.Fatalf("GetGatewayById() failed after third loop: %v", err)
 	}
-	if gatewayAfterThirdLoop.Status == nil || gatewayAfterThirdLoop.Status.StatusCode != db.GATEWAY_ACTIVE {
-		t.Fatalf("gateway status after third loop = %v, want %d(ACTIVE)", gatewayAfterThirdLoop.Status, db.GATEWAY_ACTIVE)
+	if gatewayAfterThirdLoop.Status == nil || gatewayAfterThirdLoop.Status.StatusCode != db.GATEWAY_CONFIGURING {
+		t.Fatalf("gateway status after third loop = %v, want %d(CONFIGURING)", gatewayAfterThirdLoop.Status, db.GATEWAY_CONFIGURING)
 	}
-	if gatewayAfterThirdLoop.Status.Message != nil && strings.TrimSpace(*gatewayAfterThirdLoop.Status.Message) != "" {
-		t.Fatalf("gateway message after third loop = %q, want empty", *gatewayAfterThirdLoop.Status.Message)
+
+	ctrl.gatewayControllerLoop()
+
+	gatewayAfterFourthLoop, err := database.GetGatewayById(gatewayID)
+	if err != nil {
+		t.Fatalf("GetGatewayById() failed after fourth loop: %v", err)
+	}
+	if gatewayAfterFourthLoop.Status == nil || gatewayAfterFourthLoop.Status.StatusCode != db.GATEWAY_ACTIVE {
+		t.Fatalf("gateway status after fourth loop = %v, want %d(ACTIVE)", gatewayAfterFourthLoop.Status, db.GATEWAY_ACTIVE)
+	}
+	if gatewayAfterFourthLoop.Status.Message != nil && strings.TrimSpace(*gatewayAfterFourthLoop.Status.Message) != "" {
+		t.Fatalf("gateway message after fourth loop = %q, want empty", *gatewayAfterFourthLoop.Status.Message)
 	}
 }
 
@@ -404,6 +445,8 @@ func mustCreateInternalServer(t *testing.T, database *db.Database, name, network
 func setupGatewayAnsibleTestHooks(t *testing.T, runner func(playbookPath, gatewayAddress, privateKeyPath string) error) {
 	t.Helper()
 	oldRunner := runGatewayPlaybook
+	oldPing := runGatewayPing
+	oldBecomeCheck := runGatewayBecomeCheck
 	oldDir := gatewayPlaybookDir
 	oldKey := gatewayPrivateKeyPath
 	oldPublic := gatewayPublicKeyPath
@@ -428,12 +471,16 @@ func setupGatewayAnsibleTestHooks(t *testing.T, runner func(playbookPath, gatewa
 	}
 
 	runGatewayPlaybook = runner
+	runGatewayPing = func(address, privateKeyPath string) error { return nil }
+	runGatewayBecomeCheck = func(address, privateKeyPath string) error { return nil }
 	gatewayPlaybookDir = filepath.Join(tempDir, "playbooks")
 	gatewayPrivateKeyPath = keyPath
 	gatewayPublicKeyPath = publicKeyPath
 
 	t.Cleanup(func() {
 		runGatewayPlaybook = oldRunner
+		runGatewayPing = oldPing
+		runGatewayBecomeCheck = oldBecomeCheck
 		gatewayPlaybookDir = oldDir
 		gatewayPrivateKeyPath = oldKey
 		gatewayPublicKeyPath = oldPublic

--- a/pkg/controller/gateway-controller_test.go
+++ b/pkg/controller/gateway-controller_test.go
@@ -1,6 +1,10 @@
 package controller
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"net"
@@ -15,7 +19,43 @@ import (
 	"github.com/takara9/marmot/pkg/db"
 	"github.com/takara9/marmot/pkg/marmotd"
 	"github.com/takara9/marmot/pkg/util"
+	"golang.org/x/crypto/ssh"
 )
+
+func TestReadGatewayPublicKeyIfExists_ReadsPublicKeyFile(t *testing.T) {
+	oldPublicKeyPath := gatewayPublicKeyPath
+	t.Cleanup(func() {
+		gatewayPublicKeyPath = oldPublicKeyPath
+	})
+
+	tempDir := t.TempDir()
+	gatewayPublicKeyPath = filepath.Join(tempDir, "public.key")
+
+	want := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDmarmot-test-key marmot-gateway"
+	if err := os.WriteFile(gatewayPublicKeyPath, []byte(want+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() failed for public key: %v", err)
+	}
+
+	got := readGatewayPublicKeyIfExists()
+	if got != want {
+		t.Fatalf("readGatewayPublicKeyIfExists() = %q, want %q", got, want)
+	}
+}
+
+func TestReadGatewayPublicKeyIfExists_ReturnsEmptyWhenPublicKeyFileMissing(t *testing.T) {
+	oldPublicKeyPath := gatewayPublicKeyPath
+	t.Cleanup(func() {
+		gatewayPublicKeyPath = oldPublicKeyPath
+	})
+
+	tempDir := t.TempDir()
+	gatewayPublicKeyPath = filepath.Join(tempDir, "public.key")
+
+	got := readGatewayPublicKeyIfExists()
+	if got != "" {
+		t.Fatalf("readGatewayPublicKeyIfExists() = %q, want empty", got)
+	}
+}
 
 func TestGatewayControllerStateTransitions(t *testing.T) {
 	database := newGatewayTestDatabase(t)
@@ -222,6 +262,81 @@ func TestGatewayControllerDeletesGatewayWhenInternalServerMissing(t *testing.T) 
 	}
 }
 
+func TestGatewayControllerFailedStateRecoversWhenManagedServerMissing(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	setupGatewayAnsibleTestHooks(t, func(playbookPath, gatewayAddress, privateKeyPath string) error {
+		return nil
+	})
+	ctrl := &controller{
+		db:            database,
+		marmot:        &marmotd.Marmot{NodeName: "hvc", Db: database},
+		deletionDelay: 15 * time.Second,
+	}
+
+	_ = mustCreateVirtualNetwork(t, database, "web-servers")
+	mustCreateInternalServer(t, database, "server-10", "web-servers", "172.16.10.2")
+	createdGateway := mustCreateGateway(t, database, "igw-failed-recover", "web-servers", "192.168.1.114")
+	gatewayID := api.GatewayID(createdGateway)
+
+	failedGateway, err := database.GetGatewayById(gatewayID)
+	if err != nil {
+		t.Fatalf("GetGatewayById() failed: %v", err)
+	}
+	if failedGateway.Metadata.Labels == nil {
+		labels := map[string]interface{}{}
+		failedGateway.Metadata.Labels = &labels
+	}
+	labels := *failedGateway.Metadata.Labels
+	db.SetGatewayManagedServerID(labels, "missing-server")
+	db.SetGatewayAnsibleRetries(labels, 3)
+	failedGateway.Metadata.Labels = &labels
+	now := time.Now()
+	failedGateway.Status = &api.Status{
+		StatusCode:          db.GATEWAY_FAILED,
+		Status:              util.StringPtr(db.GatewayStatus[db.GATEWAY_FAILED]),
+		Message:             util.StringPtr("gateway ansible apply failed (3/3): simulated"),
+		CreationTimeStamp:   util.TimePtr(now),
+		LastUpdateTimeStamp: util.TimePtr(now),
+	}
+	if err := database.UpdateGatewayById(gatewayID, failedGateway); err != nil {
+		t.Fatalf("UpdateGatewayById() failed: %v", err)
+	}
+
+	ctrl.gatewayControllerLoop()
+
+	afterRecovery, err := database.GetGatewayById(gatewayID)
+	if err != nil {
+		t.Fatalf("GetGatewayById() failed after recovery loop: %v", err)
+	}
+	if afterRecovery.Status == nil || afterRecovery.Status.StatusCode != db.GATEWAY_PENDING {
+		t.Fatalf("gateway status after failed recovery = %v, want %d(PENDING)", afterRecovery.Status, db.GATEWAY_PENDING)
+	}
+	if afterRecovery.Metadata.Labels != nil {
+		if got := db.GetGatewayManagedServerID(*afterRecovery.Metadata.Labels); got != "" {
+			t.Fatalf("gateway managed server id after recovery = %q, want empty", got)
+		}
+		if got := db.GetGatewayAnsibleRetries(*afterRecovery.Metadata.Labels); got != 0 {
+			t.Fatalf("gateway ansible retries after recovery = %d, want 0", got)
+		}
+	}
+
+	ctrl.gatewayControllerLoop()
+
+	afterRecreate, err := database.GetGatewayById(gatewayID)
+	if err != nil {
+		t.Fatalf("GetGatewayById() failed after recreate loop: %v", err)
+	}
+	if afterRecreate.Status == nil || afterRecreate.Status.StatusCode != db.GATEWAY_PROVISIONING {
+		t.Fatalf("gateway status after recreate loop = %v, want %d(PROVISIONING)", afterRecreate.Status, db.GATEWAY_PROVISIONING)
+	}
+	if afterRecreate.Metadata.Labels == nil {
+		t.Fatalf("gateway labels missing after recreate loop")
+	}
+	if got := db.GetGatewayManagedServerID(*afterRecreate.Metadata.Labels); strings.TrimSpace(got) == "" {
+		t.Fatalf("gateway managed server id after recreate loop is empty")
+	}
+}
+
 func mustCreateVirtualNetwork(t *testing.T, database *db.Database, name string) api.VirtualNetwork {
 	t.Helper()
 	vnet, err := database.CreateVirtualNetwork(api.VirtualNetwork{
@@ -291,21 +406,37 @@ func setupGatewayAnsibleTestHooks(t *testing.T, runner func(playbookPath, gatewa
 	oldRunner := runGatewayPlaybook
 	oldDir := gatewayPlaybookDir
 	oldKey := gatewayPrivateKeyPath
+	oldPublic := gatewayPublicKeyPath
 
 	tempDir := t.TempDir()
 	keyPath := filepath.Join(tempDir, "private.key")
-	if err := os.WriteFile(keyPath, []byte("dummy-private-key"), 0o600); err != nil {
+	publicKeyPath := filepath.Join(tempDir, "public.key")
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() failed for test private key: %v", err)
+	}
+	privateBlock := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(privateBlock), 0o600); err != nil {
 		t.Fatalf("WriteFile() failed for test private key: %v", err)
+	}
+	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		t.Fatalf("ssh.NewPublicKey() failed for test private key: %v", err)
+	}
+	if err := os.WriteFile(publicKeyPath, ssh.MarshalAuthorizedKey(publicKey), 0o644); err != nil {
+		t.Fatalf("WriteFile() failed for test public key: %v", err)
 	}
 
 	runGatewayPlaybook = runner
 	gatewayPlaybookDir = filepath.Join(tempDir, "playbooks")
 	gatewayPrivateKeyPath = keyPath
+	gatewayPublicKeyPath = publicKeyPath
 
 	t.Cleanup(func() {
 		runGatewayPlaybook = oldRunner
 		gatewayPlaybookDir = oldDir
 		gatewayPrivateKeyPath = oldKey
+		gatewayPublicKeyPath = oldPublic
 	})
 }
 

--- a/pkg/controller/gateway-playbooks/gateway-iptables-pessistence.yaml.tmpl
+++ b/pkg/controller/gateway-playbooks/gateway-iptables-pessistence.yaml.tmpl
@@ -1,0 +1,43 @@
+---
+- name: Configure marmot gateway iptables persistence
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Ensure /etc/iptables exists
+      ansible.builtin.file:
+        path: /etc/iptables
+        state: directory
+        mode: '0755'
+
+    - name: Save iptables rules
+      ansible.builtin.shell: |
+        set -euo pipefail
+        iptables-save > /etc/iptables/rules.v4
+      args:
+        executable: /bin/bash
+
+    - name: Install iptables restore service unit
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/marmot-iptables-restore.service
+        mode: '0644'
+        content: |
+          [Unit]
+          Description=Restore iptables rules from /etc/iptables/rules.v4
+          DefaultDependencies=no
+          Before=network-pre.target
+          Wants=network-pre.target
+          ConditionPathExists=/etc/iptables/rules.v4
+
+          [Service]
+          Type=oneshot
+          ExecStart=/bin/sh -c 'iptables-restore < /etc/iptables/rules.v4'
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Enable iptables restore service
+      ansible.builtin.systemd:
+        name: marmot-iptables-restore.service
+        enabled: yes
+        daemon_reload: yes

--- a/pkg/controller/gateway-playbooks/gateway-iptables.yaml.tmpl
+++ b/pkg/controller/gateway-playbooks/gateway-iptables.yaml.tmpl
@@ -152,3 +152,4 @@
         chain: POSTROUTING
         jump: MASQUERADE
         comment: marmot-gateway
+

--- a/pkg/db/db-gateway.go
+++ b/pkg/db/db-gateway.go
@@ -268,31 +268,42 @@ func (d *Database) SetDeleteTimestampGateway(id string) error {
 
 // UpdateGatewayStatusWithMessage updates status and optional message for gateway objects.
 func (d *Database) UpdateGatewayStatusWithMessage(id string, status int, message string) error {
-	gateway, err := d.GetGatewayById(id)
-	if err != nil {
-		return err
-	}
-	if gateway.Status == nil {
-		gateway.Status = &api.Status{}
-	}
-	statusChanged := gateway.Status.StatusCode != status
-	gateway.Status.StatusCode = status
-	gateway.Status.Status = util.StringPtr(GatewayStatus[status])
-	gateway.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
-	trimmedMessage := strings.TrimSpace(message)
-	if statusChanged {
-		// PatchStruct skips nil pointers, so use empty string to reliably clear stale messages.
-		gateway.Status.Message = util.StringPtr("")
-	}
-	if trimmedMessage == "" {
-		if gateway.Status.Message == nil {
+	for {
+		key := GatewayPrefix + "/" + id
+		var gateway api.Gateway
+		resp, err := d.GetJSON(key, &gateway)
+		if err != nil {
+			return err
+		}
+		if gateway.Status == nil {
+			gateway.Status = &api.Status{}
+		}
+		statusChanged := gateway.Status.StatusCode != status
+		gateway.Status.StatusCode = status
+		gateway.Status.Status = util.StringPtr(GatewayStatus[status])
+		gateway.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
+		trimmedMessage := strings.TrimSpace(message)
+		if statusChanged {
+			// Clear stale messages on status transition.
 			gateway.Status.Message = util.StringPtr("")
 		}
-	} else {
-		gateway.Status.Message = util.StringPtr(trimmedMessage)
-	}
+		if trimmedMessage == "" {
+			if gateway.Status.Message == nil {
+				gateway.Status.Message = util.StringPtr("")
+			}
+		} else {
+			gateway.Status.Message = util.StringPtr(trimmedMessage)
+		}
 
-	return d.UpdateGatewayById(id, gateway)
+		expected := resp.Kvs[0].ModRevision
+		if err := d.PutJSONCAS(key, expected, &gateway); err != nil {
+			if err == ErrUpdateConflict {
+				continue
+			}
+			return err
+		}
+		return nil
+	}
 }
 
 // GetGatewayByName returns gateways matching the given name.

--- a/pkg/db/db-gateway.go
+++ b/pkg/db/db-gateway.go
@@ -15,10 +15,11 @@ import (
 const (
 	GATEWAY_PENDING      = 0
 	GATEWAY_PROVISIONING = 1
-	GATEWAY_CONFIGURING  = 2
-	GATEWAY_ACTIVE       = 3
-	GATEWAY_FAILED       = 4
-	GATEWAY_DELETING     = 5
+	GATEWAY_WAITING_READY = 2
+	GATEWAY_CONFIGURING  = 3
+	GATEWAY_ACTIVE       = 4
+	GATEWAY_FAILED       = 5
+	GATEWAY_DELETING     = 6
 
 	GatewayLabelManagedServerID = "gatewayServerId"
 	GatewayLabelManagedBy       = "managedBy"
@@ -28,15 +29,17 @@ const (
 	GatewayServerLabelRoleValue = "gateway"
 	GatewayLabelAnsibleRetries  = "ansibleRetries"
 	GatewayLabelAppliedConfig   = "appliedConfigHash"
+	GatewayLabelWaitOSUpReadyAt = "waitOsUpReadyAt"
 )
 
 var GatewayStatus = map[int]string{
 	0: "PENDING",
 	1: "PROVISIONING",
-	2: "CONFIGURING",
-	3: "ACTIVE",
-	4: "FAILED",
-	5: "DELETING",
+	2: "WAITING_READY",
+	3: "CONFIGURING",
+	4: "ACTIVE",
+	5: "FAILED",
+	6: "DELETING",
 }
 
 func SetGatewayManagedServerID(labels map[string]interface{}, serverID string) {
@@ -95,6 +98,29 @@ func GetGatewayAppliedConfigHash(labels map[string]interface{}) string {
 		return ""
 	}
 	return strings.TrimSpace(val)
+}
+
+func SetGatewayWaitOSUpReadyAt(labels map[string]interface{}, unixTs int64) {
+	if labels == nil {
+		return
+	}
+	labels[GatewayLabelWaitOSUpReadyAt] = unixTs
+}
+
+func GetGatewayWaitOSUpReadyAt(labels map[string]interface{}) int64 {
+	if labels == nil {
+		return 0
+	}
+	switch val := labels[GatewayLabelWaitOSUpReadyAt].(type) {
+	case int:
+		return int64(val)
+	case int64:
+		return val
+	case float64:
+		return int64(val)
+	default:
+		return 0
+	}
 }
 
 // CreateGateway stores a gateway object in etcd with a generated ID and PENDING status.


### PR DESCRIPTION
## 概要
Gateway リソースが `FAILED` になったまま復旧しない／SSH 到達前に設定適用へ進んで失敗する／状態更新が正しく反映されない問題を修正しました。  
あわせて、Gateway の実装仕様メモを追加しています。

## 背景
Issue #484 の調査で、主に以下が原因でした。

- Gateway VM への SSH 準備完了前に `ansible-playbook` を実行してしまう
- `ansible` 実行引数（`--ssh-common-args`）の扱いで実行エラーになるケースがある
- `FAILED -> PENDING(0)` の状態遷移が DB 更新経路で消えることがある
- `FAILED` 状態で管理対象サーバー参照が壊れていると自己復旧しない

## 変更内容
- Gateway 設定適用前に `ansible -m ping` による起動確認を追加（リトライあり）
- `ansible` / `ansible-playbook` の実行を一時インベントリファイル経由に統一
- Host key チェック無効化を引数ではなく環境変数で設定
- Ansible 接続ユーザーを `ubuntu` に統一
- Gateway へ注入する公開鍵の読込元を `/etc/marmot/keys/public.key` に固定
- `FAILED` 状態の Gateway について、管理サーバー欠損などを検知した際の自己回復処理を追加
- Gateway ステータス更新を CAS ループへ変更し、`statusCode=0 (PENDING)` を確実に永続化
- Gateway 仕様ドキュメントを追加

## 期待される効果
- Gateway VM の初期化タイミング由来の設定失敗を低減
- `ansible` 実行時の引数解釈エラーを回避
- `FAILED` からの再試行・再作成フローの安定化
- 状態遷移の永続化不整合を解消

## テスト
- `go test ./pkg/controller` を実行し成功

## 影響範囲
- Gateway コントローラー
- Gateway 用 Ansible 実行フロー
- Gateway ステータス更新（DB）

## 補足
- 既存環境で `FAILED` が残っている場合でも、次回 reconcile で回復処理に入る想定です。