### PR TITLE
Otelのログにファイル、行番号の表示を追加

### DIFF
--- a/pkg/marmotd/loki_slog.go
+++ b/pkg/marmotd/loki_slog.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -134,6 +135,10 @@ func (h *lokiHandler) Handle(ctx context.Context, r slog.Record) error {
 		"msg":   r.Message,
 	}
 
+	if source, ok := sourceFromPC(r.PC); ok {
+		body["source"] = source
+	}
+
 	attrs := make(map[string]interface{})
 	for _, attr := range h.attrs {
 		appendAttr(attrs, h.group, attr)
@@ -188,6 +193,34 @@ func appendAttr(target map[string]interface{}, group string, attr slog.Attr) {
 	}
 
 	target[key] = attrValueToAny(value)
+}
+
+func sourceFromPC(pc uintptr) (map[string]interface{}, bool) {
+	if pc == 0 {
+		return nil, false
+	}
+
+	frames := runtime.CallersFrames([]uintptr{pc})
+	frame, _ := frames.Next()
+	if frame.File == "" && frame.Function == "" && frame.Line <= 0 {
+		return nil, false
+	}
+
+	source := map[string]interface{}{}
+	if frame.Function != "" {
+		source["function"] = frame.Function
+	}
+	if frame.File != "" {
+		source["file"] = frame.File
+	}
+	if frame.Line > 0 {
+		source["line"] = frame.Line
+	}
+
+	if len(source) == 0 {
+		return nil, false
+	}
+	return source, true
 }
 
 func attrValueToAny(v slog.Value) interface{} {

--- a/pkg/marmotd/loki_slog_test.go
+++ b/pkg/marmotd/loki_slog_test.go
@@ -1,6 +1,9 @@
 package marmotd
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 func TestNormalizeLokiPushURL(t *testing.T) {
 	tests := []struct {
@@ -33,5 +36,33 @@ func TestNormalizeLokiPushURL(t *testing.T) {
 				t.Fatalf("unexpected url: got=%s want=%s", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSourceFromPC(t *testing.T) {
+	pc, _, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("runtime.Caller failed")
+	}
+
+	source, found := sourceFromPC(pc)
+	if !found {
+		t.Fatalf("source not found")
+	}
+
+	if _, ok := source["file"].(string); !ok {
+		t.Fatalf("file is missing or not string: %#v", source["file"])
+	}
+	if _, ok := source["function"].(string); !ok {
+		t.Fatalf("function is missing or not string: %#v", source["function"])
+	}
+	if line, ok := source["line"].(int); !ok || line <= 0 {
+		t.Fatalf("line is missing or invalid: %#v", source["line"])
+	}
+}
+
+func TestSourceFromPCZero(t *testing.T) {
+	if _, ok := sourceFromPC(0); ok {
+		t.Fatalf("expected no source for pc=0")
 	}
 }


### PR DESCRIPTION
## 概要
Loki に送信される JSON ログへ、エラー発生箇所の source 情報（function, file, line）を追加しました。  
Issue: #518

## 背景
これまでは Loki 側のログに source 情報が含まれず、ブラウザ上でエラーの発生箇所を直接追跡しづらい状態でした。  
本変更により、journalctl を併用しなくても Loki 上で追跡しやすくなります。

## 変更内容
- Loki 送信用ログ整形処理で、slog の PC 情報から source を復元して JSON に格納
- 追加項目:
  - source.function
  - source.file
  - source.line
- source 復元ロジックの単体テストを追加（正常系 / pc=0 の境界系）

## 期待されるログ例
{
  "time": "2026-06-27T10:43:02.991484398Z",
  "level": "ERROR",
  "source": {
    "function": "github.com/takara9/marmot/pkg/controller.(*controller).serverControllerLoop",
    "file": "/home/ubuntu/marmot/pkg/controller/server-controller.go",
    "line": 176
  },
  "msg": "CreateServerManage()",
  "attrs": {
    "err": "network 'private-net' is not ready for IP allocation"
  }
}

## 変更ファイル
- loki_slog.go
- loki_slog_test.go

## 動作確認
- go test ./cmd/marmotd
- go test ./pkg/marmotd -run Test(SourceFromPC|SourceFromPCZero|NormalizeLokiPushURL)$

## 影響範囲
- marmotd の Loki 送信ログフォーマット
- 既存の stderr 向け JSON ログ出力仕様には影響なし

## レビュー観点
- source 情報のキー名と構造が Loki 側の可視化要件に合っているか
- source が取得できないケース（pc=0 など）でのフォールバック挙動が妥当か

Closes #518