### PR TITLE
ansibleセットアップのログ取得

### DIFF
--- a/pkg/controller/ansible-playbook-log.go
+++ b/pkg/controller/ansible-playbook-log.go
@@ -1,0 +1,101 @@
+package controller
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const ansiblePlaybookLogDir = "/var/lib/marmot/ansible-playbooks/logs"
+
+var ansiblePlaybookLogDirPath = ansiblePlaybookLogDir
+
+func ansiblePlaybookLogPath(resourceName, resourceID string) (string, error) {
+	name := sanitizeLogToken(strings.TrimSpace(resourceName), "resource")
+	id := sanitizeLogToken(strings.TrimSpace(resourceID), "unknown")
+
+	if err := os.MkdirAll(ansiblePlaybookLogDirPath, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(ansiblePlaybookLogDirPath, fmt.Sprintf("%s-%s.log", name, id)), nil
+}
+
+func resourceIDFromPlaybookPath(playbookPath, filePrefix string) string {
+	trimmedPath := strings.TrimSpace(playbookPath)
+	if trimmedPath == "" {
+		return ""
+	}
+	base := filepath.Base(trimmedPath)
+	name := strings.TrimSuffix(base, filepath.Ext(base))
+	prefix := strings.TrimSpace(filePrefix)
+	if prefix != "" && strings.HasPrefix(name, prefix) {
+		id := strings.TrimSpace(strings.TrimPrefix(name, prefix))
+		if id != "" {
+			return id
+		}
+	}
+	return strings.TrimSpace(name)
+}
+
+func sanitizeLogToken(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	clean := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		case r == '-' || r == '_' || r == '.':
+			return r
+		default:
+			return '-'
+		}
+	}, value)
+	clean = strings.Trim(clean, "-._")
+	if clean == "" {
+		return fallback
+	}
+	return clean
+}
+
+func runAnsiblePlaybookWithLogging(args []string, resourceName, resourceID string) error {
+	logPath, err := ansiblePlaybookLogPath(resourceName, resourceID)
+	if err != nil {
+		return fmt.Errorf("failed to prepare ansible log path: %w", err)
+	}
+
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to open ansible log file %q: %w", logPath, err)
+	}
+	defer func() {
+		_ = logFile.Close()
+	}()
+
+	_, _ = fmt.Fprintf(logFile, "\n=== %s ansible-playbook %s ===\n", time.Now().UTC().Format(time.RFC3339), strings.Join(args, " "))
+
+	var buf bytes.Buffer
+	mw := io.MultiWriter(&buf, logFile)
+
+	cmd := exec.Command("ansible-playbook", args...)
+	cmd.Stdout = mw
+	cmd.Stderr = mw
+	if err := cmd.Run(); err != nil {
+		trimmed := strings.TrimSpace(buf.String())
+		if trimmed == "" {
+			return fmt.Errorf("ansible-playbook failed (log: %s): %w", logPath, err)
+		}
+		return fmt.Errorf("ansible-playbook failed (log: %s): %w: %s", logPath, err, trimmed)
+	}
+
+	return nil
+}

--- a/pkg/controller/ansible-playbook-log_test.go
+++ b/pkg/controller/ansible-playbook-log_test.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResourceIDFromPlaybookPath(t *testing.T) {
+	got := resourceIDFromPlaybookPath("/var/lib/marmot/ansible-playbooks/gateway-gw-123.yaml", "gateway-")
+	if got != "gw-123" {
+		t.Fatalf("resourceIDFromPlaybookPath() = %q, want %q", got, "gw-123")
+	}
+}
+
+func TestAnsiblePlaybookLogPath_UsesResourceNameAndID(t *testing.T) {
+	oldDir := ansiblePlaybookLogDirPath
+	ansiblePlaybookLogDirPath = t.TempDir()
+	t.Cleanup(func() {
+		ansiblePlaybookLogDirPath = oldDir
+	})
+
+	path, err := ansiblePlaybookLogPath("gateway", "gw-123")
+	if err != nil {
+		t.Fatalf("ansiblePlaybookLogPath() failed: %v", err)
+	}
+	if !strings.HasSuffix(path, filepath.Join("gateway-gw-123.log")) {
+		t.Fatalf("ansiblePlaybookLogPath() = %q, want suffix %q", path, filepath.Join("gateway-gw-123.log"))
+	}
+}

