### PR TITLE
RBAC制御機能の実装

### DIFF
--- a/cmd/mactl/cmd/common.go
+++ b/cmd/mactl/cmd/common.go
@@ -35,7 +35,12 @@ func deletionMarker(status *api.Status) string {
 //  1. --api フラグで明示指定された URL または .marmot ファイルパス
 //  2. $HOME/.marmot に登録されたアクティブエンドポイント
 func getClientConfig() (*client.MarmotEndpoint, error) {
-	return config.GetClientConfig2(apiConfigFilename)
+	m, err := config.GetClientConfig2(apiConfigFilename)
+	if err != nil {
+		return nil, err
+	}
+	_ = loadTokenForEndpoint(m) // best-effort; token file may not exist yet
+	return m, nil
 }
 
 // clearScreen はターミナル画面をクリアする。

--- a/cmd/mactl/cmd/response_id_test.go
+++ b/cmd/mactl/cmd/response_id_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestExtractResponseIDPrefersMetadataID(t *testing.T) {
@@ -97,4 +99,20 @@ func captureStdoutForIDTest(t *testing.T, fn func()) string {
 	}
 	_ = r.Close()
 	return buf.String()
+}
+
+func TestPasswordHashFromPlain(t *testing.T) {
+	hash, err := passwordHashFromPlain("lemon123")
+	if err != nil {
+		t.Fatalf("passwordHashFromPlain returned error: %v", err)
+	}
+	if hash == "" {
+		t.Fatalf("passwordHashFromPlain returned empty hash")
+	}
+	if hash == "lemon123" {
+		t.Fatalf("passwordHashFromPlain returned plaintext instead of hash")
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte("lemon123")); err != nil {
+		t.Fatalf("generated hash does not match original password: %v", err)
+	}
 }

--- a/cmd/mactl/cmd/response_id_test.go
+++ b/cmd/mactl/cmd/response_id_test.go
@@ -116,3 +116,33 @@ func TestPasswordHashFromPlain(t *testing.T) {
 		t.Fatalf("generated hash does not match original password: %v", err)
 	}
 }
+
+func TestValidateUserAddPasswordPolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		password    string
+		wantErrText string
+	}{
+		{name: "accepts alphanumeric length 8", password: "lemon123"},
+		{name: "rejects short password", password: "abc123", wantErrText: "at least 8 characters"},
+		{name: "rejects non alphanumeric", password: "lemon123!", wantErrText: "alphanumeric"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateUserAddPasswordPolicy(tt.password)
+			if tt.wantErrText == "" {
+				if err != nil {
+					t.Fatalf("validateUserAddPasswordPolicy(%q) unexpected error: %v", tt.password, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateUserAddPasswordPolicy(%q) expected error containing %q", tt.password, tt.wantErrText)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrText) {
+				t.Fatalf("validateUserAddPasswordPolicy(%q) error = %q, want contains %q", tt.password, err.Error(), tt.wantErrText)
+			}
+		})
+	}
+}

