### PR TITLE
ALBの起動失敗原因に対処

### DIFF
--- a/api/marmot-api-v1.go
+++ b/api/marmot-api-v1.go
@@ -95,9 +95,11 @@ type ApplicationLoadBalancerPersistence struct {
 
 // ApplicationLoadBalancerSpec defines model for ApplicationLoadBalancerSpec.
 type ApplicationLoadBalancerSpec struct {
+	BindPublicNetworkName *string                           `json:"bindPublicNetworkName,omitempty" yaml:"bindPublicNetworkName,omitempty"`
 	BindPublicIpAddress    string                            `json:"bindPublicIpAddress" yaml:"bindPublicIpAddress"`
 	InternalVirtualNetwork string                            `json:"internalVirtualNetwork" yaml:"internalVirtualNetwork"`
 	Listeners              []ApplicationLoadBalancerListener `json:"listeners" yaml:"listeners"`
+	Routes                 *[]Route                          `json:"routes,omitempty" yaml:"routes,omitempty"`
 
 	// RemoteCIDR Source CIDR allowed to access load balancer forwarding. Empty means allow all.
 	RemoteCIDR string `json:"remoteCIDR" yaml:"remoteCIDR"`

--- a/api/marmot-api-v1.yaml
+++ b/api/marmot-api-v1.yaml
@@ -1710,8 +1710,17 @@ components:
         - remoteCIDR
         - listeners
       properties:
+        bindPublicNetworkName:
+          type: string
+          description: Public network name for ALB bind address. Defaults to host-bridge.
         bindPublicIpAddress:
           type: string
+          description: Public bind IP address. CIDR form (e.g. 10.10.0.70/24) is also accepted.
+        routes:
+          type: array
+          description: Static routes applied to public NIC.
+          items:
+            $ref: "#/components/schemas/Route"
         internalVirtualNetwork:
           type: string
         remoteCIDR:

--- a/pkg/controller/application-load-balancer-ansible.go
+++ b/pkg/controller/application-load-balancer-ansible.go
@@ -291,8 +291,12 @@ func buildApplicationLoadBalancerHAProxyConfig(loadBalancer api.ApplicationLoadB
 		frontendName := sanitizeHAProxyToken(fmt.Sprintf("%s-fe-%s", id, name))
 		backendName := sanitizeHAProxyToken(fmt.Sprintf("%s-be-%s", id, name))
 
+		bindAddress, _, err := normalizePublicBindAddress(loadBalancer.Spec.BindPublicIpAddress)
+		if err != nil {
+			return "", fmt.Errorf("invalid bindPublicIpAddress: %w", err)
+		}
 		b.WriteString("frontend " + frontendName + "\n")
-		b.WriteString(fmt.Sprintf("  bind %s:%d\n", strings.TrimSpace(loadBalancer.Spec.BindPublicIpAddress), listener.VipPort))
+		b.WriteString(fmt.Sprintf("  bind %s:%d\n", bindAddress, listener.VipPort))
 		b.WriteString("  mode " + mode + "\n")
 		b.WriteString("  default_backend " + backendName + "\n\n")
 

--- a/pkg/controller/application-load-balancer-ansible_test.go
+++ b/pkg/controller/application-load-balancer-ansible_test.go
@@ -96,6 +96,41 @@ func TestBuildApplicationLoadBalancerHAProxyConfig_TCPListenerDoesNotInjectHTTPH
 	}
 }
 
+func TestBuildApplicationLoadBalancerHAProxyConfig_NormalizesCIDRBindAddress(t *testing.T) {
+	loadBalancer := api.ApplicationLoadBalancer{
+		ApiVersion: "v1",
+		Kind:       "ApplicationLoadBalancer",
+		Metadata: api.Metadata{
+			Name: "lb-cidr",
+			Id:   "lb-cidr-1",
+		},
+		Spec: api.ApplicationLoadBalancerSpec{
+			BindPublicIpAddress:    "192.168.1.130/24",
+			InternalVirtualNetwork: "db-net",
+			Listeners: []api.ApplicationLoadBalancerListener{{
+				Name:                   "db-tcp",
+				Protocol:               "TCP",
+				VipPort:                3306,
+				BackendPort:            3306,
+				LoadBalancingAlgorithm: "roundrobin",
+				BackendSelector: api.ApplicationLoadBalancerLabelSelector{
+					MatchLabels: map[string]string{"app": "db"},
+				},
+			}},
+		},
+	}
+
+	cfg, err := buildApplicationLoadBalancerHAProxyConfig(loadBalancer, map[string][]applicationLoadBalancerBackendServer{
+		"db-tcp": {{Name: "db-a", IP: "172.16.20.11"}},
+	})
+	if err != nil {
+		t.Fatalf("buildApplicationLoadBalancerHAProxyConfig() failed: %v", err)
+	}
+	if !strings.Contains(cfg, "bind 192.168.1.130:3306") {
+		t.Fatalf("generated cfg does not normalize CIDR bind address: %s", cfg)
+	}
+}
+
 func TestDesiredApplicationLoadBalancerConfigHash_ChangesWhenBackendsChange(t *testing.T) {
 	loadBalancer := api.ApplicationLoadBalancer{
 		ApiVersion: "v1",

--- a/pkg/controller/application-load-balancer-controller.go
+++ b/pkg/controller/application-load-balancer-controller.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -21,6 +22,7 @@ const (
 	defaultApplicationLoadBalancerControllerIntervalSeconds         = 15
 	defaultApplicationLoadBalancerAgentStateReadMaxFailures         = 3
 	defaultApplicationLoadBalancerAgentStateRecoverySuccessRequired = 2
+	applicationLoadBalancerApplyResultFreshnessThreshold            = 3 * time.Second
 )
 
 var (
@@ -550,7 +552,10 @@ func (c *controller) ensureApplicationLoadBalancerServerEntry(loadBalancer api.A
 }
 
 func (c *controller) buildApplicationLoadBalancerServerSpec(loadBalancer api.ApplicationLoadBalancer, serverName string) (api.Server, error) {
-	publicIP := strings.TrimSpace(loadBalancer.Spec.BindPublicIpAddress)
+	publicIP, cidrMaskLen, err := normalizePublicBindAddress(loadBalancer.Spec.BindPublicIpAddress)
+	if err != nil {
+		return api.Server{}, fmt.Errorf("invalid bindPublicIpAddress: %w", err)
+	}
 	if publicIP == "" {
 		return api.Server{}, fmt.Errorf("load balancer bindPublicIpAddress is empty")
 	}
@@ -558,11 +563,20 @@ func (c *controller) buildApplicationLoadBalancerServerSpec(loadBalancer api.App
 	if internalNetwork == "" {
 		return api.Server{}, fmt.Errorf("load balancer internalVirtualNetwork is empty")
 	}
+	publicNetwork := applicationLoadBalancerPublicNetworkName(loadBalancer.Spec)
 
 	nics := make([]api.NetworkInterface, 0, 2)
-	publicNIC := api.NetworkInterface{Networkname: "host-bridge", Address: util.StringPtr(publicIP)}
-	if maskLen, err := c.lookupNetworkMaskLen("host-bridge"); err == nil && maskLen > 0 {
+	publicNIC := api.NetworkInterface{Networkname: publicNetwork, Address: util.StringPtr(publicIP)}
+	if cidrMaskLen > 0 {
+		publicNIC.Netmasklen = util.IntPtrInt(cidrMaskLen)
+	} else if maskLen, err := c.lookupNetworkMaskLen(publicNetwork); err == nil && maskLen > 0 {
 		publicNIC.Netmasklen = util.IntPtrInt(maskLen)
+	}
+	if loadBalancer.Spec.Routes != nil && len(*loadBalancer.Spec.Routes) > 0 {
+		publicNIC.Routes = loadBalancer.Spec.Routes
+	} else if gw, err := c.lookupNetworkGateway(publicNetwork); err == nil && strings.TrimSpace(gw) != "" {
+		defaultTo := "default"
+		publicNIC.Routes = &[]api.Route{{To: &defaultTo, Via: util.StringPtr(gw)}}
 	}
 	nics = append(nics, publicNIC)
 
@@ -678,12 +692,10 @@ func (c *controller) observeApplicationLoadBalancerAgentState(loadBalancer api.A
 		_ = c.db.UpdateLoadBalancerStatusWithMessage(loadBalancerID, db.LOAD_BALANCER_CONFIGURING, "waiting for load balancer agent to apply desired config")
 		return true
 	}
-	if !stagedAt.IsZero() {
-		if state.LastAppliedAt.IsZero() || state.LastAppliedAt.UTC().Before(stagedAt.UTC()) {
-			_ = c.resetApplicationLoadBalancerAgentStateReadSuccesses(loadBalancerID)
-			_ = c.db.UpdateLoadBalancerStatusWithMessage(loadBalancerID, db.LOAD_BALANCER_CONFIGURING, "waiting for newer load balancer agent apply result")
-			return true
-		}
+	if applicationLoadBalancerAgentApplyResultIsStale(state.LastAppliedAt, stagedAt) {
+		_ = c.resetApplicationLoadBalancerAgentStateReadSuccesses(loadBalancerID)
+		_ = c.db.UpdateLoadBalancerStatusWithMessage(loadBalancerID, db.LOAD_BALANCER_CONFIGURING, "waiting for newer load balancer agent apply result")
+		return true
 	}
 	if err := c.updateApplicationLoadBalancerLabels(loadBalancerID, func(labels map[string]interface{}) {
 		db.SetLoadBalancerAppliedConfigHash(labels, desiredHash)
@@ -702,6 +714,16 @@ func (c *controller) observeApplicationLoadBalancerAgentState(loadBalancer api.A
 	return true
 }
 
+func applicationLoadBalancerAgentApplyResultIsStale(lastAppliedAt, stagedAt time.Time) bool {
+	if stagedAt.IsZero() {
+		return false
+	}
+	if lastAppliedAt.IsZero() {
+		return true
+	}
+	return stagedAt.UTC().Sub(lastAppliedAt.UTC()) >= applicationLoadBalancerApplyResultFreshnessThreshold
+}
+
 func (c *controller) resolveApplicationLoadBalancerTargetAddress(loadBalancer api.ApplicationLoadBalancer) (string, error) {
 	serverID := strings.TrimSpace(applicationLoadBalancerManagedServerID(loadBalancer))
 	if serverID == "" {
@@ -714,14 +736,18 @@ func (c *controller) resolveApplicationLoadBalancerTargetAddress(loadBalancer ap
 	if server.Spec.NetworkInterface == nil {
 		return "", fmt.Errorf("load balancer server has no network interface")
 	}
-	publicIP := strings.TrimSpace(loadBalancer.Spec.BindPublicIpAddress)
+	publicIP, _, err := normalizePublicBindAddress(loadBalancer.Spec.BindPublicIpAddress)
+	if err != nil {
+		return "", fmt.Errorf("invalid bindPublicIpAddress: %w", err)
+	}
+	publicNetwork := applicationLoadBalancerPublicNetworkName(loadBalancer.Spec)
 	for _, nic := range *server.Spec.NetworkInterface {
 		if nic.Address != nil {
 			if ip := strings.TrimSpace(*nic.Address); publicIP != "" && ip == publicIP {
 				return ip, nil
 			}
 		}
-		if strings.TrimSpace(nic.Networkname) == "host-bridge" && nic.Address != nil {
+		if strings.TrimSpace(nic.Networkname) == publicNetwork && nic.Address != nil {
 			if ip := strings.TrimSpace(*nic.Address); ip != "" {
 				return ip, nil
 			}
@@ -731,6 +757,34 @@ func (c *controller) resolveApplicationLoadBalancerTargetAddress(loadBalancer ap
 		return publicIP, nil
 	}
 	return "", fmt.Errorf("load balancer public target address is missing")
+}
+
+func applicationLoadBalancerPublicNetworkName(spec api.ApplicationLoadBalancerSpec) string {
+	if spec.BindPublicNetworkName != nil {
+		if network := strings.TrimSpace(*spec.BindPublicNetworkName); network != "" {
+			return network
+		}
+	}
+	return "host-bridge"
+}
+
+func normalizePublicBindAddress(raw string) (string, int, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", 0, nil
+	}
+	if strings.Contains(trimmed, "/") {
+		ip, ipNet, err := net.ParseCIDR(trimmed)
+		if err != nil {
+			return "", 0, err
+		}
+		bits, _ := ipNet.Mask.Size()
+		return strings.TrimSpace(ip.String()), bits, nil
+	}
+	if parsed := net.ParseIP(trimmed); parsed != nil {
+		return strings.TrimSpace(parsed.String()), 0, nil
+	}
+	return "", 0, fmt.Errorf("invalid ip address %q", trimmed)
 }
 
 func (c *controller) handleApplicationLoadBalancerConfigFailure(loadBalancerID string, err error) {

--- a/pkg/controller/application-load-balancer-controller_test.go
+++ b/pkg/controller/application-load-balancer-controller_test.go
@@ -93,6 +93,150 @@ func TestLoadBalancerControllerStateTransitions(t *testing.T) {
 	}
 }
 
+func TestBuildApplicationLoadBalancerServerSpecSetsDefaultRouteOnPublicNIC(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{
+		db:     database,
+		marmot: &marmotd.Marmot{NodeName: "hvc", Db: database},
+	}
+
+	hostBridge, err := database.CreateVirtualNetwork(api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata:   api.Metadata{Name: "host-bridge"},
+		Spec: api.VirtualNetworkSpec{
+			IPNetworkAddress: util.StringPtr("10.10.0.0/24"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateVirtualNetwork(host-bridge) failed: %v", err)
+	}
+	ipNetID, err := database.CreateIpNetwork(api.VirtualNetworkID(hostBridge), &api.IPNetwork{AddressMaskLen: util.StringPtr("10.10.0.0/24")})
+	if err != nil {
+		t.Fatalf("CreateIpNetwork(host-bridge) failed: %v", err)
+	}
+	hostBridge.Spec.IpNetworkId = util.StringPtr(ipNetID)
+	if err := database.UpdateVirtualNetworkById(api.VirtualNetworkID(hostBridge), hostBridge); err != nil {
+		t.Fatalf("UpdateVirtualNetworkById(host-bridge) failed: %v", err)
+	}
+
+	if _, err := database.CreateVirtualNetwork(api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata:   api.Metadata{Name: "app-net"},
+		Spec: api.VirtualNetworkSpec{
+			IPNetworkAddress: util.StringPtr("172.16.9.0/24"),
+		},
+	}); err != nil {
+		t.Fatalf("CreateVirtualNetwork(app-net) failed: %v", err)
+	}
+
+	lb := api.ApplicationLoadBalancer{
+		ApiVersion: "v1",
+		Kind:       "ApplicationLoadBalancer",
+		Metadata:   api.Metadata{Name: "alb-web"},
+		Spec: api.ApplicationLoadBalancerSpec{
+			BindPublicIpAddress:    "10.10.0.70",
+			InternalVirtualNetwork: "app-net",
+		},
+	}
+
+	serverSpec, err := ctrl.buildApplicationLoadBalancerServerSpec(lb, "lb-alb-web")
+	if err != nil {
+		t.Fatalf("buildApplicationLoadBalancerServerSpec() failed: %v", err)
+	}
+	if serverSpec.Spec.NetworkInterface == nil || len(*serverSpec.Spec.NetworkInterface) == 0 {
+		t.Fatalf("NetworkInterface is empty")
+	}
+
+	publicNIC := (*serverSpec.Spec.NetworkInterface)[0]
+	if publicNIC.Routes == nil || len(*publicNIC.Routes) == 0 {
+		t.Fatalf("public NIC routes are empty")
+	}
+	route := (*publicNIC.Routes)[0]
+	if route.To == nil || strings.TrimSpace(*route.To) != "default" {
+		t.Fatalf("public NIC default route To = %v, want default", route.To)
+	}
+	if route.Via == nil || strings.TrimSpace(*route.Via) != "10.10.0.1" {
+		t.Fatalf("public NIC default route Via = %v, want 10.10.0.1", route.Via)
+	}
+}
+
+func TestBuildApplicationLoadBalancerServerSpecUsesCustomPublicNetworkAndRoutes(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{
+		db:     database,
+		marmot: &marmotd.Marmot{NodeName: "hvc", Db: database},
+	}
+
+	publicNet, err := database.CreateVirtualNetwork(api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata:   api.Metadata{Name: "pub-net"},
+		Spec: api.VirtualNetworkSpec{
+			IPNetworkAddress: util.StringPtr("10.10.0.0/24"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateVirtualNetwork(pub-net) failed: %v", err)
+	}
+	ipNetID, err := database.CreateIpNetwork(api.VirtualNetworkID(publicNet), &api.IPNetwork{AddressMaskLen: util.StringPtr("10.10.0.0/24")})
+	if err != nil {
+		t.Fatalf("CreateIpNetwork(pub-net) failed: %v", err)
+	}
+	publicNet.Spec.IpNetworkId = util.StringPtr(ipNetID)
+	if err := database.UpdateVirtualNetworkById(api.VirtualNetworkID(publicNet), publicNet); err != nil {
+		t.Fatalf("UpdateVirtualNetworkById(pub-net) failed: %v", err)
+	}
+
+	if _, err := database.CreateVirtualNetwork(api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata:   api.Metadata{Name: "app-net"},
+		Spec: api.VirtualNetworkSpec{
+			IPNetworkAddress: util.StringPtr("172.16.9.0/24"),
+		},
+	}); err != nil {
+		t.Fatalf("CreateVirtualNetwork(app-net) failed: %v", err)
+	}
+
+	to := "default"
+	via := "10.10.0.254"
+	pubNetName := "pub-net"
+	lb := api.ApplicationLoadBalancer{
+		ApiVersion: "v1",
+		Kind:       "ApplicationLoadBalancer",
+		Metadata:   api.Metadata{Name: "alb-web"},
+		Spec: api.ApplicationLoadBalancerSpec{
+			BindPublicNetworkName: &pubNetName,
+			BindPublicIpAddress:   "10.10.0.70/24",
+			Routes:                &[]api.Route{{To: &to, Via: &via}},
+			InternalVirtualNetwork: "app-net",
+		},
+	}
+
+	serverSpec, err := ctrl.buildApplicationLoadBalancerServerSpec(lb, "lb-alb-web")
+	if err != nil {
+		t.Fatalf("buildApplicationLoadBalancerServerSpec() failed: %v", err)
+	}
+	publicNIC := (*serverSpec.Spec.NetworkInterface)[0]
+	if publicNIC.Networkname != "pub-net" {
+		t.Fatalf("public NIC networkname = %q, want %q", publicNIC.Networkname, "pub-net")
+	}
+	if publicNIC.Address == nil || strings.TrimSpace(*publicNIC.Address) != "10.10.0.70" {
+		t.Fatalf("public NIC address = %v, want 10.10.0.70", publicNIC.Address)
+	}
+	if publicNIC.Netmasklen == nil || *publicNIC.Netmasklen != 24 {
+		t.Fatalf("public NIC netmasklen = %v, want 24", publicNIC.Netmasklen)
+	}
+	if publicNIC.Routes == nil || len(*publicNIC.Routes) != 1 {
+		t.Fatalf("public NIC routes = %v, want 1 route", publicNIC.Routes)
+	}
+	if gotVia := strings.TrimSpace(util.OrDefault((*publicNIC.Routes)[0].Via, "")); gotVia != via {
+		t.Fatalf("public NIC route via = %q, want %q", gotVia, via)
+	}
+}
+
 func TestLoadBalancerControllerWaitsForAgentApply(t *testing.T) {
 	database := newGatewayTestDatabase(t)
 	setupApplicationLoadBalancerAnsibleTestHooks(t, func(playbookPath, targetAddress, privateKeyPath string) error {
@@ -190,6 +334,24 @@ func TestLoadBalancerControllerWaitsForNewerAgentApplyResult(t *testing.T) {
 	}
 	if afterConfiguring.Status == nil || afterConfiguring.Status.StatusCode != db.LOAD_BALANCER_CONFIGURING {
 		t.Fatalf("load balancer status with stale agent timestamp = %v, want %d(CONFIGURING)", afterConfiguring.Status, db.LOAD_BALANCER_CONFIGURING)
+	}
+}
+
+func TestApplicationLoadBalancerAgentApplyResultIsStale_AllowsUnderThreeSecondsSkew(t *testing.T) {
+	stagedAt := time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC)
+	lastAppliedAt := stagedAt.Add(-2999 * time.Millisecond)
+
+	if applicationLoadBalancerAgentApplyResultIsStale(lastAppliedAt, stagedAt) {
+		t.Fatalf("expected non-stale result when skew is less than 3 seconds")
+	}
+}
+
+func TestApplicationLoadBalancerAgentApplyResultIsStale_RejectsThreeSecondsOrMoreSkew(t *testing.T) {
+	stagedAt := time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC)
+	lastAppliedAt := stagedAt.Add(-3 * time.Second)
+
+	if !applicationLoadBalancerAgentApplyResultIsStale(lastAppliedAt, stagedAt) {
+		t.Fatalf("expected stale result when skew is 3 seconds or more")
 	}
 }
 

--- a/pkg/controller/gateway-controller.go
+++ b/pkg/controller/gateway-controller.go
@@ -456,6 +456,31 @@ func (c *controller) lookupNetworkMaskLen(networkName string) (int, error) {
 	return *ipnet.Netmasklen, nil
 }
 
+func (c *controller) lookupNetworkGateway(networkName string) (string, error) {
+	vnet, err := c.db.GetVirtualNetworkByName(strings.TrimSpace(networkName))
+	if err != nil {
+		return "", err
+	}
+
+	if vnet.Spec.IpNetworkId != nil && strings.TrimSpace(*vnet.Spec.IpNetworkId) != "" {
+		ipnet, err := c.db.GetIpNetworkById(api.VirtualNetworkID(vnet), strings.TrimSpace(*vnet.Spec.IpNetworkId))
+		if err != nil {
+			return "", err
+		}
+		if ipnet.Gateway != nil {
+			if gw := strings.TrimSpace(*ipnet.Gateway); gw != "" {
+				return gw, nil
+			}
+		}
+	}
+
+	if vnet.Spec.IPNetworkAddress != nil && strings.TrimSpace(*vnet.Spec.IPNetworkAddress) != "" {
+		return firstHostAddressFromCIDR(*vnet.Spec.IPNetworkAddress)
+	}
+
+	return "", fmt.Errorf("gateway is empty for %s", networkName)
+}
+
 func (c *controller) deriveGatewayInternalInterfaceAddress(networkName string) (string, error) {
 	vnet, err := c.db.GetVirtualNetworkByName(strings.TrimSpace(networkName))
 	if err != nil {


### PR DESCRIPTION
## 概要
ALB が実際には動作しているにもかかわらず、STATUS が CONFIGURING のまま ACTIVE に遷移しない問題を修正しました。  
あわせて、ALB の public 側ネットワークと route を明示指定できる API 拡張を実施し、default route 欠落を防止します。

## 背景
ALB の状態判定は、lb-agent の lastAppliedHash と lastAppliedAt を使って適用完了を判断しています。  
このうち時刻比較が厳密すぎると、微小な時刻差で newer 判定に失敗し、CONFIGURING に留まるケースがありました。

## 変更内容
- ALB の newer 判定に時刻許容差を導入
- 判定仕様を「3秒未満は許容」に変更
- ALB API に public 側ネットワーク指定を追加
- ALB API に routes 指定を追加し、public NIC の route を明示的に設定可能化
- bindPublicIpAddress が CIDR 形式でも扱えるよう正規化処理を追加
- public ネットワーク名解決用の helper を追加し、controller 間で再利用
- 関連する単体テストを追加・更新

## 期待される効果
- ALB が CONFIGURING から ACTIVE へ遷移しやすくなる
- public 側 default route の欠落を回避できる
- CIDR 指定時の bind 設定不整合を防止できる

## 互換性
- 既存 API は破壊せず、項目追加のみ
- 既存マニフェストはそのまま利用可能
- 新フィールドは必要な場合のみ指定

## 動作確認
- pkg/controller の ALB 関連テストを実行し成功
- 3秒閾値の境界テストを追加し、以下を確認
1. 3秒未満の差分は許容される
2. 3秒以上の差分は待機判定になる
3. 既存の状態遷移テストに回帰がない

## マニフェスト例
spec:
  bindPublicNetworkName: host-bridge
  bindPublicIpAddress: 10.10.0.70/24
  routes:
    - to: default
      via: 10.10.0.1

