### PR TITLE
mactl get でカンマ区切り複数リソース指定をサポート（#469）

### DIFF
--- a/cmd/mactl/cmd/get.go
+++ b/cmd/mactl/cmd/get.go
@@ -23,7 +23,7 @@ var getManifestFile string
 var getCmd = &cobra.Command{
 	Use:   "get [RESOURCE [NAME]]",
 	Short: "Get resource(s) of a specific type",
-	Long:  `Get resource(s) (server/srv, image/img, volume/vol, network/net, gateway/gw, vpngateway/vpngw, applicationloadbalancer/alb, networkloadbalancer/nlb). If NAME is provided, show only that resource. Otherwise, list all resources. With -f, process manifest(s) and query by metadata.name for each document.`,
+	Long:  `Get resource(s) (server/srv, image/img, volume/vol, network/net, gateway/gw, vpngateway/vpngw, applicationloadbalancer/alb, networkloadbalancer/nlb). If NAME is provided, show only that resource. Otherwise, list all resources. RESOURCE supports comma-separated values such as "srv,net". With -f, process manifest(s) and query by metadata.name for each document.`,
 	Args:  cobra.ArbitraryArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if strings.TrimSpace(getManifestFile) != "" {
@@ -59,17 +59,48 @@ var getCmd = &cobra.Command{
 			return fmt.Errorf("resource is required unless -f is specified")
 		}
 
-		resourceName := args[0]
-		resourceName = normalizeResourceName(resourceName)
+		resourceNames, err := parseGetResourceNames(args[0])
+		if err != nil {
+			return err
+		}
 
-		// NAME が指定されているかチェック
-		var resourceSpec string
+		// NAME 指定は単一リソース時のみ許可
+		if len(resourceNames) > 1 && len(args) > 1 {
+			return fmt.Errorf("NAME is not supported when multiple resources are specified")
+		}
+
+		// 単一リソースの場合のみ NAME を適用
+		resourceSpec := ""
 		if len(args) > 1 {
 			resourceSpec = args[1]
 		}
 
-		return getResourceByTypeAndName(resourceName, resourceSpec)
+		for i, resourceName := range resourceNames {
+			if i > 0 {
+				fmt.Println()
+			}
+			if err := getResourceByTypeAndName(resourceName, resourceSpec); err != nil {
+				return fmt.Errorf("resource %q: %w", resourceName, err)
+			}
+		}
+
+		return nil
 	},
+}
+
+func parseGetResourceNames(resourceArg string) ([]string, error) {
+	parts := strings.Split(resourceArg, ",")
+	resourceNames := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		name := normalizeResourceName(strings.TrimSpace(part))
+		if name == "" {
+			return nil, fmt.Errorf("resource is required unless -f is specified")
+		}
+		resourceNames = append(resourceNames, name)
+	}
+
+	return resourceNames, nil
 }
 
 func getResourceByTypeAndName(resourceName string, resourceSpec string) error {

--- a/cmd/mactl/cmd/kubectl_commands_test.go
+++ b/cmd/mactl/cmd/kubectl_commands_test.go
@@ -71,6 +71,25 @@ var _ = Describe("kubectl-like commands", Ordered, func() {
 		})
 	})
 
+	Describe("parseGetResourceNames", func() {
+		It("parses comma separated resources and normalizes aliases", func() {
+			resources, err := parseGetResourceNames("srv,net,vol")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resources).To(Equal([]string{"server", "network", "volume"}))
+		})
+
+		It("trims spaces around each resource", func() {
+			resources, err := parseGetResourceNames(" srv , net ")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resources).To(Equal([]string{"server", "network"}))
+		})
+
+		It("returns error when empty resource is included", func() {
+			_, err := parseGetResourceNames("srv,,net")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Describe("ApplyServerDefaults", func() {
 		It("handles nil server gracefully", func() {
 			Expect(func() {


### PR DESCRIPTION
概要  
Issue #469 の要望に対応し、mactl get で srv,net のようなカンマ区切り指定を受け付けるようにしました。  
あわせて、複数リソース表示時に各リソースブロックの間へ空行を入れ、視認性を改善しています。

背景  
従来は mactl get srv,net を unknown resource type として扱っており、複数種類のリソース一覧を一度に確認できませんでした。

変更内容  
1. get の引数解析を拡張  
- リソース引数をカンマで分割して順次処理するように変更  
- エイリアス正規化（srv→server、net→network など）は既存ロジックを利用

2. 不正な組み合わせを明示的にエラー化  
- 複数リソース指定時の NAME 指定を禁止  
- 例: srv,net my-name はエラー

3. 表示の可読性向上  
- 複数リソースを連続表示する際、ブロック間に 1 行の空行を追加

4. ヘルプ文の更新  
- RESOURCE にカンマ区切り指定が可能であることを説明文へ追記

5. テスト追加  
- カンマ区切りの正常系（srv,net,vol）  
- 各要素の前後空白のトリム  
- 空要素を含む異常系（srv,,net）

期待される効果  
- 複数リソースの状態確認を 1 コマンドで実行可能  
- 日常運用時の確認コストを削減  
- 出力の読みやすさを改善

動作イメージ  
- mactl get srv,net  
  - server 一覧を表示  
  - 空行  
  - network 一覧を表示

テスト  
- go test ./cmd/mactl/cmd -run TestCmd -count=1  
- 結果: 成功

互換性  
- 単一リソース指定（例: mactl get srv）は従来どおり動作  
- 既存のリソース名エイリアスも従来どおり利用可能