### PR TITLE
ネットワーク設定の整理

### DIFF
--- a/cmd/mactl/mactl-vm-deploy-1_test.go
+++ b/cmd/mactl/mactl-vm-deploy-1_test.go
@@ -142,6 +142,9 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 	})
 
 	Context("基礎ネットワークの準備", func() {
+		/*
+		以下の部分は、workflow/main.yaml から tools/setup-libvirt-networks.sh を呼び出しているので、テストコードからコメントアウトする
+
 		It("定義 default", func() {
 			By("定義設定 デファルト")
 			cmd := exec.Command("virsh", "net-define", "testdata/default-network.xml")
@@ -219,6 +222,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 			}
 			//Expect(err).NotTo(HaveOccurred())
 		})
+		*/
 
 		It("DB登録をチェック JSON形式", func() {
 			Eventually(func(g Gomega) {

--- a/tools/cleanup-logical-volume.sh
+++ b/tools/cleanup-logical-volume.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Logical volume cleanup script
+# 
+set -euo pipefail
+
+tmpfile=$(mktemp)
+sudo lvs --reportformat json  |jq -r '.report[].lv[] | "\(.vg_name)/\(.lv_name)"' > "$tmpfile"
+
+
+cat "$tmpfile" | while read -r line; do
+  lv_path="$line"
+  echo "Deleting logical volume $lv_path"
+  sudo lvremove -y "$lv_path"
+done
+
+rm -f "$tmpfile"

--- a/tools/cleanup-ovs-bridge.sh
+++ b/tools/cleanup-ovs-bridge.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# OVS bridge cleanup script
+# 
+set -euo pipefail
+
+tmpfile=$(mktemp)
+ovs-vsctl list-br |grep -v br-int > "$tmpfile"
+
+cat "$tmpfile" | while read -r line; do
+  bridge_name="$line"
+  echo "Deleting  $bridge_name"
+  ovs-vsctl del-br "$bridge_name"
+done
+
+rm -f "$tmpfile"

--- a/tools/cleanup-vm.sh
+++ b/tools/cleanup-vm.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# VM cleanup script
+# 
+set -euo pipefail
+
+tmpfile=$(mktemp)
+
+virsh list --all | awk 'NR>2 && NF {print $2}' | xargs -I{} virsh undefine {}
+
+rm -f "$tmpfile"


### PR DESCRIPTION
# 概要

- cleanup スクリプトの追加
- cmd/mactl/mactl-vm-deploy-1_test.go で２重設定している箇所をコメント化