### PR TITLE
サーバーリスト表示の改善

### DIFF
--- a/cmd/mactl/cmd/get.go
+++ b/cmd/mactl/cmd/get.go
@@ -890,14 +890,29 @@ func outputServers(servers []api.Server) error {
 			age := formatServerAge(s.Status)
 			networkLines := serverNetworkLines(s)
 
-			// Filter out N/A network lines when getServerShowAll is false
+			// --all なし時:
+			// - default 以外のネットワークがあれば default を隠す
+			// - default しかなければ表示を維持
+			// - N/A/N/A はノイズなので隠す
 			filteredLines := networkLines
 			if !getServerShowAll {
+				hasNonDefaultNetwork := false
+				for _, line := range networkLines {
+					if line.network != "default" && line.network != "N/A" {
+						hasNonDefaultNetwork = true
+						break
+					}
+				}
+
 				filteredLines = make([]serverNetworkLine, 0, len(networkLines))
 				for _, line := range networkLines {
-					if line.address != "N/A" || line.network != "N/A" {
-						filteredLines = append(filteredLines, line)
+					if hasNonDefaultNetwork && line.network == "default" {
+						continue
 					}
+					if line.address == "N/A" && line.network == "N/A" {
+						continue
+					}
+					filteredLines = append(filteredLines, line)
 				}
 				// Ensure we have at least one line to display
 				if len(filteredLines) == 0 {

--- a/cmd/mactl/cmd/output_formatting_test.go
+++ b/cmd/mactl/cmd/output_formatting_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Output formatting", func() {
 			Expect(lines[2]).To(ContainSubstring("2h"), output)
 		})
 
-		It("keeps continuation lines that have network even when IP is N/A by default", func() {
+		It("hides default continuation line when non-default networks exist by default", func() {
 			originalShowAll := getServerShowAll
 			getServerShowAll = false
 			DeferCleanup(func() {
@@ -102,6 +102,26 @@ var _ = Describe("Output formatting", func() {
 
 			Expect(output).To(ContainSubstring("app-net"), output)
 			Expect(output).To(ContainSubstring("host-bridge"), output)
+			Expect(output).NotTo(ContainSubstring("default"), output)
+		})
+
+		It("keeps default line when default is the only attached network", func() {
+			originalShowAll := getServerShowAll
+			getServerShowAll = false
+			DeferCleanup(func() {
+				getServerShowAll = originalShowAll
+			})
+
+			output := captureOutput(func() {
+				err := outputServers([]api.Server{{
+					Metadata: api.Metadata{Name: "server-default-only"},
+					Spec: api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{
+						{Networkname: "default"},
+					}},
+				}})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
 			Expect(output).To(ContainSubstring("default"), output)
 		})
 


### PR DESCRIPTION
## 概要
Issue #546 に対応し、mactl get server の表示を見やすくしました。  
default ネットワークの表示を条件付きで抑制し、必要な情報だけが出るようにしています。

## 変更内容
- mactl get server の text 出力でネットワーク行フィルタを調整
- 非 default ネットワークが存在する場合は default 行を非表示
- default のみ接続されている場合は default 行を表示
- --all 指定時は従来どおり全ネットワーク行を表示
- 出力仕様に合わせてフォーマットテストを更新・追加

## 仕様（今回の挙動）
- 通常表示
  - default 以外のネットワークが1つでもある: default 行を表示しない
  - default しかない: default 行を表示する
- --all
  - すべてのネットワーク行を表示する（default を含む）

## 変更ファイル
- get.go
- output_formatting_test.go

## テスト
- 実行コマンド: go test ./cmd/mactl/cmd
- 結果: pass

## 影響範囲
- 対象は mactl get server の text 表示のみ
- API 仕様や他リソースの出力には影響なし

## 関連 Issue
- #546