--- a/cmd/mactl/cmd/user_add.go
+++ b/cmd/mactl/cmd/user_add.go
@@ -49,6 +49,9 @@ var userAddCmd = &cobra.Command{
 		if strings.TrimSpace(passwdStr) == "" {
 			return fmt.Errorf("password cannot be empty")
 		}
+		if err := validateUserAddPasswordPolicy(passwdStr); err != nil {
+			return err
+		}
 
 		passwordHash, err := passwordHashFromPlain(passwdStr)
 		if err != nil {
@@ -89,6 +92,20 @@ var userAddCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+func validateUserAddPasswordPolicy(password string) error {
+	p := strings.TrimSpace(password)
+	if len(p) < 8 {
+		return fmt.Errorf("password must be at least 8 characters")
+	}
+	for _, ch := range p {
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
+			continue
+		}
+		return fmt.Errorf("password must be alphanumeric")
+	}
+	return nil
 }
 
 func passwordHashFromPlain(password string) (string, error) {

--- a/cmd/mactl/cmd/user_add.go
+++ b/cmd/mactl/cmd/user_add.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/term"
 )
 
@@ -48,6 +50,11 @@ var userAddCmd = &cobra.Command{
 			return fmt.Errorf("password cannot be empty")
 		}
 
+		passwordHash, err := passwordHashFromPlain(passwdStr)
+		if err != nil {
+			return err
+		}
+
 		enabled := true
 		user := api.User{
 			ApiVersion: "v1",
@@ -56,7 +63,8 @@ var userAddCmd = &cobra.Command{
 				Name: userID,
 			},
 			Spec: api.UserSpec{
-				Enabled: enabled,
+				Enabled:      enabled,
+				PasswordHash: util.StringPtr(passwordHash),
 			},
 		}
 
@@ -81,6 +89,14 @@ var userAddCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+func passwordHashFromPlain(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", fmt.Errorf("failed to hash password: %w", err)
+	}
+	return string(hash), nil
 }
 
 func init() {

--- a/cmd/mactl/mactl-vm-deploy-1_test.go
+++ b/cmd/mactl/mactl-vm-deploy-1_test.go
@@ -18,6 +18,7 @@ import (
 var _ = Describe("MarmotdTest", Ordered, func() {
 	var mockServer *mockServerHandle
 	var containerID string
+	var testHomeDir string
 
 	BeforeAll(func(specCtx SpecContext) {
 		opts := &slog.HandlerOptions{
@@ -27,13 +28,15 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, opts))
 		slog.SetDefault(logger)
 		cleanupTestEnvironment()
+		var err error
+		testHomeDir, err = setupMactlTestHome()
+		Expect(err).NotTo(HaveOccurred())
 		if err := ensureMactlTestBinary(); err != nil {
 			Fail(fmt.Sprintf("Failed to build mactl test binary: %v", err))
 		}
 
 		By("モックサーバー用etcdの起動")
 		var etcdEp string
-		var err error
 		containerID, etcdEp, err = startEtcdContainer()
 		if err != nil {
 			Fail(fmt.Sprintf("Failed to start container: %v", err))
@@ -43,6 +46,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		By("モックサーバーの起動")
 		mockServer, err = startMockServer(etcdEp)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(loginAsAdmin()).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func(specCtx SpecContext) {
@@ -56,6 +60,9 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			fmt.Printf("Failed to remove container: %v\n", err)
+		}
+		if strings.TrimSpace(testHomeDir) != "" {
+			_ = os.RemoveAll(testHomeDir)
 		}
 		os.Remove("bin/mactl-test")
 		os.Remove("/var/actions-runner/_work/marmot/marmot/cmd/mactl/bin/mactl-test")

--- a/cmd/mactl/mactl-vm-deploy-2_test.go
+++ b/cmd/mactl/mactl-vm-deploy-2_test.go
@@ -20,6 +20,7 @@ import (
 var _ = Describe("MarmotdTest", Ordered, func() {
 	var mockServer *mockServerHandle
 	var containerID string
+	var testHomeDir string
 
 	BeforeAll(func(specCtx SpecContext) {
 		opts := &slog.HandlerOptions{
@@ -29,13 +30,15 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, opts))
 		slog.SetDefault(logger)
 		cleanupTestEnvironment()
+		var err error
+		testHomeDir, err = setupMactlTestHome()
+		Expect(err).NotTo(HaveOccurred())
 		if err := ensureMactlTestBinary(); err != nil {
 			Fail(fmt.Sprintf("Failed to build mactl test binary: %v", err))
 		}
 
 		By("モックサーバー用etcdの起動")
 		var etcdEp string
-		var err error
 		containerID, etcdEp, err = startEtcdContainer()
 		if err != nil {
 			Fail(fmt.Sprintf("Failed to start container: %v", err))
@@ -45,6 +48,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		By("モックサーバーの起動")
 		mockServer, err = startMockServer(etcdEp)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(loginAsAdmin()).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func(specCtx SpecContext) {
@@ -58,6 +62,9 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			fmt.Printf("Failed to remove container: %v\n", err)
+		}
+		if strings.TrimSpace(testHomeDir) != "" {
+			_ = os.RemoveAll(testHomeDir)
 		}
 		os.Remove("bin/mactl-test")
 		os.Remove("/var/actions-runner/_work/marmot/marmot/cmd/mactl/bin/mactl-test")

--- a/cmd/mactl/mactl-vm-deploy-3_test.go
+++ b/cmd/mactl/mactl-vm-deploy-3_test.go
@@ -20,6 +20,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 	var mockServer *mockServerHandle
 	var containerID string
 	var serverId_1, serverId_2, serverId_3 string
+	var testHomeDir string
 
 	BeforeAll(func(specCtx SpecContext) {
 		opts := &slog.HandlerOptions{
@@ -29,13 +30,15 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, opts))
 		slog.SetDefault(logger)
 		cleanupTestEnvironment()
+		var err error
+		testHomeDir, err = setupMactlTestHome()
+		Expect(err).NotTo(HaveOccurred())
 		if err := ensureMactlTestBinary(); err != nil {
 			Fail(fmt.Sprintf("Failed to build mactl test binary: %v", err))
 		}
 
 		By("モックサーバー用etcdの起動")
 		var etcdEp string
-		var err error
 		containerID, etcdEp, err = startEtcdContainer()
 		if err != nil {
 			Fail(fmt.Sprintf("Failed to start container: %v", err))
@@ -45,6 +48,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		By("モックサーバーの起動")
 		mockServer, err = startMockServer(etcdEp)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(loginAsAdmin()).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func(specCtx SpecContext) {
@@ -83,6 +87,9 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			fmt.Printf("Failed to remove container: %v\n", err)
+		}
+		if strings.TrimSpace(testHomeDir) != "" {
+			_ = os.RemoveAll(testHomeDir)
 		}
 		os.Remove("bin/mactl-test")
 		os.Remove("/var/actions-runner/_work/marmot/marmot/cmd/mactl/bin/mactl-test")

--- a/cmd/mactl/mactl_test.go
+++ b/cmd/mactl/mactl_test.go
@@ -754,4 +754,70 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+
+	Context("ユーザー認証のテスト", func() {
+		loginWithPassword := func(userID, password string) ([]byte, error) {
+			cmdLine := fmt.Sprintf(`printf "%%s\n" %q | script -qec "./bin/mactl-test --api testdata/.marmot login %s" /dev/null`, password, userID)
+			cmd := exec.Command("sh", "-lc", cmdLine)
+			return cmd.CombinedOutput()
+		}
+
+		AfterEach(func() {
+			Expect(loginAsAdmin()).NotTo(HaveOccurred())
+		})
+
+		It("mactl whoami で admin のロール情報を表示できる", func() {
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "whoami")
+			stdoutStderr, err := cmd.CombinedOutput()
+			GinkgoWriter.Println(string(stdoutStderr))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(stdoutStderr)).To(ContainSubstring("User: admin"))
+			Expect(string(stdoutStderr)).To(ContainSubstring("Administrator"))
+		})
+
+		It("作成したユーザーで login 後に whoami へ反映される", func() {
+			const userID = "auth-test-user"
+			const password = "lemon123"
+
+			cleanupCmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "user", "delete", userID)
+			_, _ = cleanupCmd.CombinedOutput()
+
+			createCmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "user", "add", userID, "--passwd", password, "--role", "Compute-Operator")
+			createOut, err := createCmd.CombinedOutput()
+			GinkgoWriter.Println(string(createOut))
+			Expect(err).NotTo(HaveOccurred())
+
+			loginOut, err := loginWithPassword(userID, password)
+			GinkgoWriter.Println(string(loginOut))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(loginOut)).To(ContainSubstring("Successfully logged in as "+userID))
+
+			whoamiCmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "whoami")
+			whoamiOut, err := whoamiCmd.CombinedOutput()
+			GinkgoWriter.Println(string(whoamiOut))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(whoamiOut)).To(ContainSubstring("User: " + userID))
+			Expect(string(whoamiOut)).To(ContainSubstring("Compute-Operator"))
+
+			Expect(loginAsAdmin()).NotTo(HaveOccurred())
+			delCmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "user", "delete", userID)
+			delOut, delErr := delCmd.CombinedOutput()
+			GinkgoWriter.Println(string(delOut))
+			Expect(delErr).NotTo(HaveOccurred())
+		})
+
+		It("logout 後の whoami は失敗する", func() {
+			logoutCmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "logout")
+			logoutOut, err := logoutCmd.CombinedOutput()
+			GinkgoWriter.Println(string(logoutOut))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(logoutOut)).To(ContainSubstring("Successfully logged out"))
+
+			whoamiCmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "whoami")
+			whoamiOut, whoamiErr := whoamiCmd.CombinedOutput()
+			GinkgoWriter.Println(string(whoamiOut))
+			Expect(whoamiErr).To(HaveOccurred())
+			Expect(strings.Contains(string(whoamiOut), "failed to get current user") || strings.Contains(string(whoamiOut), "missing or invalid Authorization header")).To(BeTrue())
+		})
+	})
 })

