### PR TITLE
mactl ssh コマンドの実装2

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,18 @@ NAME             NODE          STATUS        CPU  RAM(MB)  IP-ADDRESS       NETW
 server-20        marmot3       RUNNING       1    1024     192.168.1.20     host-bridge      5s
 
 # sshでのログイン
-$ ssh ubuntu@192.168.1.20 -i vmkey
+$ mactl ssh ubuntu@server-20 -- -i vmkey 
 ubuntu@server-20:~$ 
 ubuntu@server-20:~$ exit
 
 # サーバーの削除
 $ mactl delete server server-20
 ```
+
+`mactl ssh` を使うと、DNSを設定することなく、サーバー名で、sshログインできます。
+
+mactl [mactlのフラグ] ssh [USER@]SERVER-NAME -- [SSH-ARGS...]
+
 
 
 ## インストール

--- a/cmd/mactl/cmd/ssh.go
+++ b/cmd/mactl/cmd/ssh.go
@@ -14,7 +14,7 @@ import (
 var sshExecCommand = exec.Command
 
 var sshCmd = &cobra.Command{
-	Use:   "ssh SERVER-NAME [SSH-ARGS...]",
+	Use:   "ssh [USER@]SERVER-NAME -- [SSH-ARGS...]",
 	Short: "Connect to a server via SSH using host-bridge IP",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -25,9 +25,9 @@ var sshCmd = &cobra.Command{
 			return fmt.Errorf("failed to get API client config: %w", err)
 		}
 
-		serverName := strings.TrimSpace(args[0])
-		if serverName == "" {
-			return fmt.Errorf("server name is required")
+		sshUser, serverName, err := parseSSHLoginTarget(args[0])
+		if err != nil {
+			return err
 		}
 
 		list, _, err := m.GetServers()
@@ -49,8 +49,9 @@ var sshCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("server %q %w", serverName, err)
 		}
+		sshTarget := buildSSHTargetAddress(sshUser, targetAddress)
 
-		sshArgs := composeSSHArgs(targetAddress, args[1:])
+		sshArgs := composeSSHArgs(sshTarget, args[1:])
 		sshCommand := sshExecCommand("ssh", sshArgs...)
 		sshCommand.Stdin = os.Stdin
 		sshCommand.Stdout = os.Stdout
@@ -61,6 +62,31 @@ var sshCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+func parseSSHLoginTarget(value string) (string, string, error) {
+	target := strings.TrimSpace(value)
+	if target == "" {
+		return "", "", fmt.Errorf("server name is required")
+	}
+	if !strings.Contains(target, "@") {
+		return "", target, nil
+	}
+
+	parts := strings.SplitN(target, "@", 2)
+	user := strings.TrimSpace(parts[0])
+	serverName := strings.TrimSpace(parts[1])
+	if user == "" || serverName == "" {
+		return "", "", fmt.Errorf("invalid ssh target %q; use [USER@]SERVER-NAME", target)
+	}
+	return user, serverName, nil
+}
+
+func buildSSHTargetAddress(user, ipAddress string) string {
+	if strings.TrimSpace(user) == "" {
+		return strings.TrimSpace(ipAddress)
+	}
+	return strings.TrimSpace(user) + "@" + strings.TrimSpace(ipAddress)
 }
 
 func findServerByName(servers []api.Server, name string) (*api.Server, error) {

--- a/cmd/mactl/cmd/ssh_test.go
+++ b/cmd/mactl/cmd/ssh_test.go
@@ -8,6 +8,40 @@ import (
 )
 
 var _ = Describe("ssh helper functions", func() {
+	Describe("parseSSHLoginTarget", func() {
+		It("parses server name without user", func() {
+			user, serverName, err := parseSSHLoginTarget("server-20")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(user).To(Equal(""))
+			Expect(serverName).To(Equal("server-20"))
+		})
+
+		It("parses user and server name", func() {
+			user, serverName, err := parseSSHLoginTarget("ubuntu@server-20")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(user).To(Equal("ubuntu"))
+			Expect(serverName).To(Equal("server-20"))
+		})
+
+		It("returns error for malformed user at target", func() {
+			_, _, err := parseSSHLoginTarget("ubuntu@")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid ssh target"))
+		})
+	})
+
+	Describe("buildSSHTargetAddress", func() {
+		It("returns IP when user is empty", func() {
+			target := buildSSHTargetAddress("", "192.168.10.50")
+			Expect(target).To(Equal("192.168.10.50"))
+		})
+
+		It("returns user at IP when user is specified", func() {
+			target := buildSSHTargetAddress("ubuntu", "192.168.10.50")
+			Expect(target).To(Equal("ubuntu@192.168.10.50"))
+		})
+	})
+
 	Describe("findServerByName", func() {
 		It("returns a matching server", func() {
 			servers := []api.Server{

--- a/docs/COMMAND-REFERENCE-mactl.md
+++ b/docs/COMMAND-REFERENCE-mactl.md
@@ -113,7 +113,7 @@ API キー:
 - mactl apply [RESOURCE]
 - mactl del [RESOURCE NAME]
 - mactl console SERVER-NAME
-- mactl [mactlのフラグ] ssh [USER@]SERVER-NAME [SSH引数...]
+- mactl [mactlのフラグ] ssh [USER@]SERVER-NAME -- [SSH引数...]
   - Marmot が管理する SERVER-NAME の host-bridge IP を解決し、USER 指定時は USER@IP で ssh 接続
   - host-bridge 未接続、または host-bridge address 未設定の場合はエラー
 - mactl version

--- a/docs/COMMAND-REFERENCE-mactl.md
+++ b/docs/COMMAND-REFERENCE-mactl.md
@@ -113,8 +113,8 @@ API キー:
 - mactl apply [RESOURCE]
 - mactl del [RESOURCE NAME]
 - mactl console SERVER-NAME
-- mactl ssh SERVER-NAME [SSH引数...]
-  - Marmot が管理する SERVER-NAME の host-bridge IP を解決して ssh 接続
+- mactl [mactlのフラグ] ssh [USER@]SERVER-NAME [SSH引数...]
+  - Marmot が管理する SERVER-NAME の host-bridge IP を解決し、USER 指定時は USER@IP で ssh 接続
   - host-bridge 未接続、または host-bridge address 未設定の場合はエラー
 - mactl version
 


### PR DESCRIPTION
## 概要
Issue #562 の改善として、mactl ssh を追加し、Marmot が認識しているサーバー名で SSH ログインできるようにしました。  
あわせて、create 時点で host-bridge の IP が未割り当てでも spec.ansible で失敗しないように調整しました。

## 変更内容
1. mactl ssh コマンドを追加
- 形式: mactl ssh [USER@]SERVER-NAME -- [SSH-ARGS...]
- サーバー名を API で解決し、host-bridge の IP に置き換えて接続
- USER 指定時は USER@IP 形式で接続

2. SSH 引数の受け渡し仕様を明確化
- mactl 側のフラグと SSH 引数を分離するため、-- 以降を SSH-ARGS として扱う前提に統一
- ヘルプ Usage をこの形式に更新

3. spec.ansible の create 時バリデーションを改善
- create 時点では host-bridge NIC の存在のみ確認
- host-bridge address の必須チェックは create 時に行わない
- サーバー起動後に host-bridge address が割り当てられるのを待ってから ansible 実行

4. user@server 指定の解釈を追加
- 例: mactl ssh ubuntu@server-20
- server 部分でサーバー解決し、接続時に ubuntu@<resolved-ip> を生成

## 背景
従来は以下の課題がありました。
1. mactl ssh で user@server 指定がサーバー名として誤解釈される
2. mactl create -f の時点で host-bridge の IP 未割り当てだと spec.ansible で失敗する
3. SSH オプション指定時に mactl 側フラグと競合しやすい

## 動作確認
1. go test ./cmd/mactl/cmd が成功
2. mactl ssh --help の Usage が以下を表示  
   mactl ssh [USER@]SERVER-NAME -- [SSH-ARGS...]
3. 以下の想定が通ることをテストで確認
- user@server の分解
- host-bridge IP 解決
- SSH 引数の組み立て
- host-bridge 未接続時のエラー

## 互換性・影響範囲
1. 既存 API 仕様の変更なし
2. mactl の CLI 挙動変更は ssh と ansible 適用タイミング周辺に限定
3. ssg 互換は追加していない

## 補足
SSH 鍵指定時は公開鍵ではなく秘密鍵を指定します。  
例: -i ~/.ssh/vmkey
