### PR TITLE
APIライブラリの実装

### DIFF
--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -1,0 +1,343 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/takara9/marmot/api"
+)
+
+func (m *MarmotEndpoint) SetAccessToken(token string) {
+	m.AccessToken = strings.TrimSpace(token)
+}
+
+func (m *MarmotEndpoint) endpointURL(pathSegments ...string) (string, error) {
+	parts := []string{m.Scheme + "://" + m.HostPort, m.BasePath}
+	parts = append(parts, pathSegments...)
+	return url.JoinPath(parts[0], parts[1:]...)
+}
+
+func (m *MarmotEndpoint) newJSONRequest(method string, body any, pathSegments ...string) (*http.Request, error) {
+	reqURL, err := m.endpointURL(pathSegments...)
+	if err != nil {
+		return nil, err
+	}
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(payload)
+	}
+	return http.NewRequest(method, reqURL, reader)
+}
+
+func (m *MarmotEndpoint) doJSONRequest(req *http.Request) (int, []byte, http.Header, *url.URL, error) {
+	req.Header.Set("User-Agent", "MarmotdClient/1.0")
+	if strings.TrimSpace(req.Header.Get("Content-Type")) == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token := strings.TrimSpace(m.AccessToken); token != "" && strings.TrimSpace(req.Header.Get("Authorization")) == "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := m.Client.Do(req)
+	if err != nil {
+		return 0, nil, nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, resp.Header, nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusCreated &&
+		resp.StatusCode != http.StatusAccepted &&
+		resp.StatusCode != http.StatusNoContent {
+		msg := strings.TrimSpace(string(body))
+		var apiErr apiErrorBody
+		if err := json.Unmarshal(body, &apiErr); err == nil {
+			if strings.TrimSpace(apiErr.Message) != "" {
+				return resp.StatusCode, nil, resp.Header, nil, fmt.Errorf("%s", strings.TrimSpace(apiErr.Message))
+			}
+		}
+		if len(msg) > 0 {
+			return resp.StatusCode, nil, resp.Header, nil, fmt.Errorf("%s", msg)
+		}
+		return resp.StatusCode, nil, resp.Header, nil, fmt.Errorf("http status code = %d", resp.StatusCode)
+	}
+
+	location, err := resp.Location()
+	if err != nil && err.Error() != "http: no Location header in response" {
+		return resp.StatusCode, body, resp.Header, nil, err
+	}
+	if err != nil {
+		location = nil
+	}
+	return resp.StatusCode, body, resp.Header, location, nil
+}
+
+func decodeJSONBody[T any](body []byte) (*T, error) {
+	var value T
+	if err := json.Unmarshal(body, &value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func (m *MarmotEndpoint) AuthLogin(userID, password string) (*api.AuthLoginResponse, error) {
+	requestBody := api.AuthLoginRequest{UserId: strings.TrimSpace(userID), Password: password}
+	req, err := m.newJSONRequest(http.MethodPost, requestBody, "auth", "login")
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := decodeJSONBody[api.AuthLoginResponse](body)
+	if err != nil {
+		return nil, err
+	}
+	m.SetAccessToken(resp.AccessToken)
+	return resp, nil
+}
+
+func (m *MarmotEndpoint) AuthLogout() error {
+	req, err := m.newJSONRequest(http.MethodPost, nil, "auth", "logout")
+	if err != nil {
+		return err
+	}
+	if _, _, _, _, err := m.doJSONRequest(req); err != nil {
+		return err
+	}
+	m.SetAccessToken("")
+	return nil
+}
+
+func (m *MarmotEndpoint) AuthMe() (*api.AuthMe, error) {
+	req, err := m.newJSONRequest(http.MethodGet, nil, "auth", "me")
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return decodeJSONBody[api.AuthMe](body)
+}
+
+func (m *MarmotEndpoint) AuthzCheck(request api.AuthzCheckRequest) (*api.AuthzCheckResponse, error) {
+	req, err := m.newJSONRequest(http.MethodPost, request, "authz", "check")
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return decodeJSONBody[api.AuthzCheckResponse](body)
+}
+
+func (m *MarmotEndpoint) ListRoles() (api.Roles, error) {
+	req, err := m.newJSONRequest(http.MethodGet, nil, "roles")
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	var roles api.Roles
+	if err := json.Unmarshal(body, &roles); err != nil {
+		return nil, err
+	}
+	return roles, nil
+}
+
+func (m *MarmotEndpoint) GetRoleByName(roleName string) (*api.Role, error) {
+	req, err := m.newJSONRequest(http.MethodGet, nil, "roles", roleName)
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return decodeJSONBody[api.Role](body)
+}
+
+func (m *MarmotEndpoint) ListUsers() (api.Users, error) {
+	req, err := m.newJSONRequest(http.MethodGet, nil, "users")
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	var users api.Users
+	if err := json.Unmarshal(body, &users); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+func (m *MarmotEndpoint) CreateUser(user api.User) (*api.User, error) {
+	req, err := m.newJSONRequest(http.MethodPost, user, "users")
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return decodeJSONBody[api.User](body)
+}
+
+func (m *MarmotEndpoint) GetUserById(userID string) (*api.User, error) {
+	req, err := m.newJSONRequest(http.MethodGet, nil, "users", userID)
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return decodeJSONBody[api.User](body)
+}
+
+func (m *MarmotEndpoint) UpdateUserById(userID string, user api.User) (*api.User, error) {
+	req, err := m.newJSONRequest(http.MethodPut, user, "users", userID)
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return decodeJSONBody[api.User](body)
+}
+
+func (m *MarmotEndpoint) DeleteUserById(userID string) error {
+	req, err := m.newJSONRequest(http.MethodDelete, nil, "users", userID)
+	if err != nil {
+		return err
+	}
+	_, _, _, _, err = m.doJSONRequest(req)
+	return err
+}
+
+func (m *MarmotEndpoint) ChangeUserPassword(userID string, request api.PasswordChangeRequest) error {
+	req, err := m.newJSONRequest(http.MethodPost, request, "users", userID, "password")
+	if err != nil {
+		return err
+	}
+	_, _, _, _, err = m.doJSONRequest(req)
+	return err
+}
+
+func (m *MarmotEndpoint) LockUserById(userID string) error {
+	req, err := m.newJSONRequest(http.MethodPost, nil, "users", userID, "lock")
+	if err != nil {
+		return err
+	}
+	_, _, _, _, err = m.doJSONRequest(req)
+	return err
+}
+
+func (m *MarmotEndpoint) UnlockUserById(userID string) error {
+	req, err := m.newJSONRequest(http.MethodPost, nil, "users", userID, "unlock")
+	if err != nil {
+		return err
+	}
+	_, _, _, _, err = m.doJSONRequest(req)
+	return err
+}
+
+func (m *MarmotEndpoint) ListUserRoles(userID string) (api.RoleNames, error) {
+	req, err := m.newJSONRequest(http.MethodGet, nil, "users", userID, "roles")
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	var roles api.RoleNames
+	if err := json.Unmarshal(body, &roles); err != nil {
+		return nil, err
+	}
+	return roles, nil
+}
+
+func (m *MarmotEndpoint) AddUserRole(userID string, roleName string) error {
+	req, err := m.newJSONRequest(http.MethodPost, api.RoleAssignmentRequest{RoleName: roleName}, "users", userID, "roles")
+	if err != nil {
+		return err
+	}
+	_, _, _, _, err = m.doJSONRequest(req)
+	return err
+}
+
+func (m *MarmotEndpoint) DeleteUserRole(userID string, roleName string) error {
+	req, err := m.newJSONRequest(http.MethodDelete, nil, "users", userID, "roles", roleName)
+	if err != nil {
+		return err
+	}
+	_, _, _, _, err = m.doJSONRequest(req)
+	return err
+}
+
+func (m *MarmotEndpoint) ListUserApiKeys(userID string) (api.ApiKeys, error) {
+	req, err := m.newJSONRequest(http.MethodGet, nil, "users", userID, "apikeys")
+	if err != nil {
+		return nil, err
+	}
+	_, body, _, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	var keys api.ApiKeys
+	if err := json.Unmarshal(body, &keys); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+func (m *MarmotEndpoint) CreateUserApiKey(userID string, request api.ApiKeyCreateRequest) (*api.ApiKey, string, error) {
+	req, err := m.newJSONRequest(http.MethodPost, request, "users", userID, "apikeys")
+	if err != nil {
+		return nil, "", err
+	}
+	_, body, header, _, err := m.doJSONRequest(req)
+	if err != nil {
+		return nil, "", err
+	}
+	apiKey, err := decodeJSONBody[api.ApiKey](body)
+	if err != nil {
+		return nil, "", err
+	}
+	rawToken := strings.TrimSpace(header.Get("X-Marmot-Api-Key"))
+	if rawToken == "" {
+		return nil, "", fmt.Errorf("missing X-Marmot-Api-Key header")
+	}
+	return apiKey, rawToken, nil
+}
+
+func (m *MarmotEndpoint) DeleteUserApiKey(userID string, apiKeyID string) error {
+	req, err := m.newJSONRequest(http.MethodDelete, nil, "users", userID, "apikeys", apiKeyID)
+	if err != nil {
+		return err
+	}
+	_, _, _, _, err = m.doJSONRequest(req)
+	return err
+}

--- a/pkg/client/auth_test.go
+++ b/pkg/client/auth_test.go
@@ -1,0 +1,150 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+)
+
+func TestAuthLoginStoresTokenAndUsesBearerAuth(t *testing.T) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/auth/login":
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method for login: %s", r.Method)
+			}
+			var request api.AuthLoginRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode login request: %v", err)
+			}
+			if request.UserId != "admin" || request.Password != "passw0rd" {
+				t.Fatalf("unexpected login request: %+v", request)
+			}
+			response := api.AuthLoginResponse{
+				AccessToken: "session-token",
+				TokenType:   "Bearer",
+				User: &api.User{
+					ApiVersion: "v1",
+					Kind:       "User",
+					Metadata:   api.Metadata{Id: "admin", Name: "admin"},
+					Spec:       api.UserSpec{Enabled: true},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+		case "/api/v1/auth/me":
+			if got := r.Header.Get("Authorization"); got != "Bearer session-token" {
+				t.Fatalf("unexpected authorization header: %q", got)
+			}
+			response := api.AuthMe{UserId: "admin", Roles: []string{"Administrator"}}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	parsedURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	ep := &MarmotEndpoint{
+		Scheme:   parsedURL.Scheme,
+		HostPort: parsedURL.Host,
+		BasePath: "/api/v1",
+		Client:   server.Client(),
+	}
+
+	loginResp, err := ep.AuthLogin("admin", "passw0rd")
+	if err != nil {
+		t.Fatalf("AuthLogin failed: %v", err)
+	}
+	if loginResp == nil || loginResp.AccessToken != "session-token" {
+		t.Fatalf("unexpected login response: %+v", loginResp)
+	}
+
+	meResp, err := ep.AuthMe()
+	if err != nil {
+		t.Fatalf("AuthMe failed: %v", err)
+	}
+	if meResp == nil || meResp.UserId != "admin" {
+		t.Fatalf("unexpected me response: %+v", meResp)
+	}
+}
+
+func TestCreateUserApiKeyReturnsRawToken(t *testing.T) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/users/alice/apikeys" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-token" {
+			t.Fatalf("unexpected authorization header: %q", got)
+		}
+		var request api.ApiKeyCreateRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode api key request: %v", err)
+		}
+		if request.Comment == nil || strings.TrimSpace(*request.Comment) != "login-session" {
+			t.Fatalf("unexpected request comment: %+v", request.Comment)
+		}
+		response := api.ApiKey{
+			ApiVersion: "v1",
+			Kind:       "ApiKey",
+			Metadata:   api.Metadata{Id: "key-1", Name: "key-1"},
+			Spec:       api.ApiKeySpec{Comment: request.Comment},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Marmot-Api-Key", "raw-token-value")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	t.Cleanup(server.Close)
+
+	parsedURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	ep := &MarmotEndpoint{
+		Scheme:      parsedURL.Scheme,
+		HostPort:    parsedURL.Host,
+		BasePath:    "/api/v1",
+		AccessToken: "admin-token",
+		Client:      server.Client(),
+	}
+
+	apiKey, rawToken, err := ep.CreateUserApiKey("alice", api.ApiKeyCreateRequest{Comment: stringPtr("login-session")})
+	if err != nil {
+		t.Fatalf("CreateUserApiKey failed: %v", err)
+	}
+	if apiKey == nil || apiKey.Metadata.Id != "key-1" {
+		t.Fatalf("unexpected api key response: %+v", apiKey)
+	}
+	if rawToken != "raw-token-value" {
+		t.Fatalf("unexpected raw token: %q", rawToken)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func TestSetAccessTokenTrimsWhitespace(t *testing.T) {
+	t.Helper()
+	ep := &MarmotEndpoint{}
+	ep.SetAccessToken("  token-value  ")
+	if ep.AccessToken != "token-value" {
+		t.Fatalf("unexpected access token: %q", ep.AccessToken)
+	}
+}

--- a/pkg/client/core.go
+++ b/pkg/client/core.go
@@ -27,11 +27,12 @@ func NewMarmot(nodeName string, etcdUrl string) (*MarmotClient, error) {
 }
 
 type MarmotEndpoint struct {
-	Scheme   string // Scheme for the endpoint, e.g., "http" or "https".
-	HostPort string
-	BasePath string       // Base path for the API, e.g., "/api/v1".
+	Scheme                string // Scheme for the endpoint, e.g., "http" or "https".
+	HostPort              string
+	BasePath              string // Base path for the API, e.g., "/api/v1".
 	InsecureSkipTLSVerify bool
-	Client   *http.Client // Specialized client.
+	AccessToken           string
+	Client                *http.Client // Specialized client.
 }
 
 func NewMarmotdEp(schame string, address string, basePath string, timeout int, insecureSkipTLSVerify bool) (*MarmotEndpoint, error) {
@@ -46,11 +47,11 @@ func NewMarmotdEp(schame string, address string, basePath string, timeout int, i
 	}
 
 	return &MarmotEndpoint{
-		Scheme:   scheme,
-		HostPort: address,
-		BasePath: basePath,
+		Scheme:                scheme,
+		HostPort:              address,
+		BasePath:              basePath,
 		InsecureSkipTLSVerify: insecureSkipTLSVerify,
-		Client:   &http.Client{Transport: tr, Timeout: time.Duration(timeout) * time.Second},
+		Client:                &http.Client{Transport: tr, Timeout: time.Duration(timeout) * time.Second},
 	}, nil
 }
 
@@ -81,6 +82,9 @@ func (m *MarmotEndpoint) httpRequest2(req *http.Request) ([]byte, *url.URL, erro
 	req.Header.Set("User-Agent", "MarmotdClient/1.0")
 	if strings.TrimSpace(req.Header.Get("Content-Type")) == "" {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if token := strings.TrimSpace(m.AccessToken); token != "" && strings.TrimSpace(req.Header.Get("Authorization")) == "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	resp, err := m.Client.Do(req)


### PR DESCRIPTION
mactl から利用する認証・ユーザー管理 API クライアントを追加しました。marmotd 側で実装済みの auth / authz / roles / users / apikeys 系エンドポイントを、pkg/client に共通ライブラリとしてまとめ、login 後の bearer token を自動で再利用できるようにしています。

主な変更:
- AuthLogin / AuthLogout / AuthMe / AuthzCheck の追加
- Role / User / API key 操作用メソッドの追加
- MarmotEndpoint に AccessToken を保持して Authorization ヘッダーへ自動付与
- API key 発行時の X-Marmot-Api-Key ヘッダー取得に対応
- httptest ベースの回帰テストを追加

確認:
- go test ./pkg/client -count=1
- go test ./... -run TestDoesNotExist -count=1

補足:
- 今回はライブラリ層までで、cmd/mactl 側のコマンド配線は別 PR で対応します。
