### PR TITLE
bridge, host-bridgeのTS修正

### DIFF
--- a/pkg/marmotd/network.go
+++ b/pkg/marmotd/network.go
@@ -29,7 +29,6 @@ func mergeImportedNetworkPreservingCreation(existing api.VirtualNetwork, importe
 	merged.ApiVersion = imported.ApiVersion
 	merged.Kind = imported.Kind
 	merged.Metadata.Name = imported.Metadata.Name
-	merged.Metadata.Uuid = imported.Metadata.Uuid
 	if strings.TrimSpace(nodeName) != "" {
 		merged.Metadata.NodeName = util.StringPtr(strings.TrimSpace(nodeName))
 	}

--- a/pkg/marmotd/network.go
+++ b/pkg/marmotd/network.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/takara9/marmot/api"
@@ -13,6 +14,58 @@ import (
 	"libvirt.org/go/libvirt"
 	"libvirt.org/go/libvirtxml"
 )
+
+func shouldPreserveSystemNetworkCreationTimestamp(name string) bool {
+	switch strings.TrimSpace(name) {
+	case "default", "host-bridge":
+		return true
+	default:
+		return false
+	}
+}
+
+func mergeImportedNetworkPreservingCreation(existing api.VirtualNetwork, imported api.VirtualNetwork, nodeName string, now time.Time) api.VirtualNetwork {
+	merged := existing
+	merged.ApiVersion = imported.ApiVersion
+	merged.Kind = imported.Kind
+	merged.Metadata.Name = imported.Metadata.Name
+	merged.Metadata.Uuid = imported.Metadata.Uuid
+	if strings.TrimSpace(nodeName) != "" {
+		merged.Metadata.NodeName = util.StringPtr(strings.TrimSpace(nodeName))
+	}
+	merged.Spec = imported.Spec
+	if merged.Status == nil {
+		merged.Status = &api.Status{}
+	}
+	if merged.Status.CreationTimeStamp == nil {
+		merged.Status.CreationTimeStamp = util.TimePtr(now)
+	}
+	merged.Status.StatusCode = db.NETWORK_ACTIVE
+	merged.Status.Status = util.StringPtr(db.NetworkStatus[db.NETWORK_ACTIVE])
+	merged.Status.LastUpdateTimeStamp = util.TimePtr(now)
+	merged.Status.Message = nil
+	return merged
+}
+
+func findNetworkByNameAndNode(networks []api.VirtualNetwork, name string, nodeName string) (api.VirtualNetwork, bool) {
+	targetName := strings.TrimSpace(name)
+	targetNode := strings.TrimSpace(nodeName)
+	for _, network := range networks {
+		if strings.TrimSpace(network.Metadata.Name) != targetName {
+			continue
+		}
+		if targetNode == "" {
+			return network, true
+		}
+		if network.Metadata.NodeName == nil {
+			continue
+		}
+		if strings.TrimSpace(*network.Metadata.NodeName) == targetNode {
+			return network, true
+		}
+	}
+	return api.VirtualNetwork{}, false
+}
 
 // 起動時に既存ネットワークを取得して、データベースへの登録
 func (m *Marmot) GetVirtualNetworksAndPutDB() ([]api.VirtualNetwork, error) {
@@ -95,14 +148,32 @@ func (m *Marmot) GetVirtualNetworksAndPutDB() ([]api.VirtualNetwork, error) {
 
 		// TODO: VLAN Trunk を追加
 
-		// 同じ名前のネットワークが既にETCDに登録されているか確認
-		existingNet, err := m.Db.GetVirtualNetworkByName(name)
-		if err == nil {
+		// 同じ名前・同じノードのネットワークが既にETCDに登録されているか確認
+		networksInDB, err := m.Db.GetVirtualNetworks()
+		if err != nil {
+			slog.Error("Failed to list virtual networks from ETCD", "err", err)
+			continue
+		}
+		existingNet, found := findNetworkByNameAndNode(networksInDB, name, m.NodeName)
+		if found {
 			if networkDeletionRequested(existingNet) {
 				slog.Debug("Skipping libvirt network import because deletion is already requested for same-name network", "networkName", name, "existingNetworkId", api.VirtualNetworkID(existingNet))
 				continue
 			}
-			if existingNet.Metadata.Uuid != net.Metadata.Uuid {
+			existingUUID := strings.TrimSpace(util.OrDefault(existingNet.Metadata.Uuid, ""))
+			importedUUID := strings.TrimSpace(util.OrDefault(net.Metadata.Uuid, ""))
+			if existingUUID != importedUUID {
+				if shouldPreserveSystemNetworkCreationTimestamp(name) && existingNet.Status != nil && existingNet.Status.CreationTimeStamp != nil {
+					merged := mergeImportedNetworkPreservingCreation(existingNet, net, m.NodeName, time.Now())
+					err := m.Db.UpdateVirtualNetworkById(api.VirtualNetworkID(existingNet), merged)
+					if err != nil {
+						slog.Error("Failed to preserve system network creation timestamp", "err", err, "networkName", name, "networkId", api.VirtualNetworkID(existingNet))
+						continue
+					}
+					apiNetworks = append(apiNetworks, merged)
+					continue
+				}
+
 				err := m.Db.DeleteVirtualNetworkById(api.VirtualNetworkID(existingNet))
 				if err != nil {
 					slog.Error("Failed to delete existing virtual network in ETCD", "err", err, "networkId", api.VirtualNetworkID(existingNet))
@@ -330,16 +401,37 @@ func (m *Marmot) CheckVirtualNetworks() error {
 			continue
 		}
 
-		// 同じ名前のネットワークが既にETCDに登録されている場合は、何もしない。
-		existingNet, err := m.Db.GetVirtualNetworkByName(vnet.Metadata.Name)
-		if err != nil {
-			if err != db.ErrNotFound {
-				slog.Error("Failed to check existing virtual network in ETCD", "err", err, "networkName", vnet.Metadata.Name)
+		// 同じ名前・同じノードのネットワークが既にETCDに登録されている場合は、UUID差分を確認する。
+		networksInDB, listErr := m.Db.GetVirtualNetworks()
+		if listErr != nil {
+			slog.Error("Failed to list virtual networks from ETCD", "err", listErr)
+			continue
+		}
+		existingNet, found := findNetworkByNameAndNode(networksInDB, vnet.Metadata.Name, m.NodeName)
+		if found {
+			if networkDeletionRequested(existingNet) {
+				slog.Debug("Skipping libvirt network import because deletion is already requested for same-name network", "networkName", vnet.Metadata.Name, "existingNetworkId", api.VirtualNetworkID(existingNet))
 				continue
 			}
-		} else if networkDeletionRequested(existingNet) {
-			slog.Debug("Skipping libvirt network import because deletion is already requested for same-name network", "networkName", vnet.Metadata.Name, "existingNetworkId", api.VirtualNetworkID(existingNet))
-			continue
+
+			existingUUID := strings.TrimSpace(util.OrDefault(existingNet.Metadata.Uuid, ""))
+			importedUUID := strings.TrimSpace(util.OrDefault(vnet.Metadata.Uuid, ""))
+			if existingUUID != importedUUID {
+				if shouldPreserveSystemNetworkCreationTimestamp(vnet.Metadata.Name) && existingNet.Status != nil && existingNet.Status.CreationTimeStamp != nil {
+					merged := mergeImportedNetworkPreservingCreation(existingNet, *vnet, m.NodeName, time.Now())
+					if err := m.Db.UpdateVirtualNetworkById(api.VirtualNetworkID(existingNet), merged); err != nil {
+						slog.Error("Failed to preserve system network creation timestamp", "err", err, "networkName", vnet.Metadata.Name, "networkId", api.VirtualNetworkID(existingNet))
+						continue
+					}
+					m.Db.UpdateVirtualNetworkStatus(api.VirtualNetworkID(existingNet), db.NETWORK_ACTIVE)
+					continue
+				}
+
+				if err := m.Db.DeleteVirtualNetworkById(api.VirtualNetworkID(existingNet)); err != nil {
+					slog.Error("Failed to delete existing virtual network in ETCD", "err", err, "networkId", api.VirtualNetworkID(existingNet))
+					continue
+				}
+			}
 		}
 
 		// 既にETCDに登録されているか確認

--- a/pkg/marmotd/network_import_timestamp_test.go
+++ b/pkg/marmotd/network_import_timestamp_test.go
@@ -80,7 +80,7 @@ func TestMergeImportedNetworkPreservingCreation(t *testing.T) {
 	if merged.Status.Status == nil || *merged.Status.Status != db.NetworkStatus[db.NETWORK_ACTIVE] {
 		t.Fatalf("status mismatch: got %v want %s", merged.Status.Status, db.NetworkStatus[db.NETWORK_ACTIVE])
 	}
-	if merged.Metadata.Uuid == nil || *merged.Metadata.Uuid != "new-uuid" {
-		t.Fatalf("uuid should be updated from import")
+	if merged.Metadata.Uuid == nil || *merged.Metadata.Uuid != "old-uuid" {
+		t.Fatalf("uuid should remain stable, got %v", merged.Metadata.Uuid)
 	}
 }

--- a/pkg/marmotd/network_import_timestamp_test.go
+++ b/pkg/marmotd/network_import_timestamp_test.go
@@ -1,0 +1,86 @@
+package marmotd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestShouldPreserveSystemNetworkCreationTimestamp(t *testing.T) {
+	if !shouldPreserveSystemNetworkCreationTimestamp("default") {
+		t.Fatalf("default should be treated as creation timestamp preserved network")
+	}
+	if !shouldPreserveSystemNetworkCreationTimestamp("host-bridge") {
+		t.Fatalf("host-bridge should be treated as creation timestamp preserved network")
+	}
+	if shouldPreserveSystemNetworkCreationTimestamp("app-net") {
+		t.Fatalf("app-net should not be treated as creation timestamp preserved network")
+	}
+}
+
+func TestMergeImportedNetworkPreservingCreation(t *testing.T) {
+	createdAt := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 6, 26, 9, 30, 0, 0, time.UTC)
+
+	existing := api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata: api.Metadata{
+			Id:       "abcde",
+			Name:     "default",
+			NodeName: util.StringPtr("node-a"),
+			Uuid:     util.StringPtr("old-uuid"),
+		},
+		Spec: api.VirtualNetworkSpec{
+			BridgeName: util.StringPtr("virbr0"),
+		},
+		Status: &api.Status{
+			CreationTimeStamp:   util.TimePtr(createdAt),
+			LastUpdateTimeStamp: util.TimePtr(createdAt),
+			StatusCode:          db.NETWORK_PENDING,
+			Status:              util.StringPtr(db.NetworkStatus[db.NETWORK_PENDING]),
+		},
+	}
+
+	imported := api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata: api.Metadata{
+			Name: "default",
+			Uuid: util.StringPtr("new-uuid"),
+		},
+		Spec: api.VirtualNetworkSpec{
+			BridgeName: util.StringPtr("virbr0"),
+		},
+	}
+
+	merged := mergeImportedNetworkPreservingCreation(existing, imported, "node-a", now)
+
+	if merged.Status == nil {
+		t.Fatalf("merged status should not be nil")
+	}
+	if merged.Status.CreationTimeStamp == nil {
+		t.Fatalf("creation timestamp should be preserved")
+	}
+	if !merged.Status.CreationTimeStamp.Equal(createdAt) {
+		t.Fatalf("creation timestamp changed: got %v want %v", *merged.Status.CreationTimeStamp, createdAt)
+	}
+	if merged.Status.LastUpdateTimeStamp == nil {
+		t.Fatalf("last update timestamp should be set")
+	}
+	if !merged.Status.LastUpdateTimeStamp.Equal(now) {
+		t.Fatalf("last update timestamp mismatch: got %v want %v", *merged.Status.LastUpdateTimeStamp, now)
+	}
+	if merged.Status.StatusCode != db.NETWORK_ACTIVE {
+		t.Fatalf("status code mismatch: got %d want %d", merged.Status.StatusCode, db.NETWORK_ACTIVE)
+	}
+	if merged.Status.Status == nil || *merged.Status.Status != db.NetworkStatus[db.NETWORK_ACTIVE] {
+		t.Fatalf("status mismatch: got %v want %s", merged.Status.Status, db.NetworkStatus[db.NETWORK_ACTIVE])
+	}
+	if merged.Metadata.Uuid == nil || *merged.Metadata.Uuid != "new-uuid" {
+		t.Fatalf("uuid should be updated from import")
+	}
+}


### PR DESCRIPTION
## 概要
Issue #441 に対応し、marmotd 起動時の仮想ネットワーク取り込み処理で、host-bridge / default の status.creationTimeStamp を不用意に更新しないよう修正しました。  
既存エントリがある場合は creationTimeStamp を保持し、status.lastUpdateTimeStamp のみ更新します。

## 背景
起動時に libvirt 側ネットワークを ETCD へ再同期する際、同名ネットワークの UUID 差分などで delete + recreate が起きると creationTimeStamp が再生成され、AGE が若返って表示順が変わり、運用上わかりづらくなる問題がありました。

## 変更内容
- 起動時インポート処理で、同名判定を name + nodeName で行うように変更
- host-bridge / default は UUID 差分があっても delete + recreate せず、既存レコードを in-place 更新
- in-place 更新時は以下を保証
1. status.creationTimeStamp は保持
2. status.lastUpdateTimeStamp は現在時刻に更新
3. status は ACTIVE に更新
- 同様のロジックを起動時取り込みと定期整合チェックの両方に適用

## テスト
追加:
- TestShouldPreserveSystemNetworkCreationTimestamp
- TestMergeImportedNetworkPreservingCreation

実行:
- go test ./pkg/marmotd -run 'TestShouldPreserveSystemNetworkCreationTimestamp|TestMergeImportedNetworkPreservingCreation'

結果:
- pass

## 影響範囲
- marmotd のネットワーク同期ロジックのみ
- API 仕様変更なし
- 既存の一般ネットワーク挙動は維持（予約ネットワークのみ作成時刻保持ポリシーを適用）

## 関連 Issue
- Closes #441
