### PR TITLE
イメージのsyncの表示改善

### DIFF
--- a/cmd/mactl/cmd/get.go
+++ b/cmd/mactl/cmd/get.go
@@ -370,8 +370,17 @@ func getImageResources(name string) error {
 			images = filterImagesByLabel(images, labelSelector)
 		}
 
+		clusterNodeCount := 0
+		clusterBody, _, clusterErr := m.GetMarmotCluster()
+		if clusterErr == nil {
+			var statuses []api.HostStatus
+			if err := json.Unmarshal(clusterBody, &statuses); err == nil {
+				clusterNodeCount = len(statuses)
+			}
+		}
+
 		// 出力
-		return outputImages(images)
+		return outputImages(images, clusterNodeCount)
 	}
 
 	return runList(listFn)
@@ -939,7 +948,7 @@ func outputServers(servers []api.Server) error {
 	}
 }
 
-func outputImages(images []api.Image) error {
+func outputImages(images []api.Image, clusterNodeCount int) error {
 	switch outputStyle {
 	case "text":
 		if getServerShowAll {
@@ -987,7 +996,7 @@ func outputImages(images []api.Image) error {
 			return nil
 		}
 
-		aggregated := summarizeImages(images)
+		aggregated := summarizeImagesWithTotalNodes(images, clusterNodeCount)
 		sort.SliceStable(aggregated, func(i, j int) bool {
 			return creationTime(aggregated[i].ageStatus).Before(creationTime(aggregated[j].ageStatus))
 		})
@@ -1033,7 +1042,13 @@ type imageSummary struct {
 }
 
 func summarizeImages(images []api.Image) []imageSummary {
-	totalNodes := collectUniqueNodeCount(images)
+	return summarizeImagesWithTotalNodes(images, 0)
+}
+
+func summarizeImagesWithTotalNodes(images []api.Image, totalNodes int) []imageSummary {
+	if totalNodes <= 0 {
+		totalNodes = collectUniqueNodeCount(images)
+	}
 	byName := map[string][]api.Image{}
 	for _, img := range images {
 		name := strings.TrimSpace(img.Metadata.Name)
@@ -1096,11 +1111,14 @@ func summarizeImageGroup(name string, images []api.Image, totalNodes int) imageS
 		expectedNodes = len(nodeSet)
 	}
 	uniform := len(statusSet) == 1 && len(qcow2Set) == 1
-	complete := uniform && len(nodeSet) == expectedNodes
+	complete := uniform && len(nodeSet) == expectedNodes && status == "AVAILABLE"
 
-	synced := "DEGRADE"
-	if complete {
-		synced = "COMPLETE"
+	synced := "N/A"
+	if expectedNodes > 1 && status != "FAILED" {
+		synced = "DEGRADE"
+		if complete {
+			synced = "COMPLETE"
+		}
 	}
 
 	return imageSummary{

--- a/cmd/mactl/cmd/get_image_output_test.go
+++ b/cmd/mactl/cmd/get_image_output_test.go
@@ -30,6 +30,30 @@ var _ = Describe("summarizeImages", func() {
 		Expect(summaries[0].hasQcow2).To(Equal("yes"))
 	})
 
+	It("marks image N/A for single-node setups", func() {
+		node1 := "marmot1"
+		images := []api.Image{
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node1}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+		}
+
+		summaries := summarizeImagesWithTotalNodes(images, 1)
+		Expect(summaries).To(HaveLen(1))
+		Expect(summaries[0].synced).To(Equal("N/A"))
+	})
+
+	It("prefers actual cluster size over image node distribution", func() {
+		node1 := "marmot1"
+		node2 := "marmot2"
+		images := []api.Image{
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node1}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node2}, Status: &api.Status{Status: &statusAvailable}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+		}
+
+		summaries := summarizeImagesWithTotalNodes(images, 1)
+		Expect(summaries).To(HaveLen(1))
+		Expect(summaries[0].synced).To(Equal("N/A"))
+	})
+
 	It("marks image DEGRADE when image is missing on one of the cluster nodes", func() {
 		node1 := "marmot1"
 		node2 := "marmot2"
@@ -83,6 +107,21 @@ var _ = Describe("summarizeImages", func() {
 		Expect(summaries).To(HaveLen(1))
 		Expect(summaries[0].synced).To(Equal("DEGRADE"))
 		Expect(summaries[0].status).To(Equal("MIXED"))
+	})
+
+	It("marks image N/A when status is FAILED", func() {
+		node1 := "marmot1"
+		node2 := "marmot2"
+		statusFailed := "FAILED"
+		images := []api.Image{
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node1}, Status: &api.Status{Status: &statusFailed}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+			{Metadata: api.Metadata{Name: "ubuntu", NodeName: &node2}, Status: &api.Status{Status: &statusFailed}, Spec: api.ImageSpec{Qcow2Path: &qcow2Path}},
+		}
+
+		summaries := summarizeImages(images)
+		Expect(summaries).To(HaveLen(1))
+		Expect(summaries[0].status).To(Equal("FAILED"))
+		Expect(summaries[0].synced).To(Equal("N/A"))
 	})
 
 	It("renders WAITING images as QCOW2 no", func() {


### PR DESCRIPTION
## 背景
Issue #465 の「イメージ同期表示が雑すぎる」問題に対応しました。  
現状の get img では、シングル構成でも SYNCED が COMPLETE と表示されるケースがあり、実際のクラスタ構成と表示が一致しない問題がありました。

## 変更内容
- SYNCED 判定ロジックを修正
- get img の集約表示で、image レコード由来のノード数ではなく marmot cluster の実ノード数を優先して判定
- シングル構成時は SYNCED を N/A 表示
- クラスタ構成でも STATUS が FAILED の場合は SYNCED を N/A 表示
- COMPLETE は STATUS が AVAILABLE かつノード整合性が満たされた場合のみ表示
- LV の扱いは従来通り（SYNCED 判定対象外）

## 修正前後の期待動作
- シングル構成（ノード 1 台）:
  - 変更前: AVAILABLE + COMPLETE が表示される場合がある
  - 変更後: AVAILABLE + N/A を表示
- クラスタ構成（ノード 2 台以上）:
  - STATUS が FAILED の行は SYNCED=N/A
  - STATUS が AVAILABLE で整合している行は SYNCED=COMPLETE
  - 欠損や不整合がある行は SYNCED=DEGRADE

## テスト
- 単体テストを追加・更新
  - シングル構成で N/A になること
  - 実クラスタノード数を優先して判定すること
  - FAILED の場合に N/A になること
- 既存テストを含めてコマンドパッケージのテストを実行し、成功を確認

## 影響範囲
- mactl get img のテキスト出力（集約表示）のみ
- API の入出力仕様やデータモデルへの破壊的変更なし

## 関連 Issue
- Closes #465