--- a/cmd/mactl/mactl_test.go
+++ b/cmd/mactl/mactl_test.go
@@ -20,6 +20,7 @@ const testServerConfigRawURL = "https://raw.githubusercontent.com/takara9/marmot
 var _ = Describe("Marmotd Test", Ordered, func() {
 	var mockServer *mockServerHandle
 	var containerID string
+	var testHomeDir string
 
 	BeforeAll(func(specCtx SpecContext) {
 		opts := &slog.HandlerOptions{
@@ -29,13 +30,15 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, opts))
 		slog.SetDefault(logger)
 		cleanupTestEnvironment()
+		var err error
+		testHomeDir, err = setupMactlTestHome()
+		Expect(err).NotTo(HaveOccurred())
 		if err := ensureMactlTestBinary(); err != nil {
 			Fail(fmt.Sprintf("Failed to build mactl test binary: %v", err))
 		}
 
 		By("モックサーバー用etcdの起動")
 		var etcdEp string
-		var err error
 		containerID, etcdEp, err = startEtcdContainer()
 		if err != nil {
 			Fail(fmt.Sprintf("Failed to start container: %v", err))
@@ -45,6 +48,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		By("モックサーバーの起動")
 		mockServer, err = startMockServer(etcdEp)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(loginAsAdmin()).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func(specCtx SpecContext) {
@@ -58,6 +62,9 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			fmt.Printf("Failed to remove container: %v\n", err)
+		}
+		if strings.TrimSpace(testHomeDir) != "" {
+			_ = os.RemoveAll(testHomeDir)
 		}
 		os.Remove("bin/mactl-test")
 		os.Remove("/var/actions-runner/_work/marmot/marmot/cmd/mactl/bin/mactl-test")

--- a/cmd/mactl/test-helper.go
+++ b/cmd/mactl/test-helper.go
@@ -46,6 +46,27 @@ func ensureMactlTestBinary() error {
 	return nil
 }
 
+func loginAsAdmin() error {
+	cmd := exec.Command("sh", "-lc", "printf 'passw0rd\n' | script -qec './bin/mactl-test --api testdata/.marmot login admin' /dev/null")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to login as admin: %w (output=%s)", err, string(output))
+	}
+	return nil
+}
+
+func setupMactlTestHome() (string, error) {
+	homeDir, err := os.MkdirTemp("", "mactl-home-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp HOME: %w", err)
+	}
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		_ = os.RemoveAll(homeDir)
+		return "", fmt.Errorf("failed to set HOME: %w", err)
+	}
+	return homeDir, nil
+}
+
 func startEtcdContainer() (string, string, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/docs/MEMO-mactl-authenticvation.md
+++ b/docs/MEMO-mactl-authenticvation.md
@@ -28,6 +28,7 @@
 - `mactl login USER-ID` ログイン、他ユーザーでログインしている時は、ログインが成功すると既存セッションはログアウトする
 - `mactl whoami` 自分のユーザーIDとロールを表示、`mactl role` のエリアス
 - `mactl role` 自身に付与されたロールのリスト表示
+- `mactl role list` 組み込みロール一覧の表示
 - `mactl logout`
 - `mactl passwd` ユーザーのパスワード変更用
 - `mactl user generate-apikey --comment TEXT` APIキーを生成する。コメントは任意
@@ -44,7 +45,6 @@
 - `mactl user delete USER-ID` USER-IDの削除
 - `mactl user set-passwd USER-ID --passwd PASSWORD` USER-IDのパスワード再セット用
 - `mactl user lock USER-ID` ユーザーの使用を停止する。ユーザーのAPIキーも同様に無効化される。
-- `mactl role list` 組み込みロール一覧の表示
 - `mactl user list` ユーザー一覧の表示、表示列: USER-ID / ENABLED / ROLE / AGE
 
 ### ユーザーがパスワードをロスした時の処理

--- a/docs/MEMO-mactl-authenticvation.md
+++ b/docs/MEMO-mactl-authenticvation.md
@@ -53,6 +53,9 @@
 
 ## 認可
 - ユーザーは、割当られたロールで、コマンドを実行する権限が与えられる RBAC方式を採用する。
+- `/authz/check` は、`userId` 未指定時は認証済みの自ユーザーを照会対象とする。
+- `/authz/check` で `userId` を指定する場合、照会可能なのは「自ユーザー」または `Administrator` ロールのみとする。
+- `Administrator` 以外が他ユーザーを指定して照会した場合は、`403 forbidden` を返す。
 - ロールには、以下の種類と権限がある。
     - Administrator
         - Server: 作成, 参照, 更新, 削除

--- a/pkg/marmotd/api-auth.go
+++ b/pkg/marmotd/api-auth.go
@@ -184,6 +184,9 @@ func (s *Server) ApiAuthzCheck(ctx echo.Context) error {
 	if req.UserId != nil && strings.TrimSpace(*req.UserId) != "" {
 		checkUserID = strings.TrimSpace(*req.UserId)
 	}
+	if strings.TrimSpace(checkUserID) != strings.TrimSpace(user.Metadata.Id) && !userHasAnyRole(user, []string{"Administrator"}) {
+		return apiErrorJSON(ctx, http.StatusForbidden, "forbidden")
+	}
 	allowed, err := s.Ma.Db.Authorize(checkUserID, resource, action)
 	if err != nil {
 		return mapAuthDBError(ctx, err)

--- a/pkg/marmotd/api-rbac-middleware.go
+++ b/pkg/marmotd/api-rbac-middleware.go
@@ -1,0 +1,142 @@
+package marmotd
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+type operationRBACRule struct {
+	Resource  string
+	Verb      string
+	AllowSelf bool
+	SelfParam string
+}
+
+func rbacOperationMiddlewares(s *Server) map[string][]echo.MiddlewareFunc {
+	rules := map[string]operationRBACRule{
+		"apiAuthLogout": {Resource: "", Verb: ""},
+		"apiAuthMe":     {Resource: "", Verb: ""},
+		"apiAuthzCheck": {Resource: "", Verb: ""},
+
+		"apiListRoles":    {Resource: "", Verb: ""},
+		"apiGetRoleByName": {Resource: "", Verb: ""},
+
+		"apiGetMarmotStatus":  {Resource: "Cluster", Verb: "read"},
+		"apiGetMarmotCluster": {Resource: "Cluster", Verb: "read"},
+
+		"apiGetServers":                    {Resource: "Server", Verb: "read"},
+		"apiCreateServer":                  {Resource: "Server", Verb: "create"},
+		"apiGetServerById":                 {Resource: "Server", Verb: "read"},
+		"apiUpdateServerById":              {Resource: "Server", Verb: "update"},
+		"apiDeleteServerById":              {Resource: "Server", Verb: "delete"},
+		"apiStartServerById":               {Resource: "Server", Verb: "update"},
+		"apiStopServerById":                {Resource: "Server", Verb: "update"},
+		"apiMakeImageEntryFromRunningVMById": {Resource: "Server", Verb: "update"},
+		"apiConsoleServerById":             {Resource: "Server", Verb: "read"},
+
+		"apiListVolumes":      {Resource: "Volume", Verb: "read"},
+		"apiCreateVolume":     {Resource: "Volume", Verb: "create"},
+		"apiShowVolumeById":   {Resource: "Volume", Verb: "read"},
+		"apiUpdateVolumeById": {Resource: "Volume", Verb: "update"},
+		"apiDeleteVolumeById": {Resource: "Volume", Verb: "delete"},
+
+		"apiGetNetworks":          {Resource: "Network", Verb: "read"},
+		"apiCreateNetwork":        {Resource: "Network", Verb: "create"},
+		"apiGetNetworkById":       {Resource: "Network", Verb: "read"},
+		"apiUpdateNetworkById":    {Resource: "Network", Verb: "update"},
+		"apiDeleteNetworkById":    {Resource: "Network", Verb: "delete"},
+		"apiListIpNetworks":       {Resource: "Network", Verb: "read"},
+		"apiGetIpAddressesByNetwork": {Resource: "Network", Verb: "read"},
+		"apiGetNetworkIpNetworks": {Resource: "Network", Verb: "read"},
+
+		"apiGetGateways":        {Resource: "ServerGateway", Verb: "read"},
+		"apiCreateGateway":      {Resource: "ServerGateway", Verb: "create"},
+		"apiGetGatewayById":     {Resource: "ServerGateway", Verb: "read"},
+		"apiUpdateGatewayById":  {Resource: "ServerGateway", Verb: "update"},
+		"apiDeleteGatewayById":  {Resource: "ServerGateway", Verb: "delete"},
+		"apiGetGatewayCertById": {Resource: "ServerGateway", Verb: "read"},
+
+		"apiGetVpnGateways":        {Resource: "VpnGateway", Verb: "read"},
+		"apiCreateVpnGateway":      {Resource: "VpnGateway", Verb: "create"},
+		"apiGetVpnGatewayById":     {Resource: "VpnGateway", Verb: "read"},
+		"apiUpdateVpnGatewayById":  {Resource: "VpnGateway", Verb: "update"},
+		"apiDeleteVpnGatewayById":  {Resource: "VpnGateway", Verb: "delete"},
+		"apiGetVpnGatewayCertById": {Resource: "VpnGateway", Verb: "read"},
+
+		"apiGetNetworkLoadBalancers":      {Resource: "NetworkLoadBalancer", Verb: "read"},
+		"apiCreateNetworkLoadBalancer":    {Resource: "NetworkLoadBalancer", Verb: "create"},
+		"apiGetNetworkLoadBalancerById":   {Resource: "NetworkLoadBalancer", Verb: "read"},
+		"apiUpdateNetworkLoadBalancerById": {Resource: "NetworkLoadBalancer", Verb: "update"},
+		"apiDeleteNetworkLoadBalancerById": {Resource: "NetworkLoadBalancer", Verb: "delete"},
+
+		"apiGetLoadBalancers":      {Resource: "ApplicationLoadBalancer", Verb: "read"},
+		"apiCreateLoadBalancer":    {Resource: "ApplicationLoadBalancer", Verb: "create"},
+		"apiGetLoadBalancerById":   {Resource: "ApplicationLoadBalancer", Verb: "read"},
+		"apiUpdateLoadBalancerById": {Resource: "ApplicationLoadBalancer", Verb: "update"},
+		"apiDeleteLoadBalancerById": {Resource: "ApplicationLoadBalancer", Verb: "delete"},
+
+		"apiGetImages":            {Resource: "Server", Verb: "read"},
+		"apiCreateImage":          {Resource: "Server", Verb: "create"},
+		"apiGetImageById":         {Resource: "Server", Verb: "read"},
+		"apiUpdateImageById":      {Resource: "Server", Verb: "update"},
+		"apiDeleteImageById":      {Resource: "Server", Verb: "delete"},
+		"apiDownloadImageQcow2ById": {Resource: "Server", Verb: "read"},
+		"apiImportImageArchive":   {Resource: "Server", Verb: "create"},
+
+		"apiListUsers":       {Resource: "User", Verb: "read"},
+		"apiCreateUser":      {Resource: "User", Verb: "create"},
+		"apiGetUserById":     {Resource: "User", Verb: "read", AllowSelf: true, SelfParam: "userId"},
+		"apiUpdateUserById":  {Resource: "User", Verb: "update"},
+		"apiDeleteUserById":  {Resource: "User", Verb: "delete"},
+		"apiLockUserById":    {Resource: "User", Verb: "update"},
+		"apiUnlockUserById":  {Resource: "User", Verb: "update"},
+		"apiChangeUserPassword": {Resource: "User", Verb: "update", AllowSelf: true, SelfParam: "userId"},
+		"apiListUserRoles":      {Resource: "User", Verb: "read", AllowSelf: true, SelfParam: "userId"},
+		"apiAddUserRole":        {Resource: "User", Verb: "update"},
+		"apiDeleteUserRole":     {Resource: "User", Verb: "update"},
+		"apiListUserApiKeys":    {Resource: "User", Verb: "read", AllowSelf: true, SelfParam: "userId"},
+		"apiCreateUserApiKey":   {Resource: "User", Verb: "create", AllowSelf: true, SelfParam: "userId"},
+		"apiDeleteUserApiKey":   {Resource: "User", Verb: "delete", AllowSelf: true, SelfParam: "userId"},
+	}
+
+	middlewares := make(map[string][]echo.MiddlewareFunc, len(rules))
+	for operationID, rule := range rules {
+		r := rule
+		middlewares[operationID] = []echo.MiddlewareFunc{func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(ctx echo.Context) error {
+				user, _, _, err := s.requireBearerAuth(ctx)
+				if err != nil {
+					return err
+				}
+				if ctx.Response().Committed {
+					// requireBearerAuth already wrote an error response (e.g. 401)
+					return nil
+				}
+
+				if strings.TrimSpace(r.Resource) == "" || strings.TrimSpace(r.Verb) == "" {
+					return next(ctx)
+				}
+
+				if r.AllowSelf && strings.TrimSpace(r.SelfParam) != "" {
+					if strings.TrimSpace(ctx.Param(r.SelfParam)) == strings.TrimSpace(user.Metadata.Id) {
+						return next(ctx)
+					}
+				}
+
+				allowed, authErr := s.Ma.Db.Authorize(user.Metadata.Id, r.Resource, r.Verb)
+				if authErr != nil {
+					return mapAuthDBError(ctx, authErr)
+				}
+				if !allowed {
+					return apiErrorJSON(ctx, http.StatusForbidden, "forbidden")
+				}
+
+				return next(ctx)
+			}
+		}}
+	}
+
+	return middlewares
+}

--- a/pkg/marmotd/api-rbac-middleware.go
+++ b/pkg/marmotd/api-rbac-middleware.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v4"
+	"github.com/takara9/marmot/api"
 )
 
 type operationRBACRule struct {
@@ -12,6 +13,7 @@ type operationRBACRule struct {
 	Verb      string
 	AllowSelf bool
 	SelfParam string
+	RequiredRoles []string
 }
 
 func rbacOperationMiddlewares(s *Server) map[string][]echo.MiddlewareFunc {
@@ -85,7 +87,7 @@ func rbacOperationMiddlewares(s *Server) map[string][]echo.MiddlewareFunc {
 		"apiDownloadImageQcow2ById": {Resource: "Server", Verb: "read"},
 		"apiImportImageArchive":   {Resource: "Server", Verb: "create"},
 
-		"apiListUsers":       {Resource: "User", Verb: "read"},
+		"apiListUsers":       {Resource: "User", Verb: "read", RequiredRoles: []string{"Administrator"}},
 		"apiCreateUser":      {Resource: "User", Verb: "create"},
 		"apiGetUserById":     {Resource: "User", Verb: "read", AllowSelf: true, SelfParam: "userId"},
 		"apiUpdateUserById":  {Resource: "User", Verb: "update"},
@@ -125,6 +127,12 @@ func rbacOperationMiddlewares(s *Server) map[string][]echo.MiddlewareFunc {
 					}
 				}
 
+				if len(r.RequiredRoles) > 0 {
+					if !userHasAnyRole(user, r.RequiredRoles) {
+						return apiErrorJSON(ctx, http.StatusForbidden, "forbidden")
+					}
+				}
+
 				allowed, authErr := s.Ma.Db.Authorize(user.Metadata.Id, r.Resource, r.Verb)
 				if authErr != nil {
 					return mapAuthDBError(ctx, authErr)
@@ -139,4 +147,22 @@ func rbacOperationMiddlewares(s *Server) map[string][]echo.MiddlewareFunc {
 	}
 
 	return middlewares
+}
+
+func userHasAnyRole(user api.User, requiredRoles []string) bool {
+	if user.Spec.Roles == nil || len(*user.Spec.Roles) == 0 {
+		return false
+	}
+	for _, userRole := range *user.Spec.Roles {
+		trimmedUserRole := strings.TrimSpace(userRole)
+		if trimmedUserRole == "" {
+			continue
+		}
+		for _, requiredRole := range requiredRoles {
+			if strings.EqualFold(trimmedUserRole, strings.TrimSpace(requiredRole)) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/marmotd/api-routes.go
+++ b/pkg/marmotd/api-routes.go
@@ -7,35 +7,39 @@ import (
 
 // RegisterRoutes registers generated OpenAPI routes and project-specific extension routes.
 func RegisterRoutes(e *echo.Echo, server *Server, baseURL string) {
-	api.RegisterHandlersWithBaseURL(e, server, baseURL)
-	e.GET(baseURL+"/image/:id/qcow2", server.ApiDownloadImageQcow2ById)
-	e.POST(baseURL+"/image/import", server.ApiImportImageArchive)
+	operationMiddlewares := rbacOperationMiddlewares(server)
+	api.RegisterHandlersWithOptions(e, server, api.RegisterHandlersOptions{
+		BaseURL:              baseURL,
+		OperationMiddlewares: operationMiddlewares,
+	})
+	e.GET(baseURL+"/image/:id/qcow2", server.ApiDownloadImageQcow2ById, operationMiddlewares["apiDownloadImageQcow2ById"]...)
+	e.POST(baseURL+"/image/import", server.ApiImportImageArchive, operationMiddlewares["apiImportImageArchive"]...)
 	e.GET(baseURL+"/gateway/:id/cert", func(ctx echo.Context) error {
 		return server.ApiGetGatewayCertById(ctx, ctx.Param("id"))
-	})
-	e.POST(baseURL+"/application-load-balancer", server.ApiCreateLoadBalancer)
-	e.GET(baseURL+"/application-load-balancer", server.ApiGetLoadBalancers)
+	}, operationMiddlewares["apiGetGatewayCertById"]...)
+	e.POST(baseURL+"/application-load-balancer", server.ApiCreateLoadBalancer, operationMiddlewares["apiCreateLoadBalancer"]...)
+	e.GET(baseURL+"/application-load-balancer", server.ApiGetLoadBalancers, operationMiddlewares["apiGetLoadBalancers"]...)
 	e.GET(baseURL+"/application-load-balancer/:id", func(ctx echo.Context) error {
 		return server.ApiGetLoadBalancerById(ctx, ctx.Param("id"))
-	})
+	}, operationMiddlewares["apiGetLoadBalancerById"]...)
 	e.PUT(baseURL+"/application-load-balancer/:id", func(ctx echo.Context) error {
 		return server.ApiUpdateLoadBalancerById(ctx, ctx.Param("id"))
-	})
+	}, operationMiddlewares["apiUpdateLoadBalancerById"]...)
 	e.DELETE(baseURL+"/application-load-balancer/:id", func(ctx echo.Context) error {
 		return server.ApiDeleteLoadBalancerById(ctx, ctx.Param("id"))
-	})
-	e.POST(baseURL+"/vpn-gateway", server.ApiCreateVpnGateway)
-	e.GET(baseURL+"/vpn-gateway", server.ApiGetVpnGateways)
+	}, operationMiddlewares["apiDeleteLoadBalancerById"]...)
+	e.POST(baseURL+"/vpn-gateway", server.ApiCreateVpnGateway, operationMiddlewares["apiCreateVpnGateway"]...)
+	e.GET(baseURL+"/vpn-gateway", server.ApiGetVpnGateways, operationMiddlewares["apiGetVpnGateways"]...)
 	e.GET(baseURL+"/vpn-gateway/:id", func(ctx echo.Context) error {
 		return server.ApiGetVpnGatewayById(ctx, ctx.Param("id"))
-	})
+	}, operationMiddlewares["apiGetVpnGatewayById"]...)
 	e.PUT(baseURL+"/vpn-gateway/:id", func(ctx echo.Context) error {
 		return server.ApiUpdateVpnGatewayById(ctx, ctx.Param("id"))
-	})
+	}, operationMiddlewares["apiUpdateVpnGatewayById"]...)
 	e.DELETE(baseURL+"/vpn-gateway/:id", func(ctx echo.Context) error {
 		return server.ApiDeleteVpnGatewayById(ctx, ctx.Param("id"))
-	})
+	}, operationMiddlewares["apiDeleteVpnGatewayById"]...)
 	e.GET(baseURL+"/vpn-gateway/:id/cert", func(ctx echo.Context) error {
 		return server.ApiGetVpnGatewayCertById(ctx, ctx.Param("id"))
-	})
+	}, operationMiddlewares["apiGetVpnGatewayCertById"]...)
 }

