### PR TITLE
テスト用モックにmarmotd.jsonを読み込む様に修正

### DIFF
--- a/cmd/mactl/mactl-vm-deploy-1_test.go
+++ b/cmd/mactl/mactl-vm-deploy-1_test.go
@@ -44,7 +44,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		fmt.Printf("Container started with ID: %s\n", containerID)
 
 		By("モックサーバーの起動")
-		mockServer, err = startMockServer(etcdEp)
+		mockServer, err = startMockServer(etcdEp, "testdata/marmotd.json")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(loginAsAdmin()).NotTo(HaveOccurred())
 	})

--- a/cmd/mactl/mactl-vm-deploy-2_test.go
+++ b/cmd/mactl/mactl-vm-deploy-2_test.go
@@ -46,7 +46,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		fmt.Printf("Container started with ID: %s\n", containerID)
 
 		By("モックサーバーの起動")
-		mockServer, err = startMockServer(etcdEp)
+		mockServer, err = startMockServer(etcdEp, "testdata/marmotd.json")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(loginAsAdmin()).NotTo(HaveOccurred())
 	})

--- a/cmd/mactl/mactl-vm-deploy-3_test.go
+++ b/cmd/mactl/mactl-vm-deploy-3_test.go
@@ -46,7 +46,7 @@ var _ = Describe("MarmotdTest", Ordered, func() {
 		fmt.Printf("Container started with ID: %s\n", containerID)
 
 		By("モックサーバーの起動")
-		mockServer, err = startMockServer(etcdEp)
+		mockServer, err = startMockServer(etcdEp, "testdata/marmotd.json")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(loginAsAdmin()).NotTo(HaveOccurred())
 	})

--- a/cmd/mactl/mactl_test.go
+++ b/cmd/mactl/mactl_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Marmotd Test", Ordered, func() {
 		fmt.Printf("Container started with ID: %s\n", containerID)
 
 		By("モックサーバーの起動")
-		mockServer, err = startMockServer(etcdEp)
+		mockServer, err = startMockServer(etcdEp, "testdata/marmotd.json")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(loginAsAdmin()).NotTo(HaveOccurred())
 	})

--- a/cmd/mactl/test-helper.go
+++ b/cmd/mactl/test-helper.go
@@ -88,7 +88,7 @@ func startEtcdContainer() (string, string, error) {
 	return containerID, fmt.Sprintf("http://127.0.0.1:%d", port), nil
 }
 
