### PR TITLE
delete/delを両方使えるようにする

### DIFF
--- a/cmd/mactl/cmd/del.go
+++ b/cmd/mactl/cmd/del.go
@@ -12,10 +12,11 @@ import (
 var delManifestFile string
 
 var delCmd = &cobra.Command{
-	Use:   "del [RESOURCE NAME]",
-	Short: "Delete a resource",
-	Long:  `Delete a resource (server/srv, image/img, volume/vol, network/net, gateway/gw, vpngateway/vpngw, applicationloadbalancer/alb, networkloadbalancer/nlb) with NAME specified. With -f, process manifest(s) and delete by metadata.name for each document.`,
-	Args:  cobra.ArbitraryArgs,
+	Use:     "del [RESOURCE NAME]",
+	Aliases: []string{"delete"},
+	Short:   "Delete a resource",
+	Long:    `Delete a resource (server/srv, image/img, volume/vol, network/net, gateway/gw, vpngateway/vpngw, applicationloadbalancer/alb, networkloadbalancer/nlb) with NAME specified. With -f, process manifest(s) and delete by metadata.name for each document.`,
+	Args:    cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if strings.TrimSpace(delManifestFile) != "" {
 			if len(args) > 1 {

--- a/cmd/mactl/cmd/del_alias_test.go
+++ b/cmd/mactl/cmd/del_alias_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "testing"
+
+func TestDeleteAliasResolvesToDelCommand(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"delete"})
+	if err != nil {
+		t.Fatalf("Find(delete) returned error: %v", err)
+	}
+	if cmd == nil {
+		t.Fatalf("Find(delete) returned nil command")
+	}
+	if cmd.Name() != delCmd.Name() {
+		t.Fatalf("Find(delete) resolved to %q, want %q", cmd.Name(), delCmd.Name())
+	}
+
+	aliasCmd, _, err := rootCmd.Find([]string{"del"})
+	if err != nil {
+		t.Fatalf("Find(del) returned error: %v", err)
+	}
+	if aliasCmd == nil {
+		t.Fatalf("Find(del) returned nil command")
+	}
+	if aliasCmd.Name() != delCmd.Name() {
+		t.Fatalf("Find(del) resolved to %q, want %q", aliasCmd.Name(), delCmd.Name())
+	}
+}


### PR DESCRIPTION
## 概要
mactl に `delete` サブコマンドの別名を追加し、`mactl delete RESOURCE NAME` でも既存の削除処理が実行されるようにしました。

## 変更内容
- `del` コマンドに `delete` を alias として追加
- `mactl del ...` と `mactl delete ...` の両方を同じ処理にルーティング
- 回帰防止として、`delete` と `del` の両方が同じコマンドに解決されるテストを追加

## 動作確認
- `go test ./cmd/mactl/cmd -run TestDeleteAliasResolvesToDelCommand`

## 関連 Issue
- Closes #500

