### PR TITLE
Volume 0 で作成防止のチェックを追加

### DIFF
--- a/cmd/mactl/cmd/get.go
+++ b/cmd/mactl/cmd/get.go
@@ -1135,8 +1135,8 @@ func outputVolumes(volumes []api.Volume) error {
 		sort.SliceStable(volumes, func(i, j int) bool {
 			return creationTime(volumes[i].Status).Before(creationTime(volumes[j].Status))
 		})
-		fmt.Println("NAME          NODE        KIND  TYPE   iSCSI  SIZE(GB)  STATUS     PATH                  AGE")
-		fmt.Println("----          ----        ----  ----   -----  --------  ------     ----                  ---")
+		fmt.Println("NAME                        NODE        KIND  TYPE   iSCSI  SIZE(GB)  STATUS     PATH                  AGE")
+		fmt.Println("----                        ----        ----  ----   -----  --------  ------     ----                  ---")
 		for _, v := range volumes {
 			size := 0
 			if v.Spec.Size != nil {
@@ -1173,7 +1173,7 @@ func outputVolumes(volumes []api.Volume) error {
 				path = truncatePath(strings.TrimSpace(*v.Spec.Path), 22)
 			}
 
-			fmt.Printf("%-12s  %-10s  %-4s  %-5s  %-5s  %-8d  %-9s  %-20s  %s\n",
+			fmt.Printf("%-26s  %-10s  %-4s  %-5s  %-5s  %-8d  %-9s  %-20s  %s\n",
 				v.Metadata.Name,
 				node,
 				volKind,

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -75,7 +75,7 @@ func shouldResolvePreCreatedStorageVolume(disk api.Volume) bool {
 	return false
 }
 
-func normalizeNewStorageVolumeRequest(disk api.Volume, index int, requireSize bool) (api.Volume, error) {
+func normalizeNewStorageVolumeRequest(disk api.Volume, index int) (api.Volume, error) {
 	volType := strings.TrimSpace(util.OrDefault(disk.Spec.Type, ""))
 	if volType == "" {
 		disk.Spec.Type = util.StringPtr("qcow2")
@@ -86,7 +86,7 @@ func normalizeNewStorageVolumeRequest(disk api.Volume, index int, requireSize bo
 		return api.Volume{}, fmt.Errorf("storage[%d].spec.type must be qcow2 or lvm", index)
 	}
 
-	if requireSize && (disk.Spec.Size == nil || *disk.Spec.Size <= 0) {
+	if volumeKindOrDefault(disk.Spec) == "data" && (disk.Spec.Size == nil || *disk.Spec.Size <= 0) {
 		return api.Volume{}, fmt.Errorf("storage[%d].spec.size must be greater than 0 when creating a new %s volume", index, volType)
 	}
 
@@ -770,7 +770,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 				}
 			}
 
-			disk, err = normalizeNewStorageVolumeRequest(disk, i, requestedName != "")
+			disk, err = normalizeNewStorageVolumeRequest(disk, i)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -66,10 +66,31 @@ func shouldResolvePreCreatedStorageVolume(disk api.Volume) bool {
 	if strings.TrimSpace(api.VolumeID(disk)) != "" {
 		return true
 	}
+	if strings.TrimSpace(disk.Metadata.Name) != "" {
+		return true
+	}
 	if disk.Spec.Persistent != nil && *disk.Spec.Persistent {
 		return true
 	}
 	return false
+}
+
+func normalizeNewStorageVolumeRequest(disk api.Volume, index int, requireSize bool) (api.Volume, error) {
+	volType := strings.TrimSpace(util.OrDefault(disk.Spec.Type, ""))
+	if volType == "" {
+		disk.Spec.Type = util.StringPtr("qcow2")
+		volType = "qcow2"
+	}
+
+	if volType != "qcow2" && volType != "lvm" {
+		return api.Volume{}, fmt.Errorf("storage[%d].spec.type must be qcow2 or lvm", index)
+	}
+
+	if requireSize && (disk.Spec.Size == nil || *disk.Spec.Size <= 0) {
+		return api.Volume{}, fmt.Errorf("storage[%d].spec.size must be greater than 0 when creating a new %s volume", index, volType)
+	}
+
+	return disk, nil
 }
 
 func serverScopedStorageName(name, serverID string) string {
@@ -727,6 +748,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 		for i, disk := range *serverConfig.Spec.Storage {
 			disk.ApiVersion = "v1"
 			disk.Kind = "Volume"
+			requestedName := strings.TrimSpace(disk.Metadata.Name)
 
 			if shouldResolvePreCreatedStorageVolume(disk) {
 				diskVol, err := m.findPreCreatedStorageVolume(disk)
@@ -748,32 +770,24 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 				}
 			}
 
-			if strings.TrimSpace(disk.Metadata.Name) != "" {
+			disk, err = normalizeNewStorageVolumeRequest(disk, i, requestedName != "")
+			if err != nil {
+				return "", err
+			}
+
+			if requestedName != "" {
 				disk.Metadata.Name = serverScopedStorageName(disk.Metadata.Name, serverID)
 			}
 
-			if disk.Spec.Type != nil && *disk.Spec.Type == "qcow2" {
-				slog.Debug("qcow2ボリュームを作成", "disk index", i)
-				assignNodeNameIfUnset(&disk.Metadata, assignedNodeName)
-				diskVol, err := m.CreateNewVolumeWithWait(disk)
-				if err != nil {
-					slog.Error("CreateNewVolumeWithWait()", "err", err)
-					return "", err
-				}
-				(*serverConfig.Spec.Storage)[i] = diskVol
-				slog.Debug("データボリューム 作成成功", "disk index", i, "volume id", api.VolumeID(diskVol))
+			slog.Debug("データボリュームを作成", "disk index", i, "type", util.OrDefault(disk.Spec.Type, ""))
+			assignNodeNameIfUnset(&disk.Metadata, assignedNodeName)
+			diskVol, err := m.CreateNewVolumeWithWait(disk)
+			if err != nil {
+				slog.Error("CreateNewVolumeWithWait()", "err", err)
+				return "", err
 			}
-			if disk.Spec.Type != nil && *disk.Spec.Type == "lvm" {
-				slog.Debug("lvmボリュームを作成", "disk index", i)
-				assignNodeNameIfUnset(&disk.Metadata, assignedNodeName)
-				diskVol, err := m.CreateNewVolumeWithWait(disk)
-				if err != nil {
-					slog.Error("CreateNewVolumeWithWait()", "err", err)
-					return "", err
-				}
-				(*serverConfig.Spec.Storage)[i] = diskVol
-				slog.Debug("データボリューム 作成成功", "disk index", i, "volume id", api.VolumeID(diskVol))
-			}
+			(*serverConfig.Spec.Storage)[i] = diskVol
+			slog.Debug("データボリューム 作成成功", "disk index", i, "volume id", api.VolumeID(diskVol))
 		}
 	}
 

--- a/pkg/marmotd/server_storage_volume_naming_test.go
+++ b/pkg/marmotd/server_storage_volume_naming_test.go
@@ -25,21 +25,36 @@ func TestShouldResolvePreCreatedStorageVolume(t *testing.T) {
 		}
 	})
 
-	t.Run("returns false for name-only non-persistent request", func(t *testing.T) {
+	t.Run("returns true for name-only request without provisioning hints", func(t *testing.T) {
 		disk := api.Volume{Metadata: api.Metadata{Name: "data"}}
-		if shouldResolvePreCreatedStorageVolume(disk) {
-			t.Fatal("shouldResolvePreCreatedStorageVolume() = true, want false")
+		if !shouldResolvePreCreatedStorageVolume(disk) {
+			t.Fatal("shouldResolvePreCreatedStorageVolume() = false, want true")
 		}
 	})
 
-	t.Run("returns false when persistent is explicitly false", func(t *testing.T) {
+	t.Run("returns false for name-only request with provisioning hints", func(t *testing.T) {
+		size := 10
+		typ := "qcow2"
+		disk := api.Volume{
+			Metadata: api.Metadata{Name: "data"},
+			Spec: api.VolSpec{
+				Size: &size,
+				Type: &typ,
+			},
+		}
+		if !shouldResolvePreCreatedStorageVolume(disk) {
+			t.Fatal("shouldResolvePreCreatedStorageVolume() = false, want true")
+		}
+	})
+
+	t.Run("returns true when name exists and persistent is explicitly false", func(t *testing.T) {
 		persistent := false
 		disk := api.Volume{
 			Metadata: api.Metadata{Name: "data"},
 			Spec:     api.VolSpec{Persistent: &persistent},
 		}
-		if shouldResolvePreCreatedStorageVolume(disk) {
-			t.Fatal("shouldResolvePreCreatedStorageVolume() = true, want false")
+		if !shouldResolvePreCreatedStorageVolume(disk) {
+			t.Fatal("shouldResolvePreCreatedStorageVolume() = false, want true")
 		}
 	})
 }
@@ -72,6 +87,45 @@ func TestServerScopedStorageName(t *testing.T) {
 	t.Run("trims input before suffixing", func(t *testing.T) {
 		if got := serverScopedStorageName(" data ", " abcde "); got != "data-abcde" {
 			t.Fatalf("serverScopedStorageName() = %q, want %q", got, "data-abcde")
+		}
+	})
+}
+
+func TestNormalizeNewStorageVolumeRequest(t *testing.T) {
+	t.Run("defaults type to qcow2", func(t *testing.T) {
+		size := 10
+		disk := api.Volume{Spec: api.VolSpec{Size: &size}}
+		got, err := normalizeNewStorageVolumeRequest(disk, 0, true)
+		if err != nil {
+			t.Fatalf("normalizeNewStorageVolumeRequest() unexpected error: %v", err)
+		}
+		if got.Spec.Type == nil || *got.Spec.Type != "qcow2" {
+			t.Fatalf("normalizeNewStorageVolumeRequest() type = %v, want qcow2", got.Spec.Type)
+		}
+	})
+
+	t.Run("rejects missing size when required", func(t *testing.T) {
+		disk := api.Volume{}
+		if _, err := normalizeNewStorageVolumeRequest(disk, 2, true); err == nil {
+			t.Fatal("normalizeNewStorageVolumeRequest() expected error, got nil")
+		}
+	})
+
+	t.Run("rejects unsupported type", func(t *testing.T) {
+		size := 10
+		typ := "raw"
+		disk := api.Volume{Spec: api.VolSpec{Size: &size, Type: &typ}}
+		if _, err := normalizeNewStorageVolumeRequest(disk, 1, true); err == nil {
+			t.Fatal("normalizeNewStorageVolumeRequest() expected error, got nil")
+		}
+	})
+
+	t.Run("accepts lvm with positive size", func(t *testing.T) {
+		size := 1
+		typ := "lvm"
+		disk := api.Volume{Spec: api.VolSpec{Size: &size, Type: &typ}}
+		if _, err := normalizeNewStorageVolumeRequest(disk, 0, true); err != nil {
+			t.Fatalf("normalizeNewStorageVolumeRequest() unexpected error: %v", err)
 		}
 	})
 }

--- a/pkg/marmotd/server_storage_volume_naming_test.go
+++ b/pkg/marmotd/server_storage_volume_naming_test.go
@@ -95,7 +95,7 @@ func TestNormalizeNewStorageVolumeRequest(t *testing.T) {
 	t.Run("defaults type to qcow2", func(t *testing.T) {
 		size := 10
 		disk := api.Volume{Spec: api.VolSpec{Size: &size}}
-		got, err := normalizeNewStorageVolumeRequest(disk, 0, true)
+		got, err := normalizeNewStorageVolumeRequest(disk, 0)
 		if err != nil {
 			t.Fatalf("normalizeNewStorageVolumeRequest() unexpected error: %v", err)
 		}
@@ -104,9 +104,9 @@ func TestNormalizeNewStorageVolumeRequest(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects missing size when required", func(t *testing.T) {
+	t.Run("rejects missing size for data volume", func(t *testing.T) {
 		disk := api.Volume{}
-		if _, err := normalizeNewStorageVolumeRequest(disk, 2, true); err == nil {
+		if _, err := normalizeNewStorageVolumeRequest(disk, 2); err == nil {
 			t.Fatal("normalizeNewStorageVolumeRequest() expected error, got nil")
 		}
 	})
@@ -115,7 +115,7 @@ func TestNormalizeNewStorageVolumeRequest(t *testing.T) {
 		size := 10
 		typ := "raw"
 		disk := api.Volume{Spec: api.VolSpec{Size: &size, Type: &typ}}
-		if _, err := normalizeNewStorageVolumeRequest(disk, 1, true); err == nil {
+		if _, err := normalizeNewStorageVolumeRequest(disk, 1); err == nil {
 			t.Fatal("normalizeNewStorageVolumeRequest() expected error, got nil")
 		}
 	})
@@ -124,7 +124,15 @@ func TestNormalizeNewStorageVolumeRequest(t *testing.T) {
 		size := 1
 		typ := "lvm"
 		disk := api.Volume{Spec: api.VolSpec{Size: &size, Type: &typ}}
-		if _, err := normalizeNewStorageVolumeRequest(disk, 0, true); err != nil {
+		if _, err := normalizeNewStorageVolumeRequest(disk, 0); err != nil {
+			t.Fatalf("normalizeNewStorageVolumeRequest() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("allows os volume without size", func(t *testing.T) {
+		kind := "os"
+		disk := api.Volume{Spec: api.VolSpec{Kind: &kind}}
+		if _, err := normalizeNewStorageVolumeRequest(disk, 0); err != nil {
 			t.Fatalf("normalizeNewStorageVolumeRequest() unexpected error: %v", err)
 		}
 	})


### PR DESCRIPTION
## 概要
Issue #497 の不具合対応として、Server 作成時の storage 解決ロジックを見直し、意図しない 0GB Volume 作成を防止しました。  
あわせて、mactl get vol の NAME 列幅を拡張し、表示崩れを改善しました。

## 背景
storage に metadata.name のみ指定されたケースで、既存 Volume を再利用できず新規作成に進み、結果として size 未指定の 0GB Volume が作成されることがありました。  
期待動作は、まず名前で既存 Volume を検索し、存在すれば再利用、存在しない場合のみ新規作成判定へ進むことです。

## 変更内容
- Server 作成時の storage 解決を「名前優先検索」に変更
- metadata.name がある場合は常に既存 Volume を名前検索
- 既存 Volume が見つかった場合はその Volume を再利用
- 既存 Volume が見つからない場合:
- spec.type が nil なら qcow2 をデフォルト設定
- spec.type は qcow2 または lvm のみ許可
- metadata.name 指定ありの新規作成では spec.size > 0 を必須化
- 条件を満たす新規作成時は、volume 名に server id を付与して作成
- mactl get vol の NAME 列を 26 桁に拡張して列崩れを修正

## 期待される動作
- metadata.name 指定 + 既存あり: 既存 Volume を使用
- metadata.name 指定 + 既存なし + spec.size=nil: エラー
- metadata.name 指定 + 既存なし + spec.size>0 + spec.type in {qcow2,lvm}: name-id で新規作成
- spec.type=nil: qcow2 として扱う

## 影響範囲
- Server 作成フロー（storage 解決・新規作成条件）
- mactl get vol のテキスト表示

## テスト
- 対象ユニットテストを更新・追加し、以下で成功
- go test ./pkg/marmotd -run 'TestShouldResolvePreCreatedStorageVolume|TestServerScopedStorageName|TestNormalizeNewStorageVolumeRequest'

## 関連
- Closes #497