### PR TITLE
mactlリポジトリ作成シェルの改修他

### DIFF
--- a/Makefile.windows
+++ b/Makefile.windows
@@ -1,0 +1,59 @@
+PROGRAMS = mactl marmotd maadm marmot-lb-agent
+.PHONY: all $(PROGRAMS)
+all: $(PROGRAMS)
+
+MAKE = nmake
+CURDIR := $(shell cd)
+TAG := $(shell type TAG)
+BINDIR = dist\marmot-v$(TAG)
+
+$(PROGRAMS):
+	if not exist "$(BINDIR)" mkdir "$(BINDIR)"
+	cd cmd\$@ && $(MAKE) -f Makefile.windows
+
+generate:
+	oapi-codegen -config api\config-v1.yaml api\marmot-api-v1.yaml
+	npx @redocly/cli build-docs api\marmot-api-v1.yaml -o api\marmot-api-v1.html
+	powershell -Command "(Get-Content api\marmot-api-v1.go) | %%{$$_ -replace '``json:\"([^\"]*),omitempty\"``','``json:\"$$1,omitempty\" yaml:\"$$1,omitempty\"``' -replace '``json:\"([^\"]*)\"``','``json:\"$$1\" yaml:\"$$1\"``'} | Set-Content api\marmot-api-v1.go"
+	go mod tidy
+
+setup:
+	set GOFLAGS= && go install golang.org/x/tools/cmd/goimports@latest
+	set GOFLAGS= && go install honnef.co/go/tools/cmd/staticcheck@latest
+	set GOFLAGS= && go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+
+test: setup
+	gofmt -s -l .
+	staticcheck ./...
+
+.PHONY: package
+package: clean all setup
+	@echo $(TAG)
+	if not exist "$(BINDIR)" mkdir "$(BINDIR)"
+	copy TAG pkg\marmotd\version.txt
+	copy TAG cmd\mactl\cmd\version.txt
+	copy TAG cmd\maadm\cmd\version.txt
+	copy cmd\install.bat "$(BINDIR)\install.bat"
+	copy cmd\mactl\.marmot.example "$(BINDIR)\.marmot.example"
+	copy cmd\marmotd\marmot.service "$(BINDIR)\marmot.service"
+	copy cmd\marmotd\marmotd.json "$(BINDIR)\marmotd.json"
+	powershell -Command "Compress-Archive -Path $(BINDIR) -DestinationPath dist\marmot-v$(TAG).zip -Force"
+
+.PHONY: clean
+clean:
+	if exist "dist" rmdir /s /q "dist"
+
+DISTDIR = C:\marmot
+SERVER_EXE = marmotd.exe
+CLIENT_CMD = mactl.exe
+ADMIN_CMD = maadm.exe
+
+.PHONY: install
+install:
+	if exist "$(DISTDIR)" rmdir /s /q "$(DISTDIR)"
+	mkdir "$(DISTDIR)"
+	copy "$(BINDIR)\$(SERVER_EXE)" "$(DISTDIR)"
+	copy "$(BINDIR)\marmot-lb-agent.exe" "$(DISTDIR)"
+	copy "$(BINDIR)\marmot.service" "$(DISTDIR)"
+	copy "$(BINDIR)\$(CLIENT_CMD)" "%USERPROFILE%\AppData\Local\bin\"
+	copy "$(BINDIR)\$(ADMIN_CMD)" "%USERPROFILE%\AppData\Local\bin\"

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -2,7 +2,6 @@ PROGRAMS = mactl marmotd maadm marmot-lb-agent
 .PHONY: all $(PROGRAMS)
 all: $(PROGRAMS)
 
-MAKE = nmake
 CURDIR := $(shell cd)
 TAG := $(shell type TAG)
 BINDIR = dist\marmot-v$(TAG)
@@ -33,7 +32,6 @@ package: clean all setup
 	copy TAG pkg\marmotd\version.txt
 	copy TAG cmd\mactl\cmd\version.txt
 	copy TAG cmd\maadm\cmd\version.txt
