### PR TITLE
fix: 仮想ネットワークの status.message が ACTIVE 後に残る不具合を修正 (#386)

### DIFF
--- a/pkg/db/db-virtual_network.go
+++ b/pkg/db/db-virtual_network.go
@@ -364,37 +364,70 @@ func (d *Database) UpdateVirtualNetworkStatus(id string, status int) {
 // UpdateVirtualNetworkStatusWithMessage はステータスとメッセージを同時に更新する。
 // message が空の場合は、ステータスに応じたデフォルト値を設定。
 func (d *Database) UpdateVirtualNetworkStatusWithMessage(id string, status int, message string) {
-	network, err := d.GetVirtualNetworkById(id)
-	if err != nil {
-		if err == ErrNotFound {
-			slog.Warn("UpdateVirtualNetworkStatusWithMessage() skip missing network", "networkId", id, "status", status)
+	for {
+		network, err := d.GetVirtualNetworkById(id)
+		if err != nil {
+			if err == ErrNotFound {
+				slog.Warn("UpdateVirtualNetworkStatusWithMessage() skip missing network", "networkId", id, "status", status)
+				return
+			}
+			slog.Error("UpdateVirtualNetworkStatusWithMessage() GetVirtualNetworkById() failed", "err", err, "networkId", id)
 			return
 		}
-		slog.Error("UpdateVirtualNetworkStatusWithMessage() GetVirtualNetworkById() failed", "err", err, "networkId", id)
-		return
-	}
-	network.Status.StatusCode = status
-	network.Status.Status = util.StringPtr(NetworkStatus[network.Status.StatusCode])
-	network.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
+		if network.Status == nil {
+			network.Status = &api.Status{}
+		}
 
-	// メッセージ設定
-	if status == NETWORK_ACTIVE {
-		network.Status.Message = nil
-	} else if message != "" {
-		network.Status.Message = util.StringPtr(message)
-	} else {
-		// デフォルトメッセージ
-		network.Status.Message = util.StringPtr(defaultMessageForStatus(status))
-	}
+		network.Status.StatusCode = status
+		network.Status.Status = util.StringPtr(NetworkStatus[network.Status.StatusCode])
+		network.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
 
-	if err := d.UpdateVirtualNetworkById(id, network); err != nil {
+		trimmedMessage := strings.TrimSpace(message)
+		if status == NETWORK_ACTIVE {
+			network.Status.Message = nil
+		} else if trimmedMessage != "" {
+			network.Status.Message = util.StringPtr(trimmedMessage)
+		} else {
+			network.Status.Message = util.StringPtr(defaultMessageForStatus(status))
+		}
+
+		err = d.putVirtualNetworkByID(network)
+		if err == ErrUpdateConflict {
+			continue
+		}
 		if err == ErrNotFound {
 			slog.Warn("UpdateVirtualNetworkStatusWithMessage() update skipped; network disappeared", "networkId", id, "status", status)
 			return
 		}
-		slog.Error("UpdateVirtualNetworkStatusWithMessage() UpdateVirtualNetwork() failed", "err", err, "networkId", id)
+		if err != nil {
+			slog.Error("UpdateVirtualNetworkStatusWithMessage() putVirtualNetworkByID() failed", "err", err, "networkId", id)
+		}
 		return
 	}
+}
+
+func (d *Database) putVirtualNetworkByID(rec api.VirtualNetwork) error {
+	id := api.VirtualNetworkID(rec)
+	if strings.TrimSpace(id) == "" {
+		return ErrNotFound
+	}
+
+	lockKey := "/lock/virtualnetwork/" + id
+	mutex, err := d.LockKey(lockKey)
+	if err != nil {
+		return err
+	}
+	defer d.UnlockKey(mutex)
+
+	key := NetworkPrefix + "/" + id
+	var current api.VirtualNetwork
+	resp, err := d.GetJSON(key, &current)
+	if err != nil {
+		return err
+	}
+
+	api.SetVirtualNetworkID(&rec, id)
+	return d.PutJSONCAS(key, resp.Kvs[0].ModRevision, &rec)
 }
 
 // defaultMessageForStatus はステータスコードに対するデフォルトメッセージを返す。

--- a/pkg/db/db-virtual_network_test.go
+++ b/pkg/db/db-virtual_network_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -88,6 +89,48 @@ var _ = Describe("Networks", Ordered, func() {
 				}
 				err = v.UpdateVirtualNetworkById(api.VirtualNetworkID(netSpec), net)
 				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("UpdateVirtualNetworkStatusWithMessage は ACTIVE 遷移時に status.message をクリアする", func() {
+				if v == nil {
+					var createErr error
+					v, createErr = db.NewDatabase(url)
+					Expect(createErr).NotTo(HaveOccurred())
+				}
+
+				if strings.TrimSpace(api.VirtualNetworkID(netSpec)) == "" {
+					net := &api.VirtualNetwork{
+						Metadata: api.Metadata{
+							Name: "net-status-reset",
+						},
+						Spec: api.VirtualNetworkSpec{
+							BridgeName:       util.StringPtr("br-status-reset"),
+							DhcpEndAddress:   util.StringPtr("192.168.123.254"),
+							DhcpStartAddress: util.StringPtr("192.168.123.10"),
+							MacAddress:       util.StringPtr("52:54:00:6b:3c:59"),
+							ForwardMode:      util.StringPtr("NAT"),
+						},
+					}
+					created, createErr := v.CreateVirtualNetwork(*net)
+					Expect(createErr).NotTo(HaveOccurred())
+					netSpec = created
+				}
+
+				id := api.VirtualNetworkID(netSpec)
+
+				v.UpdateVirtualNetworkStatusWithMessage(id, db.NETWORK_PROVISIONING, "provisioning:in-progress")
+				provisioning, getErr := v.GetVirtualNetworkById(id)
+				Expect(getErr).NotTo(HaveOccurred())
+				Expect(provisioning.Status).NotTo(BeNil())
+				Expect(provisioning.Status.Message).NotTo(BeNil())
+				Expect(*provisioning.Status.Message).To(Equal("provisioning:in-progress"))
+
+				v.UpdateVirtualNetworkStatusWithMessage(id, db.NETWORK_ACTIVE, "")
+				active, getErr := v.GetVirtualNetworkById(id)
+				Expect(getErr).NotTo(HaveOccurred())
+				Expect(active.Status).NotTo(BeNil())
+				Expect(active.Status.StatusCode).To(Equal(db.NETWORK_ACTIVE))
+				Expect(active.Status.Message).To(BeNil())
 			})
 
 			It("Keyからネットワーク情報を取得", func() {


### PR DESCRIPTION
概要
- Issue #386 の修正です。
- 仮想ネットワークが ACTIVE になった後も status.message が provisioning のまま残る問題を解消しました。

原因
- ステータス更新が PatchStruct 経由だったため、nil への更新が反映されず、古い message が残っていました。

変更内容
- VirtualNetwork のステータス更新処理を CAS フルライト方式に変更
- ACTIVE 遷移時は status.message を明示的にクリア
- 回帰テストを追加（PROVISIONING → ACTIVE で message が nil になることを確認）

確認結果
- go test ./pkg/db -run TestDb -ginkgo.focus "ACTIVE 遷移時"
- 実行結果: PASS