--- a/pkg/controller/application-load-balancer-ansible.go
+++ b/pkg/controller/application-load-balancer-ansible.go
@@ -143,6 +143,7 @@ func runApplicationLoadBalancerPlaybookCommand(playbookPath, targetAddress, priv
 	if address == "" {
 		return fmt.Errorf("target address is empty")
 	}
+	resourceID := resourceIDFromPlaybookPath(playbookPath, "load-balancer-")
 	key := strings.TrimSpace(privateKeyPath)
 	if key == "" {
 		return fmt.Errorf("private key path is empty")
@@ -158,16 +159,7 @@ func runApplicationLoadBalancerPlaybookCommand(playbookPath, targetAddress, priv
 		"-u", applicationLoadBalancerAnsibleDefaultUsername,
 		"--ssh-common-args", "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
 	}
-	cmd := exec.Command("ansible-playbook", args...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		trimmed := strings.TrimSpace(string(output))
-		if trimmed == "" {
-			return fmt.Errorf("ansible-playbook failed: %w", err)
-		}
-		return fmt.Errorf("ansible-playbook failed: %w: %s", err, trimmed)
-	}
-	return nil
+	return runAnsiblePlaybookWithLogging(args, "load-balancer", resourceID)
 }
 
 func readApplicationLoadBalancerAgentStateCommand(targetAddress, privateKeyPath string) (applicationLoadBalancerAgentState, error) {

--- a/pkg/controller/gateway-ansible.go
+++ b/pkg/controller/gateway-ansible.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -164,6 +163,7 @@ func runGatewayPlaybookCommand(playbookPath, gatewayAddress, privateKeyPath stri
 	if address == "" {
 		return fmt.Errorf("gateway address is empty")
 	}
+	resourceID := resourceIDFromPlaybookPath(playbookPath, "gateway-")
 	key := strings.TrimSpace(privateKeyPath)
 	if key == "" {
 		return fmt.Errorf("private key path is empty")
@@ -179,14 +179,5 @@ func runGatewayPlaybookCommand(playbookPath, gatewayAddress, privateKeyPath stri
 		"-u", gatewayAnsibleDefaultUsername,
 		"--ssh-common-args", "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
 	}
-	cmd := exec.Command("ansible-playbook", args...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		trimmed := strings.TrimSpace(string(output))
-		if trimmed == "" {
-			return fmt.Errorf("ansible-playbook failed: %w", err)
-		}
-		return fmt.Errorf("ansible-playbook failed: %w: %s", err, trimmed)
-	}
-	return nil
+	return runAnsiblePlaybookWithLogging(args, "gateway", resourceID)
 }

--- a/pkg/controller/network-load-balancer-ansible.go
+++ b/pkg/controller/network-load-balancer-ansible.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -163,6 +162,7 @@ func runNetworkLoadBalancerPlaybookCommand(playbookPath, targetAddress, privateK
 	if address == "" {
 		return fmt.Errorf("target address is empty")
 	}
+	resourceID := resourceIDFromPlaybookPath(playbookPath, "network-load-balancer-")
 	key := strings.TrimSpace(privateKeyPath)
 	if key == "" {
 		return fmt.Errorf("private key path is empty")
@@ -178,16 +178,7 @@ func runNetworkLoadBalancerPlaybookCommand(playbookPath, targetAddress, privateK
 		"-u", networkLoadBalancerAnsibleDefaultUser,
 		"--ssh-common-args", "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
 	}
-	cmd := exec.Command("ansible-playbook", args...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		trimmed := strings.TrimSpace(string(output))
-		if trimmed == "" {
-			return fmt.Errorf("ansible-playbook failed: %w", err)
-		}
-		return fmt.Errorf("ansible-playbook failed: %w: %s", err, trimmed)
-	}
-	return nil
+	return runAnsiblePlaybookWithLogging(args, "network-load-balancer", resourceID)
 }
 
 func networkLoadBalancerBackendAvailabilityMessage(loadBalancer api.NetworkLoadBalancer, listenerBackends map[string][]networkLoadBalancerBackendServer) string {

--- a/pkg/controller/vpn-gateway-ansible.go
+++ b/pkg/controller/vpn-gateway-ansible.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -157,6 +156,7 @@ func runVpnGatewayPlaybookCommand(playbookPath, gatewayAddress, privateKeyPath s
 	if address == "" {
 		return fmt.Errorf("gateway address is empty")
 	}
+	resourceID := resourceIDFromPlaybookPath(playbookPath, "vpn-gateway-")
 	key := strings.TrimSpace(privateKeyPath)
 	if key == "" {
 		return fmt.Errorf("private key path is empty")
@@ -172,14 +172,5 @@ func runVpnGatewayPlaybookCommand(playbookPath, gatewayAddress, privateKeyPath s
 		"-u", vpnGatewayAnsibleDefaultUsername,
 		"--ssh-common-args", "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
 	}
-	cmd := exec.Command("ansible-playbook", args...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		trimmed := strings.TrimSpace(string(output))
-		if trimmed == "" {
-			return fmt.Errorf("ansible-playbook failed: %w", err)
-		}
-		return fmt.Errorf("ansible-playbook failed: %w: %s", err, trimmed)
-	}
-	return nil
+	return runAnsiblePlaybookWithLogging(args, "vpn-gateway", resourceID)
 }


### PR DESCRIPTION
## 概要
ansible-playbook 実行ログの取得方法を見直し、未対応オプションへの依存をなくして、標準出力・標準エラー出力を確実に保存できるようにしました。  
あわせてログ保存先を /var/lib/marmot/ansible-playbooks/logs に統一しました。

## 背景
- ansible-playbook には --log-path オプションがなく、従来案では実行環境により失敗する可能性があった
- 障害調査時に、実行時の標準出力・標準エラーをリソース単位で追跡できる必要がある

## 変更内容
- ansible-playbook 実行時の stdout/stderr をログファイルへ保存する共通処理を追加
- ログ出力ディレクトリを /var/lib/marmot/ansible-playbooks/logs に変更
- ログファイル名を リソース名-ID.log 形式で生成
- Gateway / VPN Gateway / Application Load Balancer / Network Load Balancer の各 ansible 実行経路に共通処理を適用
- ログパス生成・ID抽出のユニットテストを追加

## 期待される効果
- ansible 実行失敗時の原因追跡が容易になる
- リソース単位でログを確認でき、VMとの紐づけが明確になる
- ansible CLI 非対応オプションに依存しない安定した実行になる

## 動作確認
- go test ./pkg/controller -count=1 を実行し、成功を確認

