### PR TITLE
IPAM機能のバグ修正

### DIFF
--- a/pkg/db/db-ipam.go
+++ b/pkg/db/db-ipam.go
@@ -109,7 +109,7 @@ func (d *Database) CreateIpNetwork(vnetid string, spec *api.IPNetwork) (string, 
 
 	// IPアドレスの開始と終了アドレスを設定する
 	networkAddr := prefix.Addr()
-	addr := networkAddr.Next()
+	addr := networkAddr.Next().Next()
 	net.Netmasklen = util.IntPtrInt(prefix.Bits())
 	defaultStartAddr := addr
 	hostBits := prefix.Addr().BitLen() - prefix.Bits()
@@ -117,9 +117,9 @@ func (d *Database) CreateIpNetwork(vnetid string, spec *api.IPNetwork) (string, 
 		slog.Error("CreateIpNetwork()", "err", "prefix is too small for gateway and usable host", "addressMaskLen", prefix.String())
 		return "", fmt.Errorf("prefix is too small for gateway and usable host")
 	}
-	// ブロードキャストアドレスとゲートウェイを考慮して -3 する。
+	// 開始アドレス(.2)とブロードキャストアドレスを考慮して -4 する。
 	endDelta := new(big.Int).Lsh(big.NewInt(1), uint(hostBits))
-	endDelta.Sub(endDelta, big.NewInt(3))
+	endDelta.Sub(endDelta, big.NewInt(4))
 	defaultEndAddr, err := addIPBig(addr, endDelta)
 	if err != nil {
 		slog.Error("CreateIpNetwork()", "err", err, "addressMaskLen", prefix.String())

--- a/pkg/db/db-ipam_test.go
+++ b/pkg/db/db-ipam_test.go
@@ -86,6 +86,8 @@ var _ = Describe("IPAM", Ordered, func() {
 				Expect(*net.NetworkAddress).To(Equal("192.168.200.0"))
 				Expect(*net.Netmask).To(Equal("255.255.255.0"))
 				Expect(*net.Gateway).To(Equal("192.168.200.1"))
+				Expect(*net.StartAddress).To(Equal("192.168.200.2"))
+				Expect(*net.EndAddress).To(Equal("192.168.200.254"))
 				Expect(*net.Netmasklen).To(Equal(24))
 			})
 


### PR DESCRIPTION
## 概要
IPAM の既定割り当て範囲がゲートウェイ予約アドレスと整合していなかった問題を修正しました。  
具体的には、IPv4 の自動範囲で startAddress が .1（gateway）になるケースを防ぎ、.2 から割り当てるように修正しています。

## 背景
`172.16.20.0/24` のネットワークで、以下のように startAddress が `.1` で保存される状態がありました。

- gateway: 172.16.20.1
- startAddress: 172.16.20.1

この状態だと、サーバー作成時にゲートウェイ予約アドレスと競合し、プロビジョニング失敗の原因になります。

## 変更内容
- db-ipam.go
  - IPv4 既定開始アドレスを network+2 に変更（.1 を避ける）
  - 既定終了アドレスの計算式を補正し、/24 で `.254` になるよう修正
  - 予約アドレス（network, gateway, broadcast）を避けた範囲整合を確保

- db-ipam_test.go
  - IPv4 ネットワーク取得時の期待値を追加・更新
  - startAddress = 192.168.200.2
  - endAddress = 192.168.200.254

## 期待される効果
- IPAM 既定範囲がゲートウェイ予約と衝突しない
- サーバー自動割り当て時の gateway 競合エラーを回避
- /24 での上限アドレスが次サブネットへはみ出さない

## 確認項目
- go test ./pkg/db -run TestAllocationRange_DefaultIPv4|TestShouldSkipReservedIPv4Address -count=1
- go test ./pkg/db -run TestDoesNotExist -count=1
- make package

## 影響範囲
- IPAM の既定範囲計算ロジック（IPv4）
- 既定値を使うネットワーク作成フロー
- API スキーマや外部インターフェースの変更はありません