### PR TITLE
GWの永続化

### DIFF
--- a/pkg/controller/gateway-playbooks/gateway-iptables.yaml.tmpl
+++ b/pkg/controller/gateway-playbooks/gateway-iptables.yaml.tmpl
@@ -14,6 +14,73 @@
     - name: Apply sysctl configuration
       ansible.builtin.command: sysctl -p
 
+    - name: Ensure directory for persisted iptables rules exists
+      ansible.builtin.file:
+        path: /etc/marmot/iptables
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Install gateway iptables restore script
+      ansible.builtin.copy:
+        dest: /usr/local/sbin/marmot-gateway-iptables-restore.sh
+        owner: root
+        group: root
+        mode: '0755'
+        content: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          RULES_FILE="/etc/marmot/iptables/gateway-rules.v4"
+          if [[ "${1:-}" == "save" ]]; then
+            iptables-save > "${RULES_FILE}"
+            exit 0
+          fi
+
+          if [[ ! -s "${RULES_FILE}" ]]; then
+            exit 0
+          fi
+
+          IPTABLES_RESTORE="$(command -v iptables-restore || true)"
+          if [[ -z "${IPTABLES_RESTORE}" ]]; then
+            IPTABLES_RESTORE="/sbin/iptables-restore"
+          fi
+
+          "${IPTABLES_RESTORE}" < "${RULES_FILE}"
+
+    - name: Install gateway iptables restore service
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/marmot-gateway-iptables-restore.service
+        owner: root
+        group: root
+        mode: '0644'
+        content: |
+          [Unit]
+          Description=Marmot gateway iptables restore
+          DefaultDependencies=no
+          Wants=network-pre.target
+          After=network-pre.target local-fs.target
+          Before=network.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/sbin/marmot-gateway-iptables-restore.sh
+          ExecStop=/usr/local/sbin/marmot-gateway-iptables-restore.sh save
+          RemainAfterExit=yes
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Reload systemd manager configuration
+      ansible.builtin.systemd:
+        daemon_reload: true
+
+    - name: Enable gateway iptables restore service
+      ansible.builtin.systemd:
+        name: marmot-gateway-iptables-restore.service
+        enabled: true
+
     - name: Ensure gateway dedicated filter chains exist
       ansible.builtin.shell: |
         set -euo pipefail
@@ -152,3 +219,10 @@
         chain: POSTROUTING
         jump: MASQUERADE
         comment: marmot-gateway
+
+    - name: Persist iptables rules for reboot
+      ansible.builtin.shell: |
+        set -euo pipefail
+        /usr/local/sbin/marmot-gateway-iptables-restore.sh save
+      args:
+        executable: /bin/bash

--- a/pkg/controller/gateway_ansible_remote_cidr_test.go
+++ b/pkg/controller/gateway_ansible_remote_cidr_test.go
@@ -1,7 +1,10 @@
 package controller
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/takara9/marmot/api"
 )
@@ -35,5 +38,39 @@ func TestDesiredGatewayConfigHash_ChangesByRemoteCIDRs(t *testing.T) {
 
 	if hash1 == hash2 {
 		t.Fatalf("config hash should change when remoteCIDR changes: %q", hash1)
+	}
+}
+
+func TestGatewayPlaybookTemplate_PersistsRulesAndRestoresOnBoot(t *testing.T) {
+	tmpl, err := template.New("gateway-playbook").Parse(gatewayPlaybookTemplate)
+	if err != nil {
+		t.Fatalf("template parse failed: %v", err)
+	}
+
+	data := gatewayPlaybookData{
+		TargetIP:    "172.16.10.2",
+		RemoteCIDRs: []string{"10.0.0.0/24"},
+		Ports: []gatewayPortRule{
+			{Protocol: "tcp", Port: 80},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template execute failed: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "marmot-gateway-iptables-restore.service") {
+		t.Fatalf("rendered playbook missing gateway restore service: %s", out)
+	}
+	if !strings.Contains(out, "/usr/local/sbin/marmot-gateway-iptables-restore.sh") {
+		t.Fatalf("rendered playbook missing gateway restore script: %s", out)
+	}
+	if !strings.Contains(out, "iptables-save > \"${RULES_FILE}\"") {
+		t.Fatalf("rendered playbook missing gateway iptables save command: %s", out)
+	}
+	if !strings.Contains(out, "ExecStop=/usr/local/sbin/marmot-gateway-iptables-restore.sh save") {
+		t.Fatalf("rendered playbook missing gateway shutdown save hook: %s", out)
 	}
 }


### PR DESCRIPTION
## 概要
Gateway ノード再起動後に iptables ルールが失われる問題を解消するため、Gateway 用 playbook にルール永続化処理を追加しました。  
起動時の復元と停止時の保存を systemd サービスで一貫して行えるようにしています。

## 変更内容
- Gateway iptables ルール保存先ディレクトリを作成
- ルール保存・復元スクリプトを配置
- 起動時復元 / 停止時保存を行う systemd oneshot サービスを追加
- systemd の daemon-reload とサービス enable を playbook に追加
- ルール適用後に iptables-save を実行して初回再起動前にも復元データを確保
- 永続化まわりのテンプレート出力を検証するユニットテストを追加

対象ファイル:
- gateway-iptables.yaml.tmpl
- gateway_ansible_remote_cidr_test.go

## 背景・狙い
- Gateway の NAT/FORWARD ルールが再起動で消えると通信断が発生するため、再起動耐性を持たせる
- 配布パッケージ依存を増やさず、Gateway 専用の復元対象だけを管理する

## 動作確認
- go test ./pkg/controller -run TestGatewayPlaybookTemplate_PersistsRulesAndRestoresOnBoot -count=1 -v
- 結果: PASS

## 影響範囲
- Gateway 設定適用時の playbook 実行フロー
- Gateway ノードの起動/停止時における iptables ルール取り扱い

## 備考
- iptables-persistent 依存ではなく、Marmot 管理下の専用サービスで永続化しています（環境依存の副作用回避のため）。

