### PR TITLE
mactl ssh の実装

### DIFF
--- a/cmd/mactl/cmd/server_ansible.go
+++ b/cmd/mactl/cmd/server_ansible.go
@@ -31,8 +31,7 @@ func maybeApplyServerAnsiblePlaybook(m *client.MarmotEndpoint, server api.Server
 		return nil
 	}
 
-	targetAddress, err := validateServerAnsibleSpec(server)
-	if err != nil {
+	if err := validateServerAnsibleSpec(server); err != nil {
 		return err
 	}
 
@@ -43,6 +42,11 @@ func maybeApplyServerAnsiblePlaybook(m *client.MarmotEndpoint, server api.Server
 
 	fmt.Fprintln(os.Stderr, "OS起動待機中.....")
 	if err := waitServerRunning(m, serverID, serverAnsibleWaitTimeout, serverAnsibleWaitPollInterval); err != nil {
+		return err
+	}
+
+	targetAddress, err := waitServerHostBridgeAddress(m, serverID, serverAnsiblePingTimeout, serverAnsiblePingPollInterval)
+	if err != nil {
 		return err
 	}
 
@@ -70,29 +74,72 @@ func maybeApplyServerAnsiblePlaybook(m *client.MarmotEndpoint, server api.Server
 	return nil
 }
 
-func validateServerAnsibleSpec(server api.Server) (string, error) {
+func validateServerAnsibleSpec(server api.Server) error {
 	if server.Spec.Ansible == nil {
-		return "", nil
+		return nil
 	}
 	if strings.TrimSpace(server.Spec.Ansible.Playbook) == "" {
-		return "", fmt.Errorf("spec.ansible.playbook is required when spec.ansible is set")
+		return fmt.Errorf("spec.ansible.playbook is required when spec.ansible is set")
 	}
 	if strings.TrimSpace(server.Spec.Ansible.Inventory) == "" {
-		return "", fmt.Errorf("spec.ansible.inventory is required when spec.ansible is set")
+		return fmt.Errorf("spec.ansible.inventory is required when spec.ansible is set")
 	}
 	if server.Spec.NetworkInterface == nil || len(*server.Spec.NetworkInterface) == 0 {
-		return "", fmt.Errorf("spec.ansible requires spec.networkInterface with host-bridge and static address")
+		return fmt.Errorf("spec.ansible requires spec.networkInterface with host-bridge")
+	}
+	for _, nic := range *server.Spec.NetworkInterface {
+		if strings.TrimSpace(nic.Networkname) != "host-bridge" {
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("spec.ansible can be used only when host-bridge is specified in spec.networkInterface")
+}
+
+func waitServerHostBridgeAddress(m *client.MarmotEndpoint, serverID string, timeout, interval time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		body, _, err := m.GetServerById(serverID)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get server %s while waiting for host-bridge address: %w", serverID, err)
+		} else {
+			var srv api.Server
+			if err := json.Unmarshal(body, &srv); err != nil {
+				lastErr = fmt.Errorf("failed to parse server %s while waiting for host-bridge address: %w", serverID, err)
+			} else {
+				addr, err := hostBridgeAddressFromServer(srv)
+				if err == nil {
+					return addr, nil
+				}
+				lastErr = err
+			}
+		}
+
+		if time.Now().After(deadline) {
+			if lastErr != nil {
+				return "", fmt.Errorf("timeout waiting for host-bridge address for server %s: %w", serverID, lastErr)
+			}
+			return "", fmt.Errorf("timeout waiting for host-bridge address for server %s", serverID)
+		}
+		time.Sleep(interval)
+	}
+}
+
+func hostBridgeAddressFromServer(server api.Server) (string, error) {
+	if server.Spec.NetworkInterface == nil || len(*server.Spec.NetworkInterface) == 0 {
+		return "", fmt.Errorf("spec.networkInterface with host-bridge is not set")
 	}
 	for _, nic := range *server.Spec.NetworkInterface {
 		if strings.TrimSpace(nic.Networkname) != "host-bridge" {
 			continue
 		}
 		if nic.Address == nil || strings.TrimSpace(*nic.Address) == "" {
-			return "", fmt.Errorf("spec.ansible requires host-bridge address to be set")
+			return "", fmt.Errorf("host-bridge address is not assigned yet")
 		}
 		return strings.TrimSpace(*nic.Address), nil
 	}
-	return "", fmt.Errorf("spec.ansible can be used only when host-bridge is specified in spec.networkInterface")
+	return "", fmt.Errorf("host-bridge is not set in spec.networkInterface")
 }
 
 func extractSuccessID(body []byte) (string, error) {

--- a/cmd/mactl/cmd/server_ansible_test.go
+++ b/cmd/mactl/cmd/server_ansible_test.go
@@ -14,21 +14,18 @@ import (
 func TestValidateServerAnsibleSpec(t *testing.T) {
 	playbook := "playbook/setup.yaml"
 	inventory := "hosts"
-	ip := "192.168.1.64"
 
 	tests := []struct {
 		name    string
 		server  api.Server
-		wantIP  string
 		wantErr string
 	}{
 		{
 			name:   "ansible not specified",
 			server: api.Server{Spec: api.ServerSpec{}},
-			wantIP: "",
 		},
 		{
-			name: "ansible with host-bridge and address",
+			name: "ansible with host-bridge without address is accepted",
 			server: api.Server{Spec: api.ServerSpec{
 				Ansible: &api.ServerAnsible{
 					Playbook:  playbook,
@@ -36,10 +33,8 @@ func TestValidateServerAnsibleSpec(t *testing.T) {
 				},
 				NetworkInterface: &[]api.NetworkInterface{{
 					Networkname: "host-bridge",
-					Address:     &ip,
 				}},
 			}},
-			wantIP: ip,
 		},
 		{
 			name: "missing network interface",
@@ -49,7 +44,7 @@ func TestValidateServerAnsibleSpec(t *testing.T) {
 					Inventory: inventory,
 				},
 			}},
-			wantErr: "requires spec.networkInterface",
+			wantErr: "requires spec.networkInterface with host-bridge",
 		},
 		{
 			name: "missing playbook",
@@ -70,19 +65,6 @@ func TestValidateServerAnsibleSpec(t *testing.T) {
 			wantErr: "spec.ansible.inventory is required",
 		},
 		{
-			name: "host-bridge without address",
-			server: api.Server{Spec: api.ServerSpec{
-				Ansible: &api.ServerAnsible{
-					Playbook:  playbook,
-					Inventory: inventory,
-				},
-				NetworkInterface: &[]api.NetworkInterface{{
-					Networkname: "host-bridge",
-				}},
-			}},
-			wantErr: "requires host-bridge address",
-		},
-		{
 			name: "host-bridge missing",
 			server: api.Server{Spec: api.ServerSpec{
 				Ansible: &api.ServerAnsible{
@@ -91,7 +73,6 @@ func TestValidateServerAnsibleSpec(t *testing.T) {
 				},
 				NetworkInterface: &[]api.NetworkInterface{{
 					Networkname: "default",
-					Address:     &ip,
 				}},
 			}},
 			wantErr: "only when host-bridge is specified",
@@ -100,13 +81,10 @@ func TestValidateServerAnsibleSpec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotIP, err := validateServerAnsibleSpec(tt.server)
+			err := validateServerAnsibleSpec(tt.server)
 			if tt.wantErr == "" {
 				if err != nil {
 					t.Fatalf("validateServerAnsibleSpec() unexpected err: %v", err)
-				}
-				if gotIP != tt.wantIP {
-					t.Fatalf("validateServerAnsibleSpec() ip = %q, want %q", gotIP, tt.wantIP)
 				}
 				return
 			}
@@ -264,7 +242,6 @@ func TestResolveServerAnsibleInventoryPathRelative(t *testing.T) {
 func TestValidateServerAnsibleSpecUsesStrings(t *testing.T) {
 	playbook := "playbook/setup.yaml"
 	inventory := "hosts"
-	ip := "192.168.1.64"
 	server := api.Server{Spec: api.ServerSpec{
 		Ansible: &api.ServerAnsible{
 			Playbook:  playbook,
@@ -272,16 +249,42 @@ func TestValidateServerAnsibleSpecUsesStrings(t *testing.T) {
 		},
 		NetworkInterface: &[]api.NetworkInterface{{
 			Networkname: "host-bridge",
-			Address:     &ip,
 		}},
 	}}
-	got, err := validateServerAnsibleSpec(server)
+	err := validateServerAnsibleSpec(server)
 	if err != nil {
 		t.Fatalf("validateServerAnsibleSpec() unexpected err: %v", err)
 	}
-	if got != ip {
-		t.Fatalf("validateServerAnsibleSpec() = %q, want %q", got, ip)
-	}
+}
+
+func TestHostBridgeAddressFromServer(t *testing.T) {
+	ip := "192.168.1.64"
+
+	t.Run("address is resolved", func(t *testing.T) {
+		nics := []api.NetworkInterface{{Networkname: "host-bridge", Address: &ip}}
+		server := api.Server{Spec: api.ServerSpec{NetworkInterface: &nics}}
+
+		got, err := hostBridgeAddressFromServer(server)
+		if err != nil {
+			t.Fatalf("hostBridgeAddressFromServer() unexpected err: %v", err)
+		}
+		if got != ip {
+			t.Fatalf("hostBridgeAddressFromServer() = %q, want %q", got, ip)
+		}
+	})
+
+	t.Run("host-bridge without address returns error", func(t *testing.T) {
+		nics := []api.NetworkInterface{{Networkname: "host-bridge"}}
+		server := api.Server{Spec: api.ServerSpec{NetworkInterface: &nics}}
+
+		_, err := hostBridgeAddressFromServer(server)
+		if err == nil {
+			t.Fatalf("hostBridgeAddressFromServer() expected error")
+		}
+		if !strings.Contains(err.Error(), "not assigned yet") {
+			t.Fatalf("hostBridgeAddressFromServer() err = %q, want contains %q", err.Error(), "not assigned yet")
+		}
+	})
 }
 
 func TestRunServerAnsiblePlaybookWithExtraArgs(t *testing.T) {

--- a/cmd/mactl/cmd/ssh.go
+++ b/cmd/mactl/cmd/ssh.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/takara9/marmot/api"
+)
+
+var sshExecCommand = exec.Command
+
+var sshCmd = &cobra.Command{
+	Use:   "ssh SERVER-NAME [SSH-ARGS...]",
+	Short: "Connect to a server via SSH using host-bridge IP",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		m, err := getClientConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get API client config: %w", err)
+		}
+
+		serverName := strings.TrimSpace(args[0])
+		if serverName == "" {
+			return fmt.Errorf("server name is required")
+		}
+
+		list, _, err := m.GetServers()
+		if err != nil {
+			return fmt.Errorf("failed to list servers: %w", err)
+		}
+
+		var servers []api.Server
+		if err := json.Unmarshal(list, &servers); err != nil {
+			return fmt.Errorf("failed to parse servers: %w", err)
+		}
+
+		server, err := findServerByName(servers, serverName)
+		if err != nil {
+			return err
+		}
+
+		targetAddress, err := resolveHostBridgeAddress(*server)
+		if err != nil {
+			return fmt.Errorf("server %q %w", serverName, err)
+		}
+
+		sshArgs := composeSSHArgs(targetAddress, args[1:])
+		sshCommand := sshExecCommand("ssh", sshArgs...)
+		sshCommand.Stdin = os.Stdin
+		sshCommand.Stdout = os.Stdout
+		sshCommand.Stderr = os.Stderr
+
+		if err := sshCommand.Run(); err != nil {
+			return fmt.Errorf("ssh failed: %w", err)
+		}
+		return nil
+	},
+}
+
+func findServerByName(servers []api.Server, name string) (*api.Server, error) {
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return nil, fmt.Errorf("server name is required")
+	}
+
+	for i := range servers {
+		if strings.TrimSpace(servers[i].Metadata.Name) == trimmedName {
+			return &servers[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("server %q not found", trimmedName)
+}
+
+func resolveHostBridgeAddress(server api.Server) (string, error) {
+	if server.Spec.NetworkInterface == nil || len(*server.Spec.NetworkInterface) == 0 {
+		return "", fmt.Errorf("is not connected to host-bridge")
+	}
+
+	for _, nic := range *server.Spec.NetworkInterface {
+		if strings.TrimSpace(nic.Networkname) != "host-bridge" {
+			continue
+		}
+		if nic.Address == nil || strings.TrimSpace(*nic.Address) == "" {
+			return "", fmt.Errorf("has no static address on host-bridge")
+		}
+		return strings.TrimSpace(*nic.Address), nil
+	}
+
+	return "", fmt.Errorf("is not connected to host-bridge")
+}
+
+func composeSSHArgs(targetAddress string, extraArgs []string) []string {
+	args := make([]string, 0, len(extraArgs)+1)
+	separator := -1
+	for i, arg := range extraArgs {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+
+	if separator >= 0 {
+		args = append(args, extraArgs[:separator]...)
+		args = append(args, targetAddress)
+		args = append(args, extraArgs[separator+1:]...)
+		return args
+	}
+
+	args = append(args, extraArgs...)
+	args = append(args, targetAddress)
+	return args
+}
+
+func init() {
+	rootCmd.AddCommand(sshCmd)
+}

--- a/cmd/mactl/cmd/ssh_test.go
+++ b/cmd/mactl/cmd/ssh_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+var _ = Describe("ssh helper functions", func() {
+	Describe("findServerByName", func() {
+		It("returns a matching server", func() {
+			servers := []api.Server{
+				{Metadata: api.Metadata{Name: "alpha"}},
+				{Metadata: api.Metadata{Name: "beta"}},
+			}
+
+			server, err := findServerByName(servers, "beta")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(server).NotTo(BeNil())
+			Expect(server.Metadata.Name).To(Equal("beta"))
+		})
+
+		It("returns error when server is not found", func() {
+			servers := []api.Server{{Metadata: api.Metadata{Name: "alpha"}}}
+
+			_, err := findServerByName(servers, "gamma")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+	})
+
+	Describe("resolveHostBridgeAddress", func() {
+		It("returns host-bridge address", func() {
+			nics := []api.NetworkInterface{
+				{Networkname: "private-net", Address: util.StringPtr("10.0.0.2")},
+				{Networkname: "host-bridge", Address: util.StringPtr("192.168.10.50")},
+			}
+			server := api.Server{Spec: api.ServerSpec{NetworkInterface: &nics}}
+
+			address, err := resolveHostBridgeAddress(server)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(address).To(Equal("192.168.10.50"))
+		})
+
+		It("returns error when host-bridge is missing", func() {
+			nics := []api.NetworkInterface{{Networkname: "private-net", Address: util.StringPtr("10.0.0.2")}}
+			server := api.Server{Spec: api.ServerSpec{NetworkInterface: &nics}}
+
+			_, err := resolveHostBridgeAddress(server)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not connected to host-bridge"))
+		})
+
+		It("returns error when host-bridge address is empty", func() {
+			nics := []api.NetworkInterface{{Networkname: "host-bridge"}}
+			server := api.Server{Spec: api.ServerSpec{NetworkInterface: &nics}}
+
+			_, err := resolveHostBridgeAddress(server)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no static address"))
+		})
+	})
+
+	Describe("composeSSHArgs", func() {
+		It("appends target when no extra args", func() {
+			args := composeSSHArgs("192.168.10.50", nil)
+			Expect(args).To(Equal([]string{"192.168.10.50"}))
+		})
+
+		It("places target after options", func() {
+			args := composeSSHArgs("192.168.10.50", []string{"-i", "~/.ssh/id_ed25519", "-o", "StrictHostKeyChecking=no"})
+			Expect(args).To(Equal([]string{"-i", "~/.ssh/id_ed25519", "-o", "StrictHostKeyChecking=no", "192.168.10.50"}))
+		})
+
+		It("supports remote command with -- separator", func() {
+			args := composeSSHArgs("192.168.10.50", []string{"-i", "~/.ssh/id_ed25519", "--", "uname", "-a"})
+			Expect(args).To(Equal([]string{"-i", "~/.ssh/id_ed25519", "192.168.10.50", "uname", "-a"}))
+		})
+	})
+})

--- a/docs/COMMAND-REFERENCE-mactl.md
+++ b/docs/COMMAND-REFERENCE-mactl.md
@@ -113,6 +113,9 @@ API キー:
 - mactl apply [RESOURCE]
 - mactl del [RESOURCE NAME]
 - mactl console SERVER-NAME
+- mactl ssh SERVER-NAME [SSH引数...]
+  - Marmot が管理する SERVER-NAME の host-bridge IP を解決して ssh 接続
+  - host-bridge 未接続、または host-bridge address 未設定の場合はエラー
 - mactl version
 
 ## 運用メモ


### PR DESCRIPTION
## 概要
Issue #562 の改善要望に対応し、以下を実装しました。

1. mactl ssh SERVER-NAME で、Marmot 管理下のサーバー名を host-bridge の IP に解決して SSH 接続できるようにした  
2. mactl create -f 実行時に、spec.ansible の host-bridge address 未割り当てで即時エラーにならないようにした

## 背景
サーバー作成フローでは、create リクエスト受理時点で host-bridge の IP が未割り当ての場合があり、spec.ansible の事前チェックで失敗していました。  
また、サーバー名ベースでそのまま SSH したい要望がありました。

## 変更内容
- mactl ssh コマンドを追加
  - SERVER-NAME を API から解決
  - host-bridge の address を接続先として SSH 実行
  - host-bridge 未接続、または address 未設定時は明確なエラーを返却
  - ssg 互換は追加していない（要望により除去）

- server ansible の create 時バリデーションを調整
  - create 時点では host-bridge NIC の存在のみ確認
  - host-bridge address の必須チェックは create 時に行わない
  - サーバー RUNNING 後に GetServerById で host-bridge address をポーリング取得
  - address 取得後に ansible ping / playbook 実行

- テスト更新
  - mactl ssh のヘルパー/引数組み立てテストを追加
  - server ansible の新仕様に合わせて既存テストを更新
  - host-bridge address 解決ヘルパーのテストを追加

- ドキュメント更新
  - コマンドリファレンスに mactl ssh を追記

## 動作確認
- go test ./cmd/mactl/cmd  
  - 成功

## 期待される効果
- mactl create -f 直後の address 未割り当てで不要に失敗しない
- サーバー名ベースで SSH 接続できる運用性向上
- host-bridge 関連の失敗時に原因が分かるエラーメッセージを提供

## 影響範囲
- mactl の CLI 挙動に限定
- API スキーマ変更なし
- 既存の console コマンド挙動には変更なし