-	copy cmd\install.bat "$(BINDIR)\install.bat"
 	copy cmd\mactl\.marmot.example "$(BINDIR)\.marmot.example"
 	copy cmd\marmotd\marmot.service "$(BINDIR)\marmot.service"
 	copy cmd\marmotd\marmotd.json "$(BINDIR)\marmotd.json"

--- a/cmd/mactl/Makefile.windows
+++ b/cmd/mactl/Makefile.windows
@@ -1,0 +1,29 @@
+GO = go
+PROGRAM = mactl
+all: $(PROGRAM)
+
+CURDIR := $(shell cd)
+TAG := $(shell type ..\..\TAG)
+OSNAME = windows
+MARCH = $(shell go env GOARCH)
+BINDIR = ..\..\mactl-v$(TAG).$(OSNAME)-$(MARCH)
+TESTBINDIR = bin
+
+$(PROGRAM):
+	@echo Building for $(BINDIR)
+	if not exist "$(BINDIR)" mkdir "$(BINDIR)"
+	cmd /C "set GOOS=windows&& set GOARCH=$(MARCH)&& $(GO) build -o $(BINDIR)\$@.exe"
+
+.PHONY: clean
+clean:
+	if exist "$(BINDIR)" rmdir /s /q "$(BINDIR)"
+	if exist "$(TESTBINDIR)" rmdir /s /q "$(TESTBINDIR)"
+
+.PHONY: install
+install:
+	if exist "$(BINDIR)\$(PROGRAM).exe" copy "$(BINDIR)\$(PROGRAM).exe" "%USERPROFILE%\AppData\Local\bin\"
+
+.PHONY: test
+test:
+	gofmt -s -l .
+	staticcheck ./...

--- a/cmd/marmot-lb-agent/Makefile.windows
+++ b/cmd/marmot-lb-agent/Makefile.windows
@@ -1,0 +1,21 @@
+GO = go
+PROGRAM = marmot-lb-agent
+
+.PHONY: all $(PROGRAM)
+all: $(PROGRAM)
+
+TAG := $(shell type ..\..\TAG)
+BINDIR = ..\..\dist\marmot-v$(TAG)
+
+$(PROGRAM):
+	@echo $(BINDIR)
+	if not exist "$(BINDIR)" mkdir "$(BINDIR)"
+	$(GO) build -o "$(BINDIR)\$@.exe" $^
+
+.PHONY: clean
+clean:
+	if exist "$(BINDIR)" rmdir /s /q "$(BINDIR)"
+
+.PHONY: install
+install:
+	copy "$(BINDIR)\$(PROGRAM).exe" "%USERPROFILE%\AppData\Local\bin\"

--- a/cmd/marmotd/Makefile.windows
+++ b/cmd/marmotd/Makefile.windows
@@ -1,0 +1,27 @@
+GO = go
+PROGRAM = marmotd
+all: $(PROGRAM)
+
+TAG := $(shell type ..\..\TAG)
+BINDIR = ..\..\dist\marmot-v$(TAG)
+
+$(PROGRAM):
+	@echo $(BINDIR)
+	if not exist "$(BINDIR)" mkdir "$(BINDIR)"
+	$(GO) build -o "$(BINDIR)\$@.exe" $^
+
+.PHONY: clean
+clean:
+	if exist "$(BINDIR)" rmdir /s /q "$(BINDIR)"
+
+.PHONY: install
+install:
+	copy "$(BINDIR)\$(PROGRAM).exe" "%USERPROFILE%\AppData\Local\bin\"
+
+.PHONY: test
+test:
+	$(GO) test -v -race . -ginkgo.v -ginkgo.fail-fast -ginkgo.show-node-events -coverprofile cover.out
+
+.PHONY: set-version
+set-version:
+	powershell -Command "(Get-Content cmd\version._) -replace 'MARMOT_VERSION','$(TAG)' | Set-Content cmd\version.go"

