### PR TITLE
認証ハンドラーの実装

### DIFF
--- a/pkg/marmotd/api-auth-stub.go
+++ b/pkg/marmotd/api-auth-stub.go
@@ -1,110 +1,394 @@
 package marmotd
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/util"
+	"golang.org/x/crypto/bcrypt"
 )
 
-func notImplemented(ctx echo.Context, endpoint string) error {
-	return ctx.JSON(http.StatusNotImplemented, api.Error{
-		Code:    http.StatusNotImplemented,
-		Message: endpoint + " is not implemented yet",
-	})
+func apiErrorJSON(ctx echo.Context, status int, message string) error {
+	return ctx.JSON(status, api.Error{Code: int32(status), Message: message})
+}
+
+func mapAuthDBError(ctx echo.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, db.ErrNotFound):
+		return apiErrorJSON(ctx, http.StatusNotFound, err.Error())
+	case errors.Is(err, db.ErrInvalidCredentials), errors.Is(err, db.ErrUserLocked), errors.Is(err, db.ErrUserDisabled):
+		return apiErrorJSON(ctx, http.StatusUnauthorized, err.Error())
+	case errors.Is(err, db.ErrUpdateConflict):
+		return apiErrorJSON(ctx, http.StatusConflict, err.Error())
+	default:
+		return apiErrorJSON(ctx, http.StatusInternalServerError, err.Error())
+	}
+}
+
+func bearerTokenFromAuthzHeader(authz string) (string, bool) {
+	a := strings.TrimSpace(authz)
+	if a == "" {
+		return "", false
+	}
+	parts := strings.SplitN(a, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(strings.TrimSpace(parts[0]), "Bearer") {
+		return "", false
+	}
+	token := strings.TrimSpace(parts[1])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+func validatePasswordPolicy(password string) error {
+	p := strings.TrimSpace(password)
+	if len(p) < 8 {
+		return errors.New("newPassword must be at least 8 characters")
+	}
+	for _, ch := range p {
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
+			continue
+		}
+		return errors.New("newPassword must be alphanumeric")
+	}
+	return nil
+}
+
+func (s *Server) requireBearerAuth(ctx echo.Context) (api.User, api.ApiKey, string, error) {
+	token, ok := bearerTokenFromAuthzHeader(ctx.Request().Header.Get("Authorization"))
+	if !ok {
+		return api.User{}, api.ApiKey{}, "", apiErrorJSON(ctx, http.StatusUnauthorized, "missing or invalid Authorization header")
+	}
+	user, key, err := s.Ma.Db.AuthenticateApiKey(token)
+	if err != nil {
+		return api.User{}, api.ApiKey{}, "", mapAuthDBError(ctx, err)
+	}
+	return user, key, token, nil
 }
 
 func (s *Server) ApiAuthLogin(ctx echo.Context) error {
-	return notImplemented(ctx, "ApiAuthLogin")
+	var req api.AuthLoginRequest
+	if err := ctx.Bind(&req); err != nil {
+		return apiErrorJSON(ctx, http.StatusBadRequest, "invalid request body")
+	}
+	userID := strings.TrimSpace(req.UserId)
+	password := strings.TrimSpace(req.Password)
+	if userID == "" || password == "" {
+		return apiErrorJSON(ctx, http.StatusBadRequest, "userId and password are required")
+	}
+
+	user, err := s.Ma.Db.AuthenticateUser(userID, password)
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	apiKey, rawToken, err := s.Ma.Db.CreateUserApiKey(userID, api.ApiKeyCreateRequest{Comment: util.StringPtr("login-session")})
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+
+	resp := api.AuthLoginResponse{
+		AccessToken: rawToken,
+		TokenType:   "Bearer",
+		User:        &user,
+	}
+	if user.Spec.MustChangePassword != nil {
+		resp.MustChangePassword = user.Spec.MustChangePassword
+	}
+	if apiKey.Spec.ExpiresAt != nil && apiKey.Spec.IssuedAt != nil {
+		expiresIn := int64(apiKey.Spec.ExpiresAt.Sub(*apiKey.Spec.IssuedAt).Seconds())
+		if expiresIn > 0 {
+			resp.ExpiresIn = &expiresIn
+		}
+	}
+	ctx.Response().Header().Set("X-Marmot-ApiKey-Id", apiKey.Metadata.Id)
+	return ctx.JSON(http.StatusOK, resp)
 }
 
 func (s *Server) ApiAuthLogout(ctx echo.Context) error {
-	return notImplemented(ctx, "ApiAuthLogout")
+	user, key, _, err := s.requireBearerAuth(ctx)
+	if err != nil {
+		return err
+	}
+	if err := s.Ma.Db.DeleteUserApiKey(user.Metadata.Id, key.Metadata.Id); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return ctx.NoContent(http.StatusNoContent)
+		}
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 func (s *Server) ApiAuthMe(ctx echo.Context) error {
-	return notImplemented(ctx, "ApiAuthMe")
+	user, _, _, err := s.requireBearerAuth(ctx)
+	if err != nil {
+		return err
+	}
+	roles := []string{}
+	if user.Spec.Roles != nil {
+		roles = append(roles, (*user.Spec.Roles)...)
+	}
+	resp := api.AuthMe{UserId: user.Metadata.Id, Roles: roles}
+	if name := strings.TrimSpace(user.Metadata.Name); name != "" {
+		resp.DisplayName = &name
+	}
+	resp.Enabled = &user.Spec.Enabled
+	if user.Spec.MustChangePassword != nil {
+		resp.MustChangePassword = user.Spec.MustChangePassword
+	}
+	return ctx.JSON(http.StatusOK, resp)
 }
 
 func (s *Server) ApiAuthzCheck(ctx echo.Context) error {
-	return notImplemented(ctx, "ApiAuthzCheck")
+	user, _, _, err := s.requireBearerAuth(ctx)
+	if err != nil {
+		return err
+	}
+	var req api.AuthzCheckRequest
+	if err := ctx.Bind(&req); err != nil {
+		return apiErrorJSON(ctx, http.StatusBadRequest, "invalid request body")
+	}
+	resource := strings.TrimSpace(req.Resource)
+	action := strings.TrimSpace(req.Action)
+	if resource == "" || action == "" {
+		return apiErrorJSON(ctx, http.StatusBadRequest, "resource and action are required")
+	}
+	checkUserID := user.Metadata.Id
+	if req.UserId != nil && strings.TrimSpace(*req.UserId) != "" {
+		checkUserID = strings.TrimSpace(*req.UserId)
+	}
+	allowed, err := s.Ma.Db.Authorize(checkUserID, resource, action)
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	resp := api.AuthzCheckResponse{Allowed: allowed}
+	if !allowed {
+		reason := "access denied"
+		resp.Reason = &reason
+	}
+	return ctx.JSON(http.StatusOK, resp)
 }
 
 func (s *Server) ApiListRoles(ctx echo.Context) error {
-	return notImplemented(ctx, "ApiListRoles")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	roles, err := s.Ma.Db.ListRoles()
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.JSON(http.StatusOK, roles)
 }
 
 func (s *Server) ApiGetRoleByName(ctx echo.Context, roleName string) error {
-	_ = roleName
-	return notImplemented(ctx, "ApiGetRoleByName")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	role, err := s.Ma.Db.GetRoleByName(roleName)
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.JSON(http.StatusOK, role)
 }
 
 func (s *Server) ApiListUsers(ctx echo.Context) error {
-	return notImplemented(ctx, "ApiListUsers")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	users, err := s.Ma.Db.ListUsers()
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.JSON(http.StatusOK, users)
 }
 
 func (s *Server) ApiCreateUser(ctx echo.Context) error {
-	return notImplemented(ctx, "ApiCreateUser")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	var input api.User
+	if err := ctx.Bind(&input); err != nil {
+		return apiErrorJSON(ctx, http.StatusBadRequest, "invalid request body")
+	}
+	created, err := s.Ma.Db.CreateUser(input)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "already exists") {
+			return apiErrorJSON(ctx, http.StatusConflict, err.Error())
+		}
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.JSON(http.StatusCreated, created)
 }
 
 func (s *Server) ApiDeleteUserById(ctx echo.Context, userId string) error {
-	_ = userId
-	return notImplemented(ctx, "ApiDeleteUserById")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	if err := s.Ma.Db.DeleteUserById(userId); err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 func (s *Server) ApiGetUserById(ctx echo.Context, userId string) error {
-	_ = userId
-	return notImplemented(ctx, "ApiGetUserById")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	user, err := s.Ma.Db.GetUserById(userId)
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.JSON(http.StatusOK, user)
 }
 
 func (s *Server) ApiUpdateUserById(ctx echo.Context, userId string) error {
-	_ = userId
-	return notImplemented(ctx, "ApiUpdateUserById")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	var input api.User
+	if err := ctx.Bind(&input); err != nil {
+		return apiErrorJSON(ctx, http.StatusBadRequest, "invalid request body")
+	}
+	if err := s.Ma.Db.UpdateUser(userId, input); err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	user, err := s.Ma.Db.GetUserById(userId)
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.JSON(http.StatusOK, user)
 }
 
 func (s *Server) ApiListUserApiKeys(ctx echo.Context, userId string) error {
-	_ = userId
-	return notImplemented(ctx, "ApiListUserApiKeys")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	keys, err := s.Ma.Db.ListUserApiKeys(userId)
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.JSON(http.StatusOK, keys)
 }
 
 func (s *Server) ApiCreateUserApiKey(ctx echo.Context, userId string) error {
-	_ = userId
-	return notImplemented(ctx, "ApiCreateUserApiKey")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	var req api.ApiKeyCreateRequest
+	if err := ctx.Bind(&req); err != nil {
+		return apiErrorJSON(ctx, http.StatusBadRequest, "invalid request body")
+	}
+	created, rawToken, err := s.Ma.Db.CreateUserApiKey(userId, req)
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	ctx.Response().Header().Set("X-Marmot-Api-Key", rawToken)
+	return ctx.JSON(http.StatusCreated, created)
 }
 
 func (s *Server) ApiDeleteUserApiKey(ctx echo.Context, userId string, apiKeyId string) error {
-	_ = userId
-	_ = apiKeyId
-	return notImplemented(ctx, "ApiDeleteUserApiKey")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	if err := s.Ma.Db.DeleteUserApiKey(userId, apiKeyId); err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 func (s *Server) ApiLockUserById(ctx echo.Context, userId string) error {
-	_ = userId
-	return notImplemented(ctx, "ApiLockUserById")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	if err := s.Ma.Db.LockUserById(userId); err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 func (s *Server) ApiChangeUserPassword(ctx echo.Context, userId string) error {
-	_ = userId
-	return notImplemented(ctx, "ApiChangeUserPassword")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	var req api.PasswordChangeRequest
+	if err := ctx.Bind(&req); err != nil {
+		return apiErrorJSON(ctx, http.StatusBadRequest, "invalid request body")
+	}
+	if err := validatePasswordPolicy(req.NewPassword); err != nil {
+		return apiErrorJSON(ctx, http.StatusBadRequest, err.Error())
+	}
+	if req.CurrentPassword != nil && strings.TrimSpace(*req.CurrentPassword) != "" {
+		if _, err := s.Ma.Db.AuthenticateUser(userId, *req.CurrentPassword); err != nil {
+			return mapAuthDBError(ctx, err)
+		}
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.NewPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return apiErrorJSON(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to hash password: %v", err))
+	}
+
+	mustChange := util.BoolPtr(false)
+	if req.CurrentPassword == nil || strings.TrimSpace(*req.CurrentPassword) == "" {
+		mustChange = util.BoolPtr(true)
+	}
+	if err := s.Ma.Db.SetUserPasswordHash(userId, string(hash), mustChange); err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 func (s *Server) ApiListUserRoles(ctx echo.Context, userId string) error {
-	_ = userId
-	return notImplemented(ctx, "ApiListUserRoles")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	roles, err := s.Ma.Db.ListUserRoles(userId)
+	if err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.JSON(http.StatusOK, roles)
 }
 
 func (s *Server) ApiAddUserRole(ctx echo.Context, userId string) error {
-	_ = userId
-	return notImplemented(ctx, "ApiAddUserRole")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	var req api.RoleAssignmentRequest
+	if err := ctx.Bind(&req); err != nil {
+		return apiErrorJSON(ctx, http.StatusBadRequest, "invalid request body")
+	}
+	if strings.TrimSpace(req.RoleName) == "" {
+		return apiErrorJSON(ctx, http.StatusBadRequest, "roleName is required")
+	}
+	if err := s.Ma.Db.AddUserRole(userId, req.RoleName); err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 func (s *Server) ApiDeleteUserRole(ctx echo.Context, userId string, roleName string) error {
-	_ = userId
-	_ = roleName
-	return notImplemented(ctx, "ApiDeleteUserRole")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	if err := s.Ma.Db.DeleteUserRole(userId, roleName); err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 func (s *Server) ApiUnlockUserById(ctx echo.Context, userId string) error {
-	_ = userId
-	return notImplemented(ctx, "ApiUnlockUserById")
+	if _, _, _, err := s.requireBearerAuth(ctx); err != nil {
+		return err
+	}
+	if err := s.Ma.Db.UnlockUserById(userId); err != nil {
+		return mapAuthDBError(ctx, err)
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }

--- a/pkg/marmotd/api-auth.go
+++ b/pkg/marmotd/api-auth.go
@@ -33,6 +33,16 @@ func mapAuthDBError(ctx echo.Context, err error) error {
 	}
 }
 
+func mapLoginError(ctx echo.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, db.ErrNotFound) || errors.Is(err, db.ErrInvalidCredentials) {
+		return apiErrorJSON(ctx, http.StatusUnauthorized, db.ErrInvalidCredentials.Error())
+	}
+	return mapAuthDBError(ctx, err)
+}
+
 func bearerTokenFromAuthzHeader(authz string) (string, bool) {
 	a := strings.TrimSpace(authz)
 	if a == "" {
@@ -88,17 +98,20 @@ func (s *Server) ApiAuthLogin(ctx echo.Context) error {
 
 	user, err := s.Ma.Db.AuthenticateUser(userID, password)
 	if err != nil {
-		return mapAuthDBError(ctx, err)
+		return mapLoginError(ctx, err)
 	}
 	apiKey, rawToken, err := s.Ma.Db.CreateUserApiKey(userID, api.ApiKeyCreateRequest{Comment: util.StringPtr("login-session")})
 	if err != nil {
 		return mapAuthDBError(ctx, err)
 	}
 
+	responseUser := user
+	responseUser.Spec.PasswordHash = nil
+
 	resp := api.AuthLoginResponse{
 		AccessToken: rawToken,
 		TokenType:   "Bearer",
-		User:        &user,
+		User:        &responseUser,
 	}
 	if user.Spec.MustChangePassword != nil {
 		resp.MustChangePassword = user.Spec.MustChangePassword

--- a/pkg/marmotd/api_auth_handler_test.go
+++ b/pkg/marmotd/api_auth_handler_test.go
@@ -98,6 +98,8 @@ var _ = Describe("Auth API handlers", Ordered, func() {
 
 	It("supports login, me, and logout flow", func() {
 		loginResp := login("admin", "passw0rd")
+		Expect(loginResp.User).NotTo(BeNil())
+		Expect(loginResp.User.Spec.PasswordHash).To(BeNil())
 		token := loginResp.AccessToken
 
 		meCtx, meRec := newContext(http.MethodGet, "/auth/me", "", token)
@@ -119,6 +121,18 @@ var _ = Describe("Auth API handlers", Ordered, func() {
 		err = s.ApiAuthMe(meCtx2)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(meRec2.Code).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("returns uniform unauthorized for unknown user and bad password", func() {
+		unknownCtx, unknownRec := newContext(http.MethodPost, "/auth/login", `{"userId":"nouser","password":"passw0rd"}`, "")
+		err := s.ApiAuthLogin(unknownCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(unknownRec.Code).To(Equal(http.StatusUnauthorized), unknownRec.Body.String())
+
+		badPassCtx, badPassRec := newContext(http.MethodPost, "/auth/login", `{"userId":"admin","password":"wrongpass"}`, "")
+		err = s.ApiAuthLogin(badPassCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(badPassRec.Code).To(Equal(http.StatusUnauthorized), badPassRec.Body.String())
 	})
 
 	It("supports user CRUD, role assignment, and password policy", func() {

--- a/pkg/marmotd/api_auth_handler_test.go
+++ b/pkg/marmotd/api_auth_handler_test.go
@@ -1,0 +1,201 @@
+package marmotd_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/labstack/echo/v4"
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/util"
+	"golang.org/x/crypto/bcrypt"
+)
+
+var _ = Describe("Auth API handlers", Ordered, func() {
+	const (
+		port      = "26379"
+		etcdImage = "ghcr.io/takara9/etcd:3.6.5"
+	)
+
+	var (
+		containerID string
+		d           *db.Database
+		s           *marmotd.Server
+		e           *echo.Echo
+	)
+
+	newContext := func(method, path, body, token string) (echo.Context, *httptest.ResponseRecorder) {
+		req := httptest.NewRequest(method, path, strings.NewReader(body))
+		if body != "" {
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		}
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		rec := httptest.NewRecorder()
+		return e.NewContext(req, rec), rec
+	}
+
+	login := func(userID, password string) api.AuthLoginResponse {
+		ctx, rec := newContext(http.MethodPost, "/auth/login", fmt.Sprintf(`{"userId":"%s","password":"%s"}`, userID, password), "")
+		err := s.ApiAuthLogin(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec.Code).To(Equal(http.StatusOK), rec.Body.String())
+
+		var resp api.AuthLoginResponse
+		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+		Expect(strings.TrimSpace(resp.AccessToken)).NotTo(BeEmpty())
+		return resp
+	}
+
+	BeforeAll(func(ctx0 SpecContext) {
+		cmd := exec.Command("docker", "run", "-d", "--rm", "-p", fmt.Sprintf("%s:2379", port), etcdImage)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			Fail(fmt.Sprintf("failed to start etcd container: %s (%v)", string(output), err))
+		}
+		containerID = string(output[:12])
+		time.Sleep(10 * time.Second)
+
+		url := fmt.Sprintf("http://127.0.0.1:%s", port)
+		d, err = db.NewDatabase(url)
+		Expect(err).NotTo(HaveOccurred())
+		s = &marmotd.Server{Ma: &marmotd.Marmot{NodeName: "hvc", EtcdUrl: url, Db: d}}
+		e = echo.New()
+
+		hash, err := bcrypt.GenerateFromPassword([]byte("passw0rd"), bcrypt.DefaultCost)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = d.CreateUser(api.User{
+			ApiVersion: "v1",
+			Kind:       "User",
+			Metadata: api.Metadata{Id: "admin", Name: "admin"},
+			Spec: api.UserSpec{
+				Enabled:            true,
+				PasswordHash:       util.StringPtr(string(hash)),
+				Roles:              &[]string{"Administrator"},
+				MustChangePassword: util.BoolPtr(true),
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func(ctx0 SpecContext) {
+		if d != nil {
+			_ = d.Close()
+		}
+		if strings.TrimSpace(containerID) != "" {
+			_, _ = exec.Command("docker", "stop", containerID).CombinedOutput()
+		}
+	})
+
+	It("supports login, me, and logout flow", func() {
+		loginResp := login("admin", "passw0rd")
+		token := loginResp.AccessToken
+
+		meCtx, meRec := newContext(http.MethodGet, "/auth/me", "", token)
+		err := s.ApiAuthMe(meCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(meRec.Code).To(Equal(http.StatusOK), meRec.Body.String())
+
+		var me api.AuthMe
+		Expect(json.Unmarshal(meRec.Body.Bytes(), &me)).To(Succeed())
+		Expect(me.UserId).To(Equal("admin"))
+		Expect(me.Roles).To(ContainElement("Administrator"))
+
+		logoutCtx, logoutRec := newContext(http.MethodPost, "/auth/logout", "", token)
+		err = s.ApiAuthLogout(logoutCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logoutRec.Code).To(Equal(http.StatusNoContent))
+
+		meCtx2, meRec2 := newContext(http.MethodGet, "/auth/me", "", token)
+		err = s.ApiAuthMe(meCtx2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(meRec2.Code).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("supports user CRUD, role assignment, and password policy", func() {
+		token := login("admin", "passw0rd").AccessToken
+
+		hash, err := bcrypt.GenerateFromPassword([]byte("userpass1"), bcrypt.DefaultCost)
+		Expect(err).NotTo(HaveOccurred())
+		createBody := fmt.Sprintf(`{"apiVersion":"v1","kind":"User","metadata":{"id":"alice","name":"alice"},"spec":{"enabled":true,"passwordHash":%q}}`, string(hash))
+		createCtx, createRec := newContext(http.MethodPost, "/users", createBody, token)
+		err = s.ApiCreateUser(createCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createRec.Code).To(Equal(http.StatusCreated), createRec.Body.String())
+
+		addRoleCtx, addRoleRec := newContext(http.MethodPost, "/users/alice/roles", `{"roleName":"Viewer"}`, token)
+		err = s.ApiAddUserRole(addRoleCtx, "alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addRoleRec.Code).To(Equal(http.StatusNoContent), addRoleRec.Body.String())
+
+		listRoleCtx, listRoleRec := newContext(http.MethodGet, "/users/alice/roles", "", token)
+		err = s.ApiListUserRoles(listRoleCtx, "alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listRoleRec.Code).To(Equal(http.StatusOK), listRoleRec.Body.String())
+		var roles api.RoleNames
+		Expect(json.Unmarshal(listRoleRec.Body.Bytes(), &roles)).To(Succeed())
+		Expect(roles).To(ContainElement("Viewer"))
+
+		badPassCtx, badPassRec := newContext(http.MethodPost, "/users/alice/password", `{"newPassword":"abc!"}`, token)
+		err = s.ApiChangeUserPassword(badPassCtx, "alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(badPassRec.Code).To(Equal(http.StatusBadRequest), badPassRec.Body.String())
+
+		setPassCtx, setPassRec := newContext(http.MethodPost, "/users/alice/password", `{"newPassword":"newpass01"}`, token)
+		err = s.ApiChangeUserPassword(setPassCtx, "alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(setPassRec.Code).To(Equal(http.StatusNoContent), setPassRec.Body.String())
+
+		lockCtx, lockRec := newContext(http.MethodPost, "/users/alice/lock", "", token)
+		err = s.ApiLockUserById(lockCtx, "alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(lockRec.Code).To(Equal(http.StatusNoContent), lockRec.Body.String())
+
+		unlockCtx, unlockRec := newContext(http.MethodPost, "/users/alice/unlock", "", token)
+		err = s.ApiUnlockUserById(unlockCtx, "alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(unlockRec.Code).To(Equal(http.StatusNoContent), unlockRec.Body.String())
+
+		deleteCtx, deleteRec := newContext(http.MethodDelete, "/users/alice", "", token)
+		err = s.ApiDeleteUserById(deleteCtx, "alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleteRec.Code).To(Equal(http.StatusNoContent), deleteRec.Body.String())
+	})
+
+	It("supports API key create/list/delete", func() {
+		token := login("admin", "passw0rd").AccessToken
+
+		createCtx, createRec := newContext(http.MethodPost, "/users/admin/apikeys", `{}`, token)
+		err := s.ApiCreateUserApiKey(createCtx, "admin")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createRec.Code).To(Equal(http.StatusCreated), createRec.Body.String())
+		issued := strings.TrimSpace(createRec.Header().Get("X-Marmot-Api-Key"))
+		Expect(issued).NotTo(BeEmpty())
+
+		var key api.ApiKey
+		Expect(json.Unmarshal(createRec.Body.Bytes(), &key)).To(Succeed())
+		Expect(strings.TrimSpace(key.Metadata.Id)).NotTo(BeEmpty())
+
+		listCtx, listRec := newContext(http.MethodGet, "/users/admin/apikeys", "", token)
+		err = s.ApiListUserApiKeys(listCtx, "admin")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listRec.Code).To(Equal(http.StatusOK), listRec.Body.String())
+		var keys api.ApiKeys
+		Expect(json.Unmarshal(listRec.Body.Bytes(), &keys)).To(Succeed())
+		Expect(len(keys)).To(BeNumerically(">=", 1))
+
+		delCtx, delRec := newContext(http.MethodDelete, "/users/admin/apikeys/"+key.Metadata.Id, "", token)
+		err = s.ApiDeleteUserApiKey(delCtx, "admin", key.Metadata.Id)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(delRec.Code).To(Equal(http.StatusNoContent), delRec.Body.String())
+	})
+})


### PR DESCRIPTION
## 概要
MEMO の認証・認可要件に沿って、marmotd の auth/user/role/authz 系ハンドラーを実装しました。  
DB アクセスは PR #521 で整備された関数群を利用し、501 スタブ実装を本実装へ置き換えています。  
あわせてハンドラーの統合寄りテストを追加し、主要フローを検証しました。

## 背景
- docs の要件では、管理者向けユーザー管理コマンドと RBAC による認可が必要
- 既存状態はサーバー側が Not Implemented 応答で、mactl 連携を進められない状態

## 変更内容
- 認証・認可ハンドラーを実装
- 対象: api-auth-stub.go
- 実装した主な API:
1. POST /auth/login
2. POST /auth/logout
3. GET /auth/me
4. POST /authz/check
5. GET /roles
6. GET /roles/{roleName}
7. GET/POST /users
8. GET/PUT/DELETE /users/{userId}
9. POST /users/{userId}/password
10. POST /users/{userId}/lock
11. POST /users/{userId}/unlock
12. GET/POST /users/{userId}/roles
13. DELETE /users/{userId}/roles/{roleName}
14. GET/POST /users/{userId}/apikeys
15. DELETE /users/{userId}/apikeys/{apiKeyId}

- 共通処理を追加
1. Authorization: Bearer ヘッダーの抽出と認証
2. DB エラーを HTTP ステータスへマッピング
3. パスワードポリシー検証
- 仕様: 英数字のみ、8 文字以上

- ハンドラーテストを追加
- 対象: api_auth_handler_test.go
- カバーした観点:
1. login → me → logout の正常系
2. ユーザー CRUD、ロール付与、パスワードポリシー
3. API キー作成・一覧・削除

## 実装方針
- DB 層の既存責務を再利用し、ハンドラー側は入出力整形・認証ヘッダー処理・エラー変換に集中
- users/me 系ではなく users/{userId} 系を使用（現 OpenAPI に合わせる）

## テスト結果
1. go test ./pkg/marmotd -count=1 -run ^TestMarmotd$ -v -args -ginkgo.focus=Auth API handlers
- 結果: 成功（追加した 3 spec が pass）

2. go test ./... -run TestDoesNotExist -count=1
- 結果: 成功（全体コンパイル確認）

## 影響範囲
- 変更あり:
1. api-auth-stub.go
2. api_auth_handler_test.go

- 変更なし:
1. OpenAPI 仕様ファイル
2. mactl CLI 実装
3. DB スキーマ

## 補足
- 本 PR はハンドラー層の実装が主目的です
- TLS 強制や mactl 側のトークン保持・送信の実装は別 PR で扱います