--- a/pkg/marmotd/api_auth_handler_test.go
+++ b/pkg/marmotd/api_auth_handler_test.go
@@ -185,6 +185,46 @@ var _ = Describe("Auth API handlers", Ordered, func() {
 		Expect(deleteRec.Code).To(Equal(http.StatusNoContent), deleteRec.Body.String())
 	})
 
+	It("denies user list to non-administrator roles", func() {
+		viewerHash, err := bcrypt.GenerateFromPassword([]byte("viewerpass1"), bcrypt.DefaultCost)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = d.CreateUser(api.User{
+			ApiVersion: "v1",
+			Kind:       "User",
+			Metadata: api.Metadata{Id: "viewer2", Name: "viewer2"},
+			Spec: api.UserSpec{
+				Enabled:      true,
+				PasswordHash: util.StringPtr(string(viewerHash)),
+				Roles:        &[]string{"Viewer"},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		viewerToken := login("viewer2", "viewerpass1").AccessToken
+
+		router := echo.New()
+		marmotd.RegisterRoutes(router, s, "/api/v1")
+
+		viewerReq := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		viewerReq.Header.Set("Authorization", "Bearer "+viewerToken)
+		viewerRec := httptest.NewRecorder()
+		router.ServeHTTP(viewerRec, viewerReq)
+		Expect(viewerRec.Code).To(Equal(http.StatusForbidden), viewerRec.Body.String())
+
+		adminToken := login("admin", "passw0rd").AccessToken
+		adminReq := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		adminReq.Header.Set("Authorization", "Bearer "+adminToken)
+		adminRec := httptest.NewRecorder()
+		router.ServeHTTP(adminRec, adminReq)
+		Expect(adminRec.Code).To(Equal(http.StatusOK), adminRec.Body.String())
+
+		cleanupReq := httptest.NewRequest(http.MethodDelete, "/api/v1/users/viewer2", nil)
+		cleanupReq.Header.Set("Authorization", "Bearer "+adminToken)
+		cleanupRec := httptest.NewRecorder()
+		router.ServeHTTP(cleanupRec, cleanupReq)
+		Expect(cleanupRec.Code).To(Equal(http.StatusNoContent), cleanupRec.Body.String())
+	})
+
 	It("supports API key create/list/delete", func() {
 		token := login("admin", "passw0rd").AccessToken
 

--- a/pkg/marmotd/api_auth_handler_test.go
+++ b/pkg/marmotd/api_auth_handler_test.go
@@ -295,4 +295,54 @@ var _ = Describe("Auth API handlers", Ordered, func() {
 		router.ServeHTTP(cleanupRec, cleanupReq)
 		Expect(cleanupRec.Code).To(Equal(http.StatusNoContent), cleanupRec.Body.String())
 	})
+
+	It("restricts authz check target to self or administrator", func() {
+		adminToken := login("admin", "passw0rd").AccessToken
+
+		viewerHash, err := bcrypt.GenerateFromPassword([]byte("viewerpass3"), bcrypt.DefaultCost)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = d.CreateUser(api.User{
+			ApiVersion: "v1",
+			Kind:       "User",
+			Metadata: api.Metadata{Id: "viewer3", Name: "viewer3"},
+			Spec: api.UserSpec{
+				Enabled:      true,
+				PasswordHash: util.StringPtr(string(viewerHash)),
+				Roles:        &[]string{"Viewer"},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		viewerToken := login("viewer3", "viewerpass3").AccessToken
+
+		router := echo.New()
+		marmotd.RegisterRoutes(router, s, "/api/v1")
+
+		selfReq := httptest.NewRequest(http.MethodPost, "/api/v1/authz/check", strings.NewReader(`{"resource":"Server","action":"read"}`))
+		selfReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		selfReq.Header.Set("Authorization", "Bearer "+viewerToken)
+		selfRec := httptest.NewRecorder()
+		router.ServeHTTP(selfRec, selfReq)
+		Expect(selfRec.Code).To(Equal(http.StatusOK), selfRec.Body.String())
+
+		otherReq := httptest.NewRequest(http.MethodPost, "/api/v1/authz/check", strings.NewReader(`{"userId":"admin","resource":"Server","action":"read"}`))
+		otherReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		otherReq.Header.Set("Authorization", "Bearer "+viewerToken)
+		otherRec := httptest.NewRecorder()
+		router.ServeHTTP(otherRec, otherReq)
+		Expect(otherRec.Code).To(Equal(http.StatusForbidden), otherRec.Body.String())
+
+		adminReq := httptest.NewRequest(http.MethodPost, "/api/v1/authz/check", strings.NewReader(`{"userId":"viewer3","resource":"Server","action":"read"}`))
+		adminReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		adminReq.Header.Set("Authorization", "Bearer "+adminToken)
+		adminRec := httptest.NewRecorder()
+		router.ServeHTTP(adminRec, adminReq)
+		Expect(adminRec.Code).To(Equal(http.StatusOK), adminRec.Body.String())
+
+		cleanupReq := httptest.NewRequest(http.MethodDelete, "/api/v1/users/viewer3", nil)
+		cleanupReq.Header.Set("Authorization", "Bearer "+adminToken)
+		cleanupRec := httptest.NewRecorder()
+		router.ServeHTTP(cleanupRec, cleanupReq)
+		Expect(cleanupRec.Code).To(Equal(http.StatusNoContent), cleanupRec.Body.String())
+	})
 })

--- a/pkg/marmotd/api_auth_handler_test.go
+++ b/pkg/marmotd/api_auth_handler_test.go
@@ -212,4 +212,47 @@ var _ = Describe("Auth API handlers", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(delRec.Code).To(Equal(http.StatusNoContent), delRec.Body.String())
 	})
+
+	It("enforces role-based access on registered routes", func() {
+		adminToken := login("admin", "passw0rd").AccessToken
+
+		viewerHash, err := bcrypt.GenerateFromPassword([]byte("viewerpass1"), bcrypt.DefaultCost)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = d.CreateUser(api.User{
+			ApiVersion: "v1",
+			Kind:       "User",
+			Metadata: api.Metadata{Id: "viewer1", Name: "viewer1"},
+			Spec: api.UserSpec{
+				Enabled:      true,
+				PasswordHash: util.StringPtr(string(viewerHash)),
+				Roles:        &[]string{"Viewer"},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		viewerToken := login("viewer1", "viewerpass1").AccessToken
+
+		router := echo.New()
+		marmotd.RegisterRoutes(router, s, "/api/v1")
+
+		createReq := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(`{"apiVersion":"v1","kind":"User","metadata":{"id":"blocked","name":"blocked"},"spec":{"enabled":true,"passwordHash":"dummy"}}`))
+		createReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		createReq.Header.Set("Authorization", "Bearer "+viewerToken)
+		createRec := httptest.NewRecorder()
+		router.ServeHTTP(createRec, createReq)
+		Expect(createRec.Code).To(Equal(http.StatusForbidden), createRec.Body.String())
+
+		passReq := httptest.NewRequest(http.MethodPost, "/api/v1/users/viewer1/password", strings.NewReader(`{"newPassword":"viewerpass2"}`))
+		passReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		passReq.Header.Set("Authorization", "Bearer "+viewerToken)
+		passRec := httptest.NewRecorder()
+		router.ServeHTTP(passRec, passReq)
+		Expect(passRec.Code).To(Equal(http.StatusNoContent), passRec.Body.String())
+
+		cleanupReq := httptest.NewRequest(http.MethodDelete, "/api/v1/users/viewer1", nil)
+		cleanupReq.Header.Set("Authorization", "Bearer "+adminToken)
+		cleanupRec := httptest.NewRecorder()
+		router.ServeHTTP(cleanupRec, cleanupReq)
+		Expect(cleanupRec.Code).To(Equal(http.StatusNoContent), cleanupRec.Body.String())
+	})
 })


### PR DESCRIPTION
## 概要
認証・認可周りの運用で発生していた2つの問題を修正しました。

1. RBAC の operation 単位適用を導入し、ROLEに応じたアクセス制御を API ルートに統一適用  
2. mactl user add で作成したユーザーがログインできない不具合を修正  
3. mactl create 実行時にログイン後でも 401 missing or invalid Authorization header になる不具合を修正

## 背景
- user add で指定したパスワードが作成時に保存されず、PasswordHash が空のユーザーが作られていた
- 一部コマンドでアクセストークンのロードが漏れており、login 後でも Authorization ヘッダなしで API を叩く経路があった
- RBAC ミドルウェアで認証エラー後に後続処理が継続し、401 と 404 が連結表示されるケースがあった

## 変更内容
### 1) RBAC 適用
- 追加: api-rbac-middleware.go
  - operationId ごとに resource/verb/self 例外を定義
  - requireBearerAuth + Authorize による一元認可
- 更新: api-routes.go
  - RegisterHandlersWithOptions で OperationMiddlewares を適用
  - 拡張ルートにも同一 RBAC を適用
- 更新: api_auth_handler_test.go
  - Viewer の禁止操作が 403、自ユーザーの許可操作が通ることを検証

### 2) user add のログイン不可修正
- 更新: user_add.go
  - --passwd を bcrypt ハッシュ化して Spec.PasswordHash を設定してから CreateUser
- 更新: response_id_test.go
  - ハッシュ生成の回帰テストを追加

### 3) login 後 create で 401 となる不具合修正
- 更新: common.go
  - getClientConfig 内でトークンを自動ロードするよう変更
  - 既存コマンド全体に副作用なく適用される形で修正
- 更新: api-rbac-middleware.go
  - 認証失敗でレスポンス確定済みの場合は後続処理を止めるガードを追加

## 動作確認
- go build ./cmd/mactl ./cmd/marmotd
- go test ./pkg/marmotd -run TestMarmotd -count=1 -ginkgo.focus="Auth API handlers"
- go test ./cmd/mactl/cmd -run TestPasswordHashFromPlain -count=1

## 期待される効果
- ROLEベースのアクセス制御が API 全体で一貫適用される
- mactl user add 直後に対象ユーザーでログイン可能になる
- mactl login 後の mactl create が Authorization ヘッダ付きで実行される
- 認証失敗時の 401/404 連結表示が解消される