### PR TITLE
重複ボリューム利用の回避

### DIFF
--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -62,6 +62,35 @@ func volumeKindOrDefault(spec api.VolSpec) string {
 	return "data"
 }
 
+func shouldResolvePreCreatedStorageVolume(disk api.Volume) bool {
+	if strings.TrimSpace(api.VolumeID(disk)) != "" {
+		return true
+	}
+	if disk.Spec.Persistent != nil && *disk.Spec.Persistent {
+		return true
+	}
+	return false
+}
+
+func serverScopedStorageName(name, serverID string) string {
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return ""
+	}
+
+	trimmedServerID := strings.TrimSpace(serverID)
+	if trimmedServerID == "" {
+		return trimmedName
+	}
+
+	suffix := "-" + trimmedServerID
+	if strings.HasSuffix(trimmedName, suffix) {
+		return trimmedName
+	}
+
+	return trimmedName + suffix
+}
+
 func chooseAssignedNodeName(defaultNode string, requestedNode *string, storageNode string) (string, error) {
 	defaultAssigned := strings.TrimSpace(defaultNode)
 	assigned := defaultAssigned
@@ -142,6 +171,11 @@ func (m *Marmot) resolveStorageBoundNodeName(storage *[]api.Volume) (string, err
 
 	vols := make([]*api.Volume, 0, len(*storage))
 	for i, disk := range *storage {
+		if !shouldResolvePreCreatedStorageVolume(disk) {
+			vols = append(vols, nil)
+			continue
+		}
+
 		vol, err := m.findPreCreatedStorageVolume(disk)
 		if err != nil {
 			return "", fmt.Errorf("storage[%d] volume lookup failed: %w", i, err)
@@ -689,26 +723,33 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 	// データボリュームの作成
 	slog.Debug("データボリュームの生成")
 	if serverConfig.Spec.Storage != nil {
+		serverID := api.ServerID(serverConfig)
 		for i, disk := range *serverConfig.Spec.Storage {
 			disk.ApiVersion = "v1"
 			disk.Kind = "Volume"
 
-			diskVol, err := m.findPreCreatedStorageVolume(disk)
-			if err != nil {
-				slog.Error("findPreCreatedStorageVolume()", "err", err, "disk index", i)
-				return "", err
+			if shouldResolvePreCreatedStorageVolume(disk) {
+				diskVol, err := m.findPreCreatedStorageVolume(disk)
+				if err != nil {
+					slog.Error("findPreCreatedStorageVolume()", "err", err, "disk index", i)
+					return "", err
+				}
+				if diskVol != nil {
+					slog.Debug("既存ボリュームを使用", "disk index", i, "volume id", api.VolumeID(*diskVol))
+
+					// 永続フラグを立てる
+					var persistent bool = true
+					diskVol.Spec.Persistent = &persistent
+
+					slog.Debug("既存ボリュームの情報取得成功", "disk index", i, "volume id", api.VolumeID(*diskVol), "path", diskVol.Spec.Path, "status", diskVol.Status.Status)
+					(*serverConfig.Spec.Storage)[i] = *diskVol
+					slog.Debug("既存ボリュームの情報設定成功", "disk index", i, "volume id", api.VolumeID(*diskVol), "disk", disk)
+					continue
+				}
 			}
-			if diskVol != nil {
-				slog.Debug("既存ボリュームを使用", "disk index", i, "volume id", api.VolumeID(*diskVol))
 
-				// 永続フラグを立てる
-				var persistent bool = true
-				diskVol.Spec.Persistent = &persistent
-
-				slog.Debug("既存ボリュームの情報取得成功", "disk index", i, "volume id", api.VolumeID(*diskVol), "path", diskVol.Spec.Path, "status", diskVol.Status.Status)
-				(*serverConfig.Spec.Storage)[i] = *diskVol
-				slog.Debug("既存ボリュームの情報設定成功", "disk index", i, "volume id", api.VolumeID(*diskVol), "disk", disk)
-				continue
+			if strings.TrimSpace(disk.Metadata.Name) != "" {
+				disk.Metadata.Name = serverScopedStorageName(disk.Metadata.Name, serverID)
 			}
 
 			if disk.Spec.Type != nil && *disk.Spec.Type == "qcow2" {

--- a/pkg/marmotd/server_storage_volume_naming_test.go
+++ b/pkg/marmotd/server_storage_volume_naming_test.go
@@ -1,0 +1,77 @@
+package marmotd
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/api"
+)
+
+func TestShouldResolvePreCreatedStorageVolume(t *testing.T) {
+	t.Run("returns true when volume id is specified", func(t *testing.T) {
+		disk := api.Volume{Metadata: api.Metadata{Id: "abcde"}}
+		if !shouldResolvePreCreatedStorageVolume(disk) {
+			t.Fatal("shouldResolvePreCreatedStorageVolume() = false, want true")
+		}
+	})
+
+	t.Run("returns true when persistent is true", func(t *testing.T) {
+		persistent := true
+		disk := api.Volume{
+			Metadata: api.Metadata{Name: "shared-data"},
+			Spec:     api.VolSpec{Persistent: &persistent},
+		}
+		if !shouldResolvePreCreatedStorageVolume(disk) {
+			t.Fatal("shouldResolvePreCreatedStorageVolume() = false, want true")
+		}
+	})
+
+	t.Run("returns false for name-only non-persistent request", func(t *testing.T) {
+		disk := api.Volume{Metadata: api.Metadata{Name: "data"}}
+		if shouldResolvePreCreatedStorageVolume(disk) {
+			t.Fatal("shouldResolvePreCreatedStorageVolume() = true, want false")
+		}
+	})
+
+	t.Run("returns false when persistent is explicitly false", func(t *testing.T) {
+		persistent := false
+		disk := api.Volume{
+			Metadata: api.Metadata{Name: "data"},
+			Spec:     api.VolSpec{Persistent: &persistent},
+		}
+		if shouldResolvePreCreatedStorageVolume(disk) {
+			t.Fatal("shouldResolvePreCreatedStorageVolume() = true, want false")
+		}
+	})
+}
+
+func TestServerScopedStorageName(t *testing.T) {
+	t.Run("returns empty for empty name", func(t *testing.T) {
+		if got := serverScopedStorageName("", "12345"); got != "" {
+			t.Fatalf("serverScopedStorageName() = %q, want empty", got)
+		}
+	})
+
+	t.Run("keeps original name when server id is empty", func(t *testing.T) {
+		if got := serverScopedStorageName("data", ""); got != "data" {
+			t.Fatalf("serverScopedStorageName() = %q, want %q", got, "data")
+		}
+	})
+
+	t.Run("appends server id suffix", func(t *testing.T) {
+		if got := serverScopedStorageName("data", "abcde"); got != "data-abcde" {
+			t.Fatalf("serverScopedStorageName() = %q, want %q", got, "data-abcde")
+		}
+	})
+
+	t.Run("does not double append suffix", func(t *testing.T) {
+		if got := serverScopedStorageName("data-abcde", "abcde"); got != "data-abcde" {
+			t.Fatalf("serverScopedStorageName() = %q, want %q", got, "data-abcde")
+		}
+	})
+
+	t.Run("trims input before suffixing", func(t *testing.T) {
+		if got := serverScopedStorageName(" data ", " abcde "); got != "data-abcde" {
+			t.Fatalf("serverScopedStorageName() = %q, want %q", got, "data-abcde")
+		}
+	})
+}


### PR DESCRIPTION
## 概要
Fixes #499

サーバー作成時に、異なるVMで同じ storage.name を指定した場合に同一Volumeが再利用され、qcow2のロック競合でVM作成が失敗する不具合を修正しました。

## 背景
現行実装では、storage の指定が name のみでも既存Volume検索に入り、同名Volumeを再利用するケースがありました。  
その結果、別VM同士で同一Volumeを参照し、後続VMで以下のような失敗が発生していました。

- Failed to get write lock
- Is another process using the image ...?

## 変更内容
- サーバー作成時の「既存Volume再利用条件」を明確化
- 既存Volumeを解決するのは次の場合のみ
  - storage.id が指定されている場合
  - storage.spec.persistent = true の場合
- 上記以外（nameのみ指定の非永続Volume）は新規作成扱いに変更
- 新規作成時は storage.name をサーバー単位にスコープ化
  - 形式: requested-name + "-" + serverId
  - 同名でもVM間で衝突しないようにする
- ノード解決処理でも同じ再利用条件を適用し、nameのみで既存Volume探索しないよう統一

## 期待される効果
- 異なるVMで同じ storage.name を指定しても、別Volumeとして作成される
- qcow2イメージのロック競合によるVM作成失敗を回避
- 事前作成Volumeの再利用（id指定 / persistent=true）は従来どおり維持

## テスト
以下のユニットテストを追加し、回帰防止を確認しました。

- pre-created判定ロジック（id指定 / persistent=true / false）
- serverId付き命名ロジック
  - suffix付与
  - 二重付与防止
  - trim挙動

実行コマンド（抜粋）:
- go test ./pkg/marmotd -run TestShouldResolvePreCreatedStorageVolume|TestServerScopedStorageName|TestChooseAssignedNodeName|TestNodeNameFromResolvedVolumes|TestSelectReusableVolume -count=1

結果:
- pass

## 影響範囲
- サーバー作成時のストレージ解決・命名ロジックのみ
- APIスキーマ変更なし
- 既存の永続Volume再利用ユースケースは維持