-func startMockServer(etcdEp string) (*mockServerHandle, error) {
+func startMockServer(etcdEp string, configPath string) (*mockServerHandle, error) {
 	// 個別にログを確認したい場合はコメントアウトを外す
 	//opts := &slog.HandlerOptions{
 	//	AddSource: true,
@@ -104,6 +104,20 @@ func startMockServer(etcdEp string) (*mockServerHandle, error) {
 	}
 
 	nodeName := "hvc"
+	cfg := marmotd.CurrentConfig()
+	if strings.TrimSpace(configPath) != "" {
+		loadedCfg, err := marmotd.LoadConfig(configPath)
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("failed to load marmotd config: %w", err)
+		}
+		cfg = loadedCfg
+	}
+	cfg.NodeName = nodeName
+	cfg.EtcdURL = etcdEp
+	// テスト時は 53 番ポート競合を避けるため固定ポートを使う
+	cfg.DNSListenAddr = "127.0.0.1:1053"
+	marmotd.SetRuntimeConfig(cfg)
 
 	e := echo.New()
 	server := marmotd.NewServerWithOptions(nodeName, etcdEp, true)
@@ -160,11 +174,7 @@ func startMockServer(etcdEp string) (*mockServerHandle, error) {
 		}
 		stoppers = append(stoppers, gatewayController)
 
-		dnsCfg := &marmotd.MarmotdConfig{
-			DNSListenAddr: "127.0.0.1:1053",
-			DNSUpstream:   "8.8.8.8:53",
-		}
-		_, err = internaldns.StartInternalDNSServer(ctx, nodeName, etcdEp, dnsCfg)
+		_, err = internaldns.StartInternalDNSServer(ctx, nodeName, etcdEp, cfg)
 		if err != nil {
 			slog.Error("Failed to start DNS server", "err", err)
 			stopControllers()

--- a/pkg/marmotd/marmotd-config.go
+++ b/pkg/marmotd/marmotd-config.go
@@ -33,6 +33,22 @@ type OSImage struct {
 	OSVersion string `json:"osVersion"`
 }
 
+type HostBridgeRouteConfig struct {
+	To  string `json:"to"`
+	Via string `json:"via"`
+}
+
+type HostBridgeNameserversConfig struct {
+	Addresses []string `json:"addresses"`
+	Search    []string `json:"search"`
+}
+
+type HostBridgeDefaultConfig struct {
+	Netmasklen  int                          `json:"netmasklen"`
+	Nameservers HostBridgeNameserversConfig  `json:"nameservers"`
+	Routes      []HostBridgeRouteConfig      `json:"routes"`
+}
+
 // MarmotdConfig は /etc/marmot/marmotd.json で設定可能なパラメータを保持します。
 type MarmotdConfig struct {
 	// ハイパーバイザーのノード名
@@ -69,6 +85,21 @@ type MarmotdConfig struct {
 	// DATA ボリューム用の LVM Volume Group 名
 	// 例: "vg2"
 	DataVolumeGroup string `json:"data_volume_group"`
+
+	// host-bridge の IP アドレス範囲を表す CIDR
+	// 例: "192.168.1.0/24"
+	HostBridgeIPNetAddr string `json:"host-bridge-ip-net-addr"`
+
+	// host-bridge の IP アドレス払い出し開始アドレス
+	// 例: "192.168.1.190"
+	HostBridgeIPAddrStart string `json:"host-bridge-ip-addr-start"`
+
+	// host-bridge の IP アドレス払い出し終了アドレス
+	// 例: "192.168.1.194"
+	HostBridgeIPAddrEnd string `json:"host-bridge-ip-addr-end"`
+
+	// host-bridge 利用時のサーバー既定ネットワーク設定
+	HostBridgeDefault *HostBridgeDefaultConfig `json:"host-bridge-default"`
 
 	// コントローラーが DeletionTimestamp を検知してから実際に削除処理を
 	// 開始するまでの待機秒数
@@ -199,6 +230,17 @@ func normalizeConfig(cfg *MarmotdConfig) *MarmotdConfig {
 	if strings.TrimSpace(normalized.DataVolumeGroup) == "" {
 		normalized.DataVolumeGroup = db.DefaultDataVolumeGroup
 	}
+	normalized.HostBridgeIPNetAddr = strings.TrimSpace(normalized.HostBridgeIPNetAddr)
+	normalized.HostBridgeIPAddrStart = strings.TrimSpace(normalized.HostBridgeIPAddrStart)
+	normalized.HostBridgeIPAddrEnd = strings.TrimSpace(normalized.HostBridgeIPAddrEnd)
+	if normalized.HostBridgeDefault != nil {
+		normalized.HostBridgeDefault.Nameservers.Addresses = trimNonEmptyStrings(normalized.HostBridgeDefault.Nameservers.Addresses)
+		normalized.HostBridgeDefault.Nameservers.Search = trimNonEmptyStrings(normalized.HostBridgeDefault.Nameservers.Search)
+		for i := range normalized.HostBridgeDefault.Routes {
+			normalized.HostBridgeDefault.Routes[i].To = strings.TrimSpace(normalized.HostBridgeDefault.Routes[i].To)
+			normalized.HostBridgeDefault.Routes[i].Via = strings.TrimSpace(normalized.HostBridgeDefault.Routes[i].Via)
+		}
+	}
 	if normalized.DeletionDelaySeconds <= 0 {
 		normalized.DeletionDelaySeconds = defaults.DeletionDelaySeconds
 	}
@@ -274,6 +316,21 @@ func extractIPv4(addr net.Addr) net.IP {
 	default:
 		return nil
 	}
+}
+
+func trimNonEmptyStrings(values []string) []string {
+	if len(values) == 0 {
+		return values
+	}
+	trimmed := values[:0]
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		trimmed = append(trimmed, value)
+	}
+	return trimmed
 }
 
 func (c *MarmotdConfig) ImageCreateFromVMTimeout() time.Duration {


### PR DESCRIPTION
**実施内容**
1. `startMockServer()` に marmotd.json のパス引数を追加  
- 変更: test-helper.go  
- シグネチャを `startMockServer(etcdEp string, configPath string)` に変更。  
- `configPath` が指定された場合は `marmotd.LoadConfig()` で読み込み。  
- テスト既存挙動維持のため、DNS リスンは従来どおり `127.0.0.1:1053` を上書き。  
- 読み込んだ設定は `marmotd.SetRuntimeConfig()` に反映。

2. 指定4テストが marmotd.json を使うよう修正  
- 変更: mactl_test.go  
- 変更: mactl-vm-deploy-1_test.go  
- 変更: mactl-vm-deploy-2_test.go  
- 変更: mactl-vm-deploy-3_test.go  
- 各 `startMockServer(etcdEp)` を `startMockServer(etcdEp, "testdata/marmotd.json")` に更新。

3. `type MarmotdConfig` に新規追加項目を反映  
- 変更: marmotd-config.go  
- 追加フィールド:
  - `host-bridge-ip-net-addr`
  - `host-bridge-ip-addr-start`
  - `host-bridge-ip-addr-end`
  - `host-bridge-default`（ネスト構造: netmasklen, nameservers, routes）
- 併せて関連の補助型を追加し、`normalizeConfig` で trim/正規化を実施。

**確認結果**
1. ビルド確認  
- 実行: `go test ./cmd/mactl -run '^$'`  
- 結果: 成功（コンパイルOK）

2. 変更箇所の単体テスト  
- 実行: `go test ./pkg/marmotd -run VolumeGroupConfig -count=1`  
- 結果: 対象実行なし（Ginkgo構成のため）

3. 不具合再現シナリオ確認（今回の対象）  
- `go test ./pkg/marmotd` は既存のGinkgo再実行エラー（RunSpecs複数回）で完走不可でした。  
- ただし、今回変更ファイルの診断エラーはすべてなし（Problems 0件）です。