--- a/pkg/config/endpoint-config.go
+++ b/pkg/config/endpoint-config.go
@@ -9,23 +9,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const exampleConfigPath = "/etc/marmot/.marmot.example"
+// defaultMarmotConfig は ~/.marmot が存在しない場合に書き込むデフォルト設定内容
+const defaultMarmotConfig = `current: 0
+endpoints:
+  - http://localhost:8750
+`
 
 // EnsureMarmotConfig は $HOME/.marmot が存在しない場合、
-// /etc/marmot/.marmot.example からコピーして自動作成する。
+// デフォルト設定を直接書き込んで自動作成する。
 func EnsureMarmotConfig() error {
 	dest := MarmotConfigPath()
 	if _, err := os.Stat(dest); err == nil {
 		return nil // すでに存在する
 	}
-	data, err := os.ReadFile(exampleConfigPath)
-	if err != nil {
-		return fmt.Errorf("サンプル設定ファイルが見つかりません (%s): %w", exampleConfigPath, err)
-	}
-	if err := os.WriteFile(dest, data, 0600); err != nil {
+	if err := os.WriteFile(dest, []byte(defaultMarmotConfig), 0600); err != nil {
 		return fmt.Errorf("設定ファイルの作成に失敗しました (%s): %w", dest, err)
 	}
-	slog.Debug("設定ファイルを作成しました", "path", dest, "from", exampleConfigPath)
+	slog.Debug("設定ファイルを作成しました", "path", dest)
 	return nil
 }
 
@@ -37,9 +37,14 @@ type MarmotConfig struct {
 	EndpointComments []string `yaml:"endpointComments,omitempty"`
 }
 
-// MarmotConfigPath は $HOME/.marmot のパスを返す
+// MarmotConfigPath は $HOME/.marmot のパスを返す。
+// Windows では USERPROFILE を HOME の代わりに使う。
 func MarmotConfigPath() string {
-	return filepath.Join(os.Getenv("HOME"), ".marmot")
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	return filepath.Join(home, ".marmot")
 }
 
 // ReadMarmotConfig は指定パスから MarmotConfig を読み込む

--- a/pkg/util/hostbridge.go
+++ b/pkg/util/hostbridge.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package util
 
 import (

--- a/pkg/util/hostbridge_netplan_test.go
+++ b/pkg/util/hostbridge_netplan_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package util
 
 import (

--- a/pkg/util/setup-linux.go
+++ b/pkg/util/setup-linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package util
 
 import (

--- a/pkg/util/setup-linux_identity_test.go
+++ b/pkg/util/setup-linux_identity_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package util
 
 import (

--- a/pkg/util/setup-linux_netplan_unit_test.go
+++ b/pkg/util/setup-linux_netplan_unit_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package util
 
 import (

--- a/pkg/util/setup-linux_test.go
+++ b/pkg/util/setup-linux_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package util_test
 
 import (

--- a/pkg/util/setup-linux_test.go
+++ b/pkg/util/setup-linux_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Linux セットアップ", Ordered, Label("integration", "requ
 		// テスト用のサーバースペックを定義
 		testSpec := api.Server{
 			Metadata: api.Metadata{
-				Id: "a123456",
+				Id:   "a123456",
 				Name: "test-linux",
 				Uuid: util.StringPtr("550e8400-e29b-41d4-a716-446655440000"),
 			},
@@ -135,7 +135,7 @@ var _ = Describe("Linux セットアップ", Ordered, Label("integration", "requ
 		// テスト用のサーバースペックを定義
 		testSpec := api.Server{
 			Metadata: api.Metadata{
-				Id: "b123456",
+				Id:   "b123456",
 				Name: "test-linux-lvm",
 				Uuid: util.StringPtr("550e8400-e29b-41d4-a716-446655440001"),
 			},
@@ -199,7 +199,7 @@ var _ = Describe("Linux セットアップ", Ordered, Label("integration", "requ
 	Context("複数NIC設定のテスト", func() {
 		testSpec := api.Server{
 			Metadata: api.Metadata{
-				Id: "c123456",
+				Id:   "c123456",
 				Name: "test-linux-mh",
 				Uuid: util.StringPtr("550e8400-e29b-41d4-a716-446655440002"),
 			},
@@ -271,7 +271,7 @@ var _ = Describe("Linux セットアップ", Ordered, Label("integration", "requ
 	Context("最大NIC設定のテスト", func() {
 		testSpec := api.Server{
 			Metadata: api.Metadata{
-				Id: "d123456",
+				Id:   "d123456",
 				Name: "test-linux-mh",
 				Uuid: util.StringPtr("550e8400-e29b-41d4-a716-446655440003"),
 			},

--- a/tools/Makefile.windows.mactl
+++ b/tools/Makefile.windows.mactl
@@ -1,0 +1,29 @@
+GO = go
+PROGRAM = mactl
+all: $(PROGRAM)
+
+CURDIR := $(shell cd)
+TAG := $(shell type ..\..\TAG)
+OSNAME = windows
+MARCH = $(shell go env GOARCH)
+BINDIR = ..\..\mactl-v$(TAG).$(OSNAME)-$(MARCH)
+TESTBINDIR = bin
+
+$(PROGRAM):
+	@echo Building for $(BINDIR)
+	if not exist "$(BINDIR)" mkdir "$(BINDIR)"
+	cmd /C "set GOOS=windows&& set GOARCH=$(MARCH)&& $(GO) build -o $(BINDIR)\$@.exe"
+
+.PHONY: clean
+clean:
+	if exist "$(BINDIR)" rmdir /s /q "$(BINDIR)"
+	if exist "$(TESTBINDIR)" rmdir /s /q "$(TESTBINDIR)"
+
+.PHONY: install
+install:
+	if exist "$(BINDIR)\$(PROGRAM).exe" copy "$(BINDIR)\$(PROGRAM).exe" "%USERPROFILE%\AppData\Local\bin\"
+
+.PHONY: test
+test:
+	gofmt -s -l .
+	staticcheck ./...

--- a/tools/Makefile.windows.root
+++ b/tools/Makefile.windows.root
@@ -1,0 +1,46 @@
+PROGRAMS = mactl
+all: $(PROGRAMS)
+
+GO = go
+CURDIR := $(shell cd)
+TAG := $(shell type TAG)
+OSNAME = windows
+MARCH = $(shell go env GOARCH)
+BINDIR = $(CURDIR)\mactl-v$(TAG).$(OSNAME)-$(MARCH)
+
+$(PROGRAMS):
+	if not exist "$(BINDIR)" mkdir "$(BINDIR)"
+	cd cmd\$@ && $(MAKE) -f Makefile.windows
+
+setup:
+	type TAG > cmd\mactl\version.txt
+	set GOFLAGS= && go install golang.org/x/tools/cmd/goimports@latest
+	set GOFLAGS= && go install honnef.co/go/tools/cmd/staticcheck@latest
+	cd $(CURDIR)\pkg\client && go mod tidy
+	cd $(CURDIR)\pkg\config && go mod tidy
+	cd $(CURDIR)\pkg\types && go mod tidy
+	cd $(CURDIR)\api && go mod tidy
+	cd $(CURDIR) && go mod tidy
+
+test:
+	gofmt -s -l .
+	staticcheck ./...
+
+.PHONY: package
+package: clean all
+	@echo $(TAG)
+	powershell -Command "Compress-Archive -Path $(BINDIR) -DestinationPath $(CURDIR)\mactl-v$(TAG).$(OSNAME)-$(MARCH).zip -Force"
+
+.PHONY: clean
+clean:
+	if exist "$(BINDIR)" rmdir /s /q "$(BINDIR)"
+	if exist "mactl-v$(TAG).$(OSNAME)-$(MARCH).zip" del "mactl-v$(TAG).$(OSNAME)-$(MARCH).zip"
+
+DISTDIR = C:\marmot
+CLIENT_CMD = mactl.exe
+
+.PHONY: install
+install:
+	if exist "$(DISTDIR)" rmdir /s /q "$(DISTDIR)"
+	mkdir "$(DISTDIR)"
+	if exist "$(BINDIR)\$(CLIENT_CMD)" copy "$(BINDIR)\$(CLIENT_CMD)" "%USERPROFILE%\AppData\Local\bin\"

--- a/tools/go.mod.api
+++ b/tools/go.mod.api
@@ -3,6 +3,6 @@ module api
 go 1.25.3
 
 require (
-	github.com/labstack/echo/v4 v4.13.4
-	github.com/oapi-codegen/runtime v1.1.2
+	github.com/labstack/echo/v4 v4.15.2
+	github.com/oapi-codegen/runtime v1.4.1
 )

--- a/tools/go.mod.config
+++ b/tools/go.mod.config
@@ -2,9 +2,13 @@ module config
 
 go 1.25.3
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/takara9/marmot/api v0.8.7
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 replace (
+	github.com/takara9/marmot/api => ../../api
 	github.com/takara9/marmot/pkg/client => ../client
 	github.com/takara9/marmot/pkg/config => ../config
 	github.com/takara9/marmot/pkg/types => ../types

--- a/tools/go.mod.root
+++ b/tools/go.mod.root
@@ -1,4 +1,4 @@
-module main
+module github.com/takara9/marmot
 
 go 1.25.3
 

--- a/tools/make-client-repo.sh
+++ b/tools/make-client-repo.sh
@@ -1,50 +1,55 @@
-#!/bin/bash 
+#!/usr/bin/env bash
 
-echo "Creating client repository..."
+set -euo pipefail
 
-TARGET_DIR="mactl"
-echo "Target directory: ${TARGET_DIR}"
-mkdir -p ~/${TARGET_DIR}
-mkdir -p ~/${TARGET_DIR}/api
-mkdir -p ~/${TARGET_DIR}/cmd
-mkdir -p ~/${TARGET_DIR}/cmd/mactl
-mkdir -p ~/${TARGET_DIR}/pkg
-mkdir -p ~/${TARGET_DIR}/pkg/client
-mkdir -p ~/${TARGET_DIR}/pkg/config
-mkdir -p ~/${TARGET_DIR}/pkg/types
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET_ROOT="${1:-${HOME}/mactl}"
 
-cp ../TAG ~/${TARGET_DIR}/TAG
-cp go.mod.root ~/${TARGET_DIR}/go.mod
-cp Makefile.root ~/${TARGET_DIR}/Makefile
-cp go.mod.api ~/${TARGET_DIR}/api/go.mod
-cp go.mod.client ~/${TARGET_DIR}/pkg/client/go.mod
-cp go.mod.config ~/${TARGET_DIR}/pkg/config/go.mod
-cp go.mod.types ~/${TARGET_DIR}/pkg/types/go.mod
-cp Makefile.mactl ~/${TARGET_DIR}/cmd/mactl/Makefile
-cp ../cmd/mactl/main.go ~/${TARGET_DIR}/cmd/mactl
-cp -r ../cmd/mactl/cmd ~/${TARGET_DIR}/cmd/mactl
+echo "Create mactl client repository"
+echo "  source: ${REPO_ROOT}"
+echo "  target: ${TARGET_ROOT}"
 
-cp ../api/marmot-api-v1.go ~/${TARGET_DIR}/api/
-cp ../pkg/config/config.go ~/${TARGET_DIR}/pkg/config
-cp ../pkg/config/hypervisor_config.go ~/${TARGET_DIR}/pkg/config
-cp ../pkg/client/marmot-client.go ~/${TARGET_DIR}/pkg/client
-cp ../pkg/types/types.go ~/${TARGET_DIR}/pkg/types
-
-
-TARGET="github.com/takara9/marmot/cmd/mactl/cmd"
-REPLACE="main/cmd/mactl/cmd"
-sed -i s%${TARGET}%${REPLACE}%g ~/${TARGET_DIR}/cmd/mactl/main.go
-
-# /etc/marmot ディレクトリの作成とコンフィグファイルの配置
-MARMOT_CONF_DIR="/etc/marmot"
-MARMOT_CONF_FILE="${MARMOT_CONF_DIR}/marmotd.json"
-echo "Creating ${MARMOT_CONF_DIR} ..."
-sudo mkdir -p "${MARMOT_CONF_DIR}"
-
-if [ -f "${MARMOT_CONF_FILE}" ]; then
-    echo "Config file already exists: ${MARMOT_CONF_FILE} (skipped)"
-else
-    sudo cp ../cmd/marmotd/testdata/marmotd.json "${MARMOT_CONF_FILE}"
-    sudo chmod 0644 "${MARMOT_CONF_FILE}"
-    echo "Config file installed: ${MARMOT_CONF_FILE}"
+if ! command -v rsync >/dev/null 2>&1; then
+    echo "error: rsync command is required" >&2
+    exit 1
 fi
+
+mkdir -p "${TARGET_ROOT}" \
+         "${TARGET_ROOT}/api" \
+         "${TARGET_ROOT}/cmd/mactl" \
+         "${TARGET_ROOT}/pkg/client" \
+         "${TARGET_ROOT}/pkg/config" \
+         "${TARGET_ROOT}/pkg/db" \
+         "${TARGET_ROOT}/pkg/types" \
+         "${TARGET_ROOT}/pkg/util"
+
+# Root files for standalone client repo.
+cp "${REPO_ROOT}/TAG" "${TARGET_ROOT}/TAG"
+cp "${SCRIPT_DIR}/go.mod.root" "${TARGET_ROOT}/go.mod"
+cp "${SCRIPT_DIR}/Makefile.root" "${TARGET_ROOT}/Makefile"
+cp "${SCRIPT_DIR}/Makefile.windows.root" "${TARGET_ROOT}/Makefile.windows"
+
+# Submodule go.mod files and mactl build Makefile.
+cp "${SCRIPT_DIR}/go.mod.api" "${TARGET_ROOT}/api/go.mod"
+cp "${SCRIPT_DIR}/go.mod.client" "${TARGET_ROOT}/pkg/client/go.mod"
+cp "${SCRIPT_DIR}/go.mod.config" "${TARGET_ROOT}/pkg/config/go.mod"
+cp "${SCRIPT_DIR}/go.mod.types" "${TARGET_ROOT}/pkg/types/go.mod"
+cp "${SCRIPT_DIR}/Makefile.mactl" "${TARGET_ROOT}/cmd/mactl/Makefile"
+cp "${SCRIPT_DIR}/Makefile.windows.mactl" "${TARGET_ROOT}/cmd/mactl/Makefile.windows"
+
+# Sync source trees to follow the latest upstream layout.
+rsync -a --delete --exclude='go.mod' "${REPO_ROOT}/api/" "${TARGET_ROOT}/api/"
+rsync -a --delete --exclude='go.mod' "${REPO_ROOT}/pkg/client/" "${TARGET_ROOT}/pkg/client/"
+rsync -a --delete --exclude='go.mod' "${REPO_ROOT}/pkg/config/" "${TARGET_ROOT}/pkg/config/"
+rsync -a --delete "${REPO_ROOT}/pkg/db/" "${TARGET_ROOT}/pkg/db/"
+rsync -a --delete --exclude='go.mod' "${REPO_ROOT}/pkg/types/" "${TARGET_ROOT}/pkg/types/"
+rsync -a --delete "${REPO_ROOT}/pkg/util/" "${TARGET_ROOT}/pkg/util/"
+rsync -a --delete "${REPO_ROOT}/cmd/mactl/cmd/" "${TARGET_ROOT}/cmd/mactl/cmd/"
+cp "${REPO_ROOT}/cmd/mactl/main.go" "${TARGET_ROOT}/cmd/mactl/main.go"
+
+echo "done"
+echo "next:"
+echo "  cd ${TARGET_ROOT}"
+echo "  make setup"
+echo "  make"


### PR DESCRIPTION
## 概要
`tools/make-client-repo.sh` を最新化して、本体の更新に追随できるようにしました。同時に、Windows でのビルド対応も追加しました。

## 主な変更

### 1. `tools/make-client-repo.sh` の全面改良（Issue #265）

**変更前の問題:**
- 単一ファイルの明示的コピー（`cp ../api/marmot-api-v1.go`）に依存
- ファイル削除や新規追加時に手動更新が必要
- 本体の進化に追随できない

**変更後:**
- `rsync --delete` で `api/`、`pkg/client/`、`pkg/config/`、`pkg/db/`、`pkg/types/`、`pkg/util/`、`cmd/mactl/cmd/` を同期
- 本体が更新されると自動的に生成 repo に反映
- 実行位置に依存しないパス解決（SCRIPT_DIR を基準）
- 出力先を引数指定可能（未指定時は `~/mactl`）

### 2. Go module テンプレートの修正

- `tools/go.mod.root`: `module main` → `module github.com/takara9/marmot`
  - ローカル pkg（db, util など）の import を正しく解決
  
- `tools/go.mod.config`: `github.com/takara9/marmot/api` の require/replace を追加
  - `pkg/config` の `go mod tidy` 時の ambiguous import を解決

- `tools/go.mod.api`: 依存バージョンを最新化
  - `github.com/oapi-codegen/runtime` を v1.1.2 → v1.4.1

### 3. Windows ビルド対応

**新規追加ファイル:**
- `Makefile.windows` (ルート)
- `tools/Makefile.windows.root` (クライアント repo 生成用テンプレート)
- `tools/Makefile.windows.mactl` (mactl ビルド用テンプレット)
- `cmd/mactl/Makefile.windows`
- `cmd/marmotd/Makefile.windows`
- `cmd/maadm/Makefile.windows`
- `cmd/marmot-lb-agent/Makefile.windows`

**特徴:**
- GNU Make for Windows（nmake）対応
- パス区切りを `\` に統一
- `cmd /C` で環境変数を確実に設定してビルド
- 相対パス出力で Quote parsing エラーを回避
- 圧縮は PowerShell `Compress-Archive` で .zip 生成

### 4. Linux 固有コードの build constraints 追加

`pkg/util/` の Linux 専用ファイルに `//go:build linux` を追加:
- `setup-linux.go`
- `setup-linux_test.go`
- `setup-linux_netplan_unit_test.go`
- `setup-linux_identity_test.go`
- `hostbridge.go`
- `hostbridge_netplan_test.go`

→ Windows クロスコンパイル（`GOOS=windows`）で自動的にスキップ

### 5. Windows での config ファイル自動生成

**変更:** `pkg/config/endpoint-config.go`

**変更前:**
- `/etc/marmot/.marmot.example` をコピーして `~/.marmot` を生成
- Windows では `/etc/marmot` が存在しないため失敗

**変更後:**
- デフォルト設定をコード内に直接埋め込み
- `~/.marmot` が存在しない場合、以下の内容で自動生成:
  ```yaml
  current: 0
  endpoints:
    - http://localhost:8750
  ```
- `MarmotConfigPath()` に Windows USERPROFILE フォールバック対応

## 使用方法

### Linux/macOS
```bash
cd tools
./make-client-repo.sh ~/my-mactl
cd ~/my-mactl
make setup
make
```

### Windows
```powershell
cd tools
bash make-client-repo.sh C:\Users\...\mactl
cd mactl
make -f Makefile.windows setup
make -f Makefile.windows
```

## テスト済み環境
- Linux (bash, GNU Make, GOOS/GOARCH)
- Windows (PowerShell, GNU Make for Windows, cross-compile)

## 関連 Issue
- #265: mactl クライアントのリポジトリを作成するシェルを修正する
