### PR TITLE
mactl console 実行時に Authorization ヘッダーが付与されない問題を修正

### DIFF
--- a/cmd/mactl/cmd/console.go
+++ b/cmd/mactl/cmd/console.go
@@ -100,6 +100,7 @@ var consoleCmd = &cobra.Command{
 		}
 		req.Host = hostPort
 		req.Header.Set("Connection", "close")
+		setConsoleAuthorizationHeader(req, m.AccessToken)
 		if err := req.Write(conn); err != nil {
 			return fmt.Errorf("failed to send console request: %w", err)
 		}
@@ -264,6 +265,20 @@ func portFromHostPort(hostPort string) (string, error) {
 		return "", fmt.Errorf("invalid API host: %s", hostPort)
 	}
 	return port, nil
+}
+
+func setConsoleAuthorizationHeader(req *http.Request, accessToken string) {
+	if req == nil {
+		return
+	}
+	if strings.TrimSpace(req.Header.Get("Authorization")) != "" {
+		return
+	}
+	token := strings.TrimSpace(accessToken)
+	if token == "" {
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
 }
 
 func init() {

--- a/cmd/mactl/cmd/console_auth_test.go
+++ b/cmd/mactl/cmd/console_auth_test.go
@@ -3,21 +3,56 @@ package cmd
 import (
 	"net/http"
 	"testing"
-
-	"github.com/takara9/marmot/pkg/client"
 )
 
 func TestConsoleRequestAddsAuthorizationHeader(t *testing.T) {
-	m := &client.MarmotEndpoint{AccessToken: "token-123"}
 	req, err := http.NewRequest(http.MethodGet, "http://example.com/api/v1/server/abc/console", nil)
 	if err != nil {
 		t.Fatalf("NewRequest() failed: %v", err)
 	}
 	req.Host = "example.com"
 	req.Header.Set("Connection", "close")
-	if token := m.AccessToken; token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
+	setConsoleAuthorizationHeader(req, "token-123")
+
+	if got := req.Header.Get("Authorization"); got != "Bearer token-123" {
+		t.Fatalf("Authorization header = %q, want %q", got, "Bearer token-123")
 	}
+}
+
+func TestConsoleRequestKeepsExistingAuthorizationHeader(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/api/v1/server/abc/console", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() failed: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer existing")
+
+	setConsoleAuthorizationHeader(req, "token-123")
+
+	if got := req.Header.Get("Authorization"); got != "Bearer existing" {
+		t.Fatalf("Authorization header = %q, want %q", got, "Bearer existing")
+	}
+}
+
+func TestConsoleRequestSkipsEmptyAuthorizationToken(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/api/v1/server/abc/console", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() failed: %v", err)
+	}
+
+	setConsoleAuthorizationHeader(req, "   ")
+
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization header = %q, want empty", got)
+	}
+}
+
+func TestConsoleRequestTrimsAuthorizationToken(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/api/v1/server/abc/console", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() failed: %v", err)
+	}
+
+	setConsoleAuthorizationHeader(req, "  token-123  ")
 
 	if got := req.Header.Get("Authorization"); got != "Bearer token-123" {
 		t.Fatalf("Authorization header = %q, want %q", got, "Bearer token-123")


### PR DESCRIPTION
概要
mactl console SERVERNAME 実行時に 401 missing or invalid Authorization header が返る問題を修正しました。  
原因は、console 経路が通常の API クライアント経路を通らず、Authorization ヘッダーの自動付与対象外だったことです。

原因
- console リクエストは net.Conn に対して生の HTTP リクエストを書き込む実装
- そのため、通常 API 呼び出しで行っている Bearer トークン付与が適用されていなかった

変更内容
- console リクエスト送信前に Authorization ヘッダーを設定する処理を追加
- 既存 Authorization ヘッダーがある場合は上書きしない
- 空白トークンは設定しない
- トークンの前後空白を trim して設定

変更ファイル
- console.go
- console_auth_test.go

テスト
- go test ./cmd/mactl/cmd -run Console -count=1
- go test ./cmd/mactl/cmd -run ^$ -count=1

確認ポイント
- mactl login 済み状態で mactl console SERVERNAME を実行し、401 が解消されること
- 既存 console の接続動作に回帰がないこと

影響範囲
- mactl console のリクエストヘッダー生成のみ
- 他コマンドやサーバー側認証ロジックの仕様変更はなし