### PR TITLE
VPNGWの落ちる原因対応

### DIFF
--- a/api/marmot-api-v1.go
+++ b/api/marmot-api-v1.go
@@ -467,6 +467,7 @@ type VpnGateway struct {
 type VpnGatewaySpec struct {
 	BindPublicIpAddress    string `json:"bindPublicIpAddress" yaml:"bindPublicIpAddress"`
 	InternalVirtualNetwork string `json:"internalVirtualNetwork" yaml:"internalVirtualNetwork"`
+	Routes                 *[]Route `json:"routes,omitempty" yaml:"routes,omitempty"`
 
 	// RemoteCIDRs Source CIDR list allowed to access vpn gateway. Empty means allow all.
 	RemoteCIDRs *[]string `json:"remoteCIDRs,omitempty" yaml:"remoteCIDRs,omitempty"`

--- a/api/marmot-api-v1.yaml
+++ b/api/marmot-api-v1.yaml
@@ -1679,6 +1679,11 @@ components:
           type: string
         internalVirtualNetwork:
           type: string
+        routes:
+          type: array
+          description: Static routes applied to public NIC.
+          items:
+            $ref: "#/components/schemas/Route"
         remoteCIDRs:
           type: array
           description: Source CIDR list allowed to access vpn gateway. Empty means allow all.

--- a/pkg/controller/vpn-gateway-controller.go
+++ b/pkg/controller/vpn-gateway-controller.go
@@ -383,6 +383,12 @@ func (c *controller) buildVpnGatewayServerSpec(vpnGateway api.VpnGateway, server
 	if maskLen, err := c.lookupNetworkMaskLen("host-bridge"); err == nil && maskLen > 0 {
 		publicNIC.Netmasklen = util.IntPtrInt(maskLen)
 	}
+	if vpnGateway.Spec.Routes != nil && len(*vpnGateway.Spec.Routes) > 0 {
+		publicNIC.Routes = vpnGateway.Spec.Routes
+	} else if gw, err := c.lookupNetworkGateway("host-bridge"); err == nil && strings.TrimSpace(gw) != "" {
+		defaultTo := "default"
+		publicNIC.Routes = &[]api.Route{{To: &defaultTo, Via: util.StringPtr(gw)}}
+	}
 	nics = append(nics, publicNIC)
 
 	internalNIC := api.NetworkInterface{Networkname: internalNetwork}

--- a/pkg/controller/vpn-gateway-controller_test.go
+++ b/pkg/controller/vpn-gateway-controller_test.go
@@ -1,0 +1,143 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestBuildVpnGatewayServerSpecSetsDefaultPublicRoute(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{
+		db:     database,
+		marmot: &marmotd.Marmot{NodeName: "hvc", Db: database},
+	}
+
+	hostBridge, err := database.CreateVirtualNetwork(api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata:   api.Metadata{Name: "host-bridge"},
+		Spec: api.VirtualNetworkSpec{
+			IPNetworkAddress: util.StringPtr("10.10.0.0/24"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateVirtualNetwork(host-bridge) failed: %v", err)
+	}
+	ipNetID, err := database.CreateIpNetwork(api.VirtualNetworkID(hostBridge), &api.IPNetwork{AddressMaskLen: util.StringPtr("10.10.0.0/24")})
+	if err != nil {
+		t.Fatalf("CreateIpNetwork(host-bridge) failed: %v", err)
+	}
+	hostBridge.Spec.IpNetworkId = util.StringPtr(ipNetID)
+	if err := database.UpdateVirtualNetworkById(api.VirtualNetworkID(hostBridge), hostBridge); err != nil {
+		t.Fatalf("UpdateVirtualNetworkById(host-bridge) failed: %v", err)
+	}
+
+	if _, err := database.CreateVirtualNetwork(api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata:   api.Metadata{Name: "app-net"},
+		Spec: api.VirtualNetworkSpec{
+			IPNetworkAddress: util.StringPtr("172.16.20.0/24"),
+		},
+	}); err != nil {
+		t.Fatalf("CreateVirtualNetwork(app-net) failed: %v", err)
+	}
+
+	vpnGateway := api.VpnGateway{
+		ApiVersion: "v1",
+		Kind:       "VpnGateway",
+		Metadata:   api.Metadata{Name: "vpn-gw"},
+		Spec: api.VpnGatewaySpec{
+			BindPublicIpAddress:    "10.10.0.40",
+			InternalVirtualNetwork: "app-net",
+		},
+	}
+
+	serverSpec, err := ctrl.buildVpnGatewayServerSpec(vpnGateway, "vgw-vpn-gw")
+	if err != nil {
+		t.Fatalf("buildVpnGatewayServerSpec() failed: %v", err)
+	}
+	if serverSpec.Spec.NetworkInterface == nil || len(*serverSpec.Spec.NetworkInterface) == 0 {
+		t.Fatalf("NetworkInterface is empty")
+	}
+
+	publicNIC := (*serverSpec.Spec.NetworkInterface)[0]
+	if publicNIC.Routes == nil || len(*publicNIC.Routes) == 0 {
+		t.Fatalf("public NIC routes are empty")
+	}
+	route := (*publicNIC.Routes)[0]
+	if route.To == nil || strings.TrimSpace(*route.To) != "default" {
+		t.Fatalf("public NIC default route To = %v, want default", route.To)
+	}
+	if route.Via == nil || strings.TrimSpace(*route.Via) != "10.10.0.1" {
+		t.Fatalf("public NIC default route Via = %v, want 10.10.0.1", route.Via)
+	}
+}
+
+func TestBuildVpnGatewayServerSpecUsesCustomRoutes(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &controller{
+		db:     database,
+		marmot: &marmotd.Marmot{NodeName: "hvc", Db: database},
+	}
+
+	hostBridge, err := database.CreateVirtualNetwork(api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata:   api.Metadata{Name: "host-bridge"},
+		Spec: api.VirtualNetworkSpec{
+			IPNetworkAddress: util.StringPtr("10.10.0.0/24"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateVirtualNetwork(host-bridge) failed: %v", err)
+	}
+	ipNetID, err := database.CreateIpNetwork(api.VirtualNetworkID(hostBridge), &api.IPNetwork{AddressMaskLen: util.StringPtr("10.10.0.0/24")})
+	if err != nil {
+		t.Fatalf("CreateIpNetwork(host-bridge) failed: %v", err)
+	}
+	hostBridge.Spec.IpNetworkId = util.StringPtr(ipNetID)
+	if err := database.UpdateVirtualNetworkById(api.VirtualNetworkID(hostBridge), hostBridge); err != nil {
+		t.Fatalf("UpdateVirtualNetworkById(host-bridge) failed: %v", err)
+	}
+
+	if _, err := database.CreateVirtualNetwork(api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata:   api.Metadata{Name: "app-net"},
+		Spec: api.VirtualNetworkSpec{
+			IPNetworkAddress: util.StringPtr("172.16.20.0/24"),
+		},
+	}); err != nil {
+		t.Fatalf("CreateVirtualNetwork(app-net) failed: %v", err)
+	}
+
+	to := "default"
+	via := "10.10.0.254"
+	vpnGateway := api.VpnGateway{
+		ApiVersion: "v1",
+		Kind:       "VpnGateway",
+		Metadata:   api.Metadata{Name: "vpn-gw"},
+		Spec: api.VpnGatewaySpec{
+			BindPublicIpAddress:    "10.10.0.40",
+			InternalVirtualNetwork: "app-net",
+			Routes:                 &[]api.Route{{To: &to, Via: &via}},
+		},
+	}
+
+	serverSpec, err := ctrl.buildVpnGatewayServerSpec(vpnGateway, "vgw-vpn-gw")
+	if err != nil {
+		t.Fatalf("buildVpnGatewayServerSpec() failed: %v", err)
+	}
+	publicNIC := (*serverSpec.Spec.NetworkInterface)[0]
+	if publicNIC.Routes == nil || len(*publicNIC.Routes) != 1 {
+		t.Fatalf("public NIC routes = %v, want 1 route", publicNIC.Routes)
+	}
+	if gotVia := strings.TrimSpace(util.OrDefault((*publicNIC.Routes)[0].Via, "")); gotVia != via {
+		t.Fatalf("public NIC route via = %q, want %q", gotVia, via)
+	}
+}


### PR DESCRIPTION
## 概要
VPN Gateway の Server Spec 生成時に、public NIC 側のルートが欠落して意図しない経路設定になる問題を修正しました。  
あわせて、VPN Gateway に public NIC 用の routes を明示指定できるよう API を拡張しています。

## 背景
Issue 496 の事象として、VPN Gateway の public NIC にデフォルトルートが入らず、ゲスト OS 側で内部 NIC 側に誤った経路が乗るケースがありました。  
このため、host-bridge のゲートウェイを public NIC のデフォルトルートとして設定するフォールバックを追加しています。

## 変更内容
1. API 拡張
- VpnGatewaySpec に routes を追加
- OpenAPI スキーマにも routes を追加（Route 配列）

2. Controller 修正
- VPN Gateway 作成時、spec.routes が指定されていれば public NIC にそのまま適用
- spec.routes 未指定時は host-bridge の gateway を参照し、default route を自動設定

3. テスト追加
- public NIC に default route が自動設定されることのテストを追加
- custom routes 指定時に指定値が優先されることのテストを追加

## テスト
- go test ./pkg/controller -run TestBuildVpnGatewayServerSpec

## 影響範囲
- VpnGatewaySpec を利用する API クライアントに routes 項目が追加されます（既存指定なしでも後方互換で動作）
- VPN Gateway のネットワーク初期化挙動のみを対象とした変更で、他リソースには直接影響しません

## 関連
- Issue 496