### PR TITLE
mmImageを導入

### DIFF
--- a/api/marmot-api-v1.go
+++ b/api/marmot-api-v1.go
@@ -6,6 +6,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -357,6 +358,7 @@ type ServerSpec struct {
 	BootVolume       *Volume             `json:"bootVolume,omitempty" yaml:"bootVolume,omitempty"`
 	Cpu              *int                `json:"cpu,omitempty" yaml:"cpu,omitempty"`
 	Memory           *int                `json:"memory,omitempty" yaml:"memory,omitempty"`
+	MmImage          *string             `json:"mmImage,omitempty" yaml:"mmImage,omitempty"`
 	NetworkInterface *[]NetworkInterface `json:"networkInterface,omitempty" yaml:"networkInterface,omitempty"`
 	OsLv             *string             `json:"osLv,omitempty" yaml:"osLv,omitempty"`
 	OsVariant        *string             `json:"osVariant,omitempty" yaml:"osVariant,omitempty"`
@@ -366,6 +368,31 @@ type ServerSpec struct {
 
 // Servers defines model for Servers.
 type Servers = []Server
+
+// NormalizeMMImageAlias keeps ServerSpec.mmImage and ServerSpec.osVariant in sync.
+// mmImage is the preferred field name and takes precedence when both are set.
+func (s *ServerSpec) NormalizeMMImageAlias() {
+	if s == nil {
+		return
+	}
+
+	if s.MmImage != nil && strings.TrimSpace(*s.MmImage) != "" {
+		s.OsVariant = s.MmImage
+		return
+	}
+
+	if s.OsVariant != nil && strings.TrimSpace(*s.OsVariant) != "" {
+		s.MmImage = s.OsVariant
+	}
+}
+
+// NormalizeMMImageAlias keeps Server.spec.mmImage and Server.spec.osVariant in sync.
+func (s *Server) NormalizeMMImageAlias() {
+	if s == nil {
+		return
+	}
+	s.Spec.NormalizeMMImageAlias()
+}
 
 // Status defines model for Status.
 type Status struct {

--- a/api/marmot-api-v1.yaml
+++ b/api/marmot-api-v1.yaml
@@ -1546,8 +1546,11 @@ components:
           type: string
         osVg:
           type: string
+        mmImage:
+          type: string
         osVariant:
           type: string
+          deprecated: true
         bootVolume:
           $ref: "#/components/schemas/Volume"
         auth:

--- a/cmd/mactl/cmd/manifest.go
+++ b/cmd/mactl/cmd/manifest.go
@@ -240,7 +240,13 @@ func ManifestToServer(manifest map[string]interface{}) (*api.Server, error) {
 // ApplyServerDefaults は server.spec.storage 配下の既定値を補完する。
 // storage[].spec.type が未指定なら qcow2、storage[].spec.kind が未指定なら data を設定する。
 func ApplyServerDefaults(server *api.Server) {
-	if server == nil || server.Spec.Storage == nil {
+	if server == nil {
+		return
+	}
+
+	server.NormalizeMMImageAlias()
+
+	if server.Spec.Storage == nil {
 		return
 	}
 

--- a/cmd/mactl/cmd/manifest_test.go
+++ b/cmd/mactl/cmd/manifest_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
 )
 
 var _ = Describe("manifest", func() {
@@ -206,6 +207,32 @@ spec:
 			Expect(func() {
 				ApplyServerDefaults(server)
 			}).NotTo(Panic())
+		})
+
+		It("copies spec.mmImage into spec.osVariant", func() {
+			server := &api.Server{
+				Spec: api.ServerSpec{
+					MmImage: util.StringPtr("ubuntu24.04"),
+				},
+			}
+
+			ApplyServerDefaults(server)
+
+			Expect(server.Spec.OsVariant).NotTo(BeNil())
+			Expect(*server.Spec.OsVariant).To(Equal("ubuntu24.04"))
+		})
+
+		It("keeps spec.mmImage in sync when only spec.osVariant is set", func() {
+			server := &api.Server{
+				Spec: api.ServerSpec{
+					OsVariant: util.StringPtr("ubuntu22.04"),
+				},
+			}
+
+			ApplyServerDefaults(server)
+
+			Expect(server.Spec.MmImage).NotTo(BeNil())
+			Expect(*server.Spec.MmImage).To(Equal("ubuntu22.04"))
 		})
 
 		Describe("ManifestToImage", func() {

--- a/pkg/marmotd/api-server.go
+++ b/pkg/marmotd/api-server.go
@@ -27,6 +27,9 @@ func (s *Server) ApiGetServers(ctx echo.Context) error {
 		slog.Error("ApiGetServers()", "err", err)
 		return ctx.JSON(http.StatusInternalServerError, api.Error{Code: 1, Message: err.Error()})
 	}
+	for i := range recs {
+		recs[i].NormalizeMMImageAlias()
+	}
 	return ctx.JSON(http.StatusOK, recs)
 }
 
@@ -40,6 +43,7 @@ func (s *Server) ApiCreateServer(ctx echo.Context) error {
 		slog.Error("ApiCreateServer()", "err", err)
 		return ctx.JSON(http.StatusInternalServerError, api.Error{Code: 1, Message: err.Error()})
 	}
+	virtualServer.NormalizeMMImageAlias()
 	slog.Debug("Recived post body", "serverSpec=", virtualServer, "cpu=", virtualServer.Spec.Cpu, "memory=", virtualServer.Spec.Memory, "os", virtualServer.Spec.OsVariant)
 	// nodeName の割当はスケジューラーが担当する。
 
@@ -69,6 +73,7 @@ func (s *Server) ApiGetServerById(ctx echo.Context, id string) error {
 		}
 		return ctx.JSON(http.StatusInternalServerError, api.Error{Code: 1, Message: err.Error()})
 	}
+	server.NormalizeMMImageAlias()
 	return ctx.JSON(http.StatusOK, server)
 }
 
@@ -106,6 +111,7 @@ func (s *Server) ApiUpdateServerById(ctx echo.Context, id string) error {
 		slog.Error("ApiUpdateServerById()", "err", err)
 		return ctx.JSON(http.StatusInternalServerError, api.Error{Code: 1, Message: err.Error()})
 	}
+	serverSpec.NormalizeMMImageAlias()
 
 	if err := s.Ma.UpdateServerById(id, serverSpec); err != nil {
 		slog.Error("UpdateServerById()", "err", err)


### PR DESCRIPTION
変更内容
1. ServerSpec に mmImage を追加し、相互同期ヘルパーを実装  
marmot-api-v1.go

2. Server API の入出力で mmImage/osVariant を正規化  
作成・更新リクエストで mmImage を受け付け、取得レスポンスでも両者が揃うようにしました。  
api-server.go

3. mactl のマニフェスト既定値処理で正規化を実施  
apply/create で mmImage 指定時にも既存ロジックが崩れないようにしています。  
manifest.go

4. OpenAPI スキーマを更新  
ServerSpec に mmImage を追加し、osVariant を deprecated 扱いにしました。  
marmot-api-v1.yaml

5. 追加テスト  
ApplyServerDefaults で mmImage/osVariant の同期が行われることを検証しました。  
manifest_test.go

確認結果
1. go test ./api -run TestDoesNotExist -count=1 でコンパイル確認済み
2. go test ./pkg/marmotd -run TestDoesNotExist -count=1 でコンパイル確認済み
3. go test ./cmd/mactl/cmd -run TestDoesNotExist -count=1 でコンパイル確認済み
4. 変更ファイルのエラー診断で問題なし

補足
1. 今回は後方互換重視のため、内部実装の主軸は osVariant のままです
2. 次段で完全移行するなら、ドキュメント例（README や testdata）を mmImage に寄せていくのが安全です

