### PR TITLE
PR #520 指摘対応: API Key 競合対策とユーザー状態処理の修正

### DIFF
--- a/pkg/db/db-auth.go
+++ b/pkg/db/db-auth.go
@@ -281,9 +281,6 @@ func (d *Database) CreateUser(input api.User) (api.User, error) {
 	if user.Status == nil {
 		user.Status = &api.UserStatus{}
 	}
-	if !user.Spec.Enabled {
-		user.Spec.Enabled = true
-	}
 	if user.Status.PasswordUpdatedAt == nil && user.Spec.PasswordHash != nil && strings.TrimSpace(*user.Spec.PasswordHash) != "" {
 		user.Status.PasswordUpdatedAt = util.TimePtr(time.Now())
 	}
@@ -394,6 +391,9 @@ func (d *Database) SetUserPasswordHash(userID, passwordHash string, mustChangePa
 	resp, err := d.GetJSON(key, &user)
 	if err != nil {
 		return err
+	}
+	if user.Status == nil {
+		user.Status = &api.UserStatus{}
 	}
 	if user.Spec.PasswordHash == nil {
 		user.Spec.PasswordHash = util.StringPtr(passwordHash)
@@ -794,13 +794,6 @@ func (d *Database) revokeUserApiKeyLocked(userID, apiKeyID string) error {
 	if err != nil {
 		return err
 	}
-	var indexRef struct {
-		TokenHash string `json:"tokenHash"`
-	}
-	if _, err := d.GetJSON(apiKeyIdIndexKey(userID, apiKeyID), &indexRef); err == nil && strings.TrimSpace(indexRef.TokenHash) != "" {
-		_ = d.DeleteJSON(AuthApiKeyIndexPrefix + "/" + strings.TrimSpace(indexRef.TokenHash))
-		_ = d.DeleteJSON(apiKeyIdIndexKey(userID, apiKeyID))
-	}
 	if apiKey.Spec.Revoked == nil {
 		apiKey.Spec.Revoked = util.BoolPtr(true)
 	} else {
@@ -812,6 +805,15 @@ func (d *Database) revokeUserApiKeyLocked(userID, apiKeyID string) error {
 	apiKey.Status.RevokedAt = util.TimePtr(time.Now())
 	if err := d.PutJSONCAS(key, resp.Kvs[0].ModRevision, apiKey); err != nil {
 		return err
+	}
+	var indexRef struct {
+		TokenHash string `json:"tokenHash"`
+	}
+	if _, err := d.GetJSON(apiKeyIdIndexKey(userID, apiKeyID), &indexRef); err == nil {
+		if strings.TrimSpace(indexRef.TokenHash) != "" {
+			_ = d.DeleteJSON(AuthApiKeyIndexPrefix + "/" + strings.TrimSpace(indexRef.TokenHash))
+		}
+		_ = d.DeleteJSON(apiKeyIdIndexKey(userID, apiKeyID))
 	}
 	return nil
 }
@@ -862,7 +864,8 @@ func (d *Database) AuthenticateApiKey(token string) (api.User, api.ApiKey, error
 		return api.User{}, api.ApiKey{}, ErrUserDisabled
 	}
 	var apiKey api.ApiKey
-	if _, err := d.GetJSON(userApiKeyKey(ref.UserID, ref.ApiKeyID), &apiKey); err != nil {
+	resp, err := d.GetJSON(userApiKeyKey(ref.UserID, ref.ApiKeyID), &apiKey)
+	if err != nil {
 		return api.User{}, api.ApiKey{}, ErrInvalidCredentials
 	}
 	if apiKey.Spec.Revoked != nil && *apiKey.Spec.Revoked {
@@ -878,7 +881,10 @@ func (d *Database) AuthenticateApiKey(token string) (api.User, api.ApiKey, error
 		apiKey.Status = &api.ApiKeyStatus{}
 	}
 	apiKey.Status.LastUsedAt = util.TimePtr(time.Now())
-	if err := d.PutJSON(userApiKeyKey(ref.UserID, ref.ApiKeyID), apiKey); err != nil {
+	if err := d.PutJSONCAS(userApiKeyKey(ref.UserID, ref.ApiKeyID), resp.Kvs[0].ModRevision, apiKey); err != nil {
+		if err == ErrUpdateConflict {
+			return api.User{}, api.ApiKey{}, ErrInvalidCredentials
+		}
 		slog.Warn("AuthenticateApiKey() failed to stamp last used", "err", err, "userId", ref.UserID, "apiKeyId", ref.ApiKeyID)
 	}
 	return user, apiKey, nil

--- a/pkg/db/db-auth_test.go
+++ b/pkg/db/db-auth_test.go
@@ -188,5 +188,70 @@ var _ = Describe("Auth", Ordered, func() {
 			_, err = d.GetUserById(userID)
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("preserves enabled=false on create", func() {
+			hash, err := bcrypt.GenerateFromPassword([]byte("passw0rd"), bcrypt.DefaultCost)
+			Expect(err).NotTo(HaveOccurred())
+
+			disabledID := "disabled-user"
+			created, err := d.CreateUser(api.User{
+				ApiVersion: "v1",
+				Kind:       "User",
+				Metadata: api.Metadata{
+					Id:   disabledID,
+					Name: disabledID,
+				},
+				Spec: api.UserSpec{
+					Enabled:      false,
+					PasswordHash: util.StringPtr(string(hash)),
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(created.Spec.Enabled).To(BeFalse())
+
+			got, err := d.GetUserById(disabledID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Spec.Enabled).To(BeFalse())
+
+			err = d.DeleteUserById(disabledID)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("SetUserPasswordHash initializes nil status safely", func() {
+			hash, err := bcrypt.GenerateFromPassword([]byte("passw0rd"), bcrypt.DefaultCost)
+			Expect(err).NotTo(HaveOccurred())
+
+			legacyID := "legacy-user"
+			legacy := api.User{
+				ApiVersion: "v1",
+				Kind:       "User",
+				Metadata: api.Metadata{
+					Id:   legacyID,
+					Name: legacyID,
+				},
+				Spec: api.UserSpec{
+					Enabled:      true,
+					PasswordHash: util.StringPtr(string(hash)),
+				},
+				Status: nil,
+			}
+			err = d.PutJSON("/marmot/user/"+legacyID, legacy)
+			Expect(err).NotTo(HaveOccurred())
+
+			newHash, err := bcrypt.GenerateFromPassword([]byte("newpassw0rd"), bcrypt.DefaultCost)
+			Expect(err).NotTo(HaveOccurred())
+			err = d.SetUserPasswordHash(legacyID, string(newHash), util.BoolPtr(true))
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := d.GetUserById(legacyID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Status).NotTo(BeNil())
+			Expect(updated.Status.PasswordUpdatedAt).NotTo(BeNil())
+			Expect(updated.Spec.MustChangePassword).NotTo(BeNil())
+			Expect(*updated.Spec.MustChangePassword).To(BeTrue())
+
+			err = d.DeleteUserById(legacyID)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
概要  
PR #520 のレビュー指摘（issuecomment-4822946142）に対応し、認証系 DB アクセスの整合性と安全性を修正しました。  
主に API Key revoke/authenticate の競合対策、User status の nil 安全化、CreateUser の enabled 値保持を対象にしています。

変更内容  
1. CreateUser で enabled=false を保持  
- これまで false が true に上書きされるケースを解消  
- 対象: db-auth.go

2. SetUserPasswordHash の nil 安全化  
- user.Status が nil の場合に初期化してから PasswordUpdatedAt を更新  
- 対象: db-auth.go

3. revokeUserApiKeyLocked の処理順序を修正  
- 先に API Key 本体を CAS で revoked 化  
- CAS 成功後に token index / id index を削除  
- CAS 競合時に index だけ先に消える不整合を防止  
- 対象: db-auth.go

4. AuthenticateApiKey の lastUsedAt 更新を CAS 化  
- API Key 読み取り時の ModRevision を使って CAS 更新  
- 競合時は ErrInvalidCredentials を返す  
- 対象: db-auth.go

テスト  
以下を追加して回帰を検証しました。  
- enabled=false が CreateUser で保持されること  
- SetUserPasswordHash が nil status でも安全に動作すること  
- 対象: db-auth_test.go

実行結果  
- go test ./pkg/db -count=1 -v -args -ginkgo.focus=Auth: 成功  
- go test ./... -run TestDoesNotExist -count=1: 成功

影響範囲  
- 認証 DB ロジックのみ  
- API 仕様変更なし  
- 既存呼び出しインターフェース変更なし

補足  
今回の修正はレビュー指摘への最小対応に限定し、リファクタリングや追加仕様変更は含めていません。