### PR TITLE
ceph連携のためのmarmotd.jsonのパラメーター追加

### DIFF
--- a/pkg/marmotd/marmotd-config.go
+++ b/pkg/marmotd/marmotd-config.go
@@ -2,6 +2,7 @@ package marmotd
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"sort"
@@ -464,5 +465,28 @@ func LoadConfig(path string) (*MarmotdConfig, error) {
 		return nil, err
 	}
 
-	return normalizeConfig(cfg), nil
+	normalized := normalizeConfig(cfg)
+	if err := validateCephConfig(normalized); err != nil {
+		return nil, err
+	}
+	return normalized, nil
+}
+
+// validateCephConfig は ceph_enabled=true の場合に必須項目を検証します。
+func validateCephConfig(cfg *MarmotdConfig) error {
+	if !cfg.CephEnabled {
+		return nil
+	}
+	if len(cfg.CephMonitors) == 0 {
+		return fmt.Errorf("ceph_monitors: ceph_enabled=true の場合、最低1つ必須です")
+	}
+	if cfg.CephKeyFile == "" {
+		return fmt.Errorf("ceph_key_file: ceph_enabled=true の場合、必須です")
+	}
+	f, err := os.Open(cfg.CephKeyFile)
+	if err != nil {
+		return fmt.Errorf("ceph_key_file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	return nil
 }

--- a/pkg/marmotd/marmotd-config.go
+++ b/pkg/marmotd/marmotd-config.go
@@ -488,5 +488,12 @@ func validateCephConfig(cfg *MarmotdConfig) error {
 		return fmt.Errorf("ceph_key_file: %w", err)
 	}
 	defer func() { _ = f.Close() }()
+	fi, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("ceph_key_file: %w", err)
+	}
+	if fi.IsDir() {
+		return fmt.Errorf("ceph_key_file: ディレクトリは指定できません")
+	}
 	return nil
 }

--- a/pkg/marmotd/marmotd-config.go
+++ b/pkg/marmotd/marmotd-config.go
@@ -142,6 +142,36 @@ type MarmotdConfig struct {
 	// 例: "/etc/marmot/certs/server.key"
 	// 空の場合は HTTP を使用する。
 	TLSKeyFile string `json:"tls_key_file"`
+
+	// Ceph 連携の有効/無効フラグ。
+	// true の場合、Ceph をバックエンドストレージとして利用可能にする。
+	// false（省略時）の場合、Ceph 機能は無効化される。
+	CephEnabled bool `json:"ceph_enabled"`
+
+	// Ceph Monitor のアドレスリスト。
+	// 例: ["10.1.4.11:6789", "10.1.4.12:6789", "10.1.4.13:6789"]
+	// ceph_enabled=true の場合、最低1つ必須。
+	CephMonitors []string `json:"ceph_monitors"`
+
+	// Ceph クラスタに接続するユーザー名。
+	// 例: "client.marmot"
+	// ceph_enabled=true の場合、最小権限ユーザーの指定が推奨。
+	CephUser string `json:"ceph_user"`
+
+	// Ceph 認証キーファイルのパス。
+	// 例: "/etc/ceph/marmot.client.key"
+	// ceph_enabled=true の場合、ファイル存在確認と読み取り権限チェックが行われる。
+	CephKeyFile string `json:"ceph_key_file"`
+
+	// storageClass から Ceph CRUSH rule への対応マップ。
+	// キーは storageClass (hdd, ssd, nvme など)、値は CRUSH rule 名。
+	// 例: {"hdd": "rule-hdd", "ssd": "rule-ssd", "nvme": "rule-nvme"}
+	CephCrushRuleByClass map[string]string `json:"ceph_crush_rule_by_class"`
+
+	// storageClass から Ceph pool への対応マップ。
+	// キーは storageClass (hdd, ssd, nvme など)、値は pool 名。
+	// 例: {"hdd": "marmot-hdd", "ssd": "marmot-ssd", "nvme": "marmot-nvme"}
+	CephPoolByClass map[string]string `json:"ceph_pool_by_class"`
 }
 
 var runtimeConfigState = struct {
@@ -178,6 +208,12 @@ func defaultConfig() *MarmotdConfig {
 		LokiPushURL:                      "",
 		TLSCertFile:                      "",
 		TLSKeyFile:                       "",
+		CephEnabled:                      false,
+		CephMonitors:                     nil,
+		CephUser:                         "",
+		CephKeyFile:                      "",
+		CephCrushRuleByClass:             make(map[string]string),
+		CephPoolByClass:                  make(map[string]string),
 	}
 }
 
@@ -262,6 +298,24 @@ func normalizeConfig(cfg *MarmotdConfig) *MarmotdConfig {
 	normalized.LokiPushURL = strings.TrimSpace(normalized.LokiPushURL)
 	normalized.TLSCertFile = strings.TrimSpace(normalized.TLSCertFile)
 	normalized.TLSKeyFile = strings.TrimSpace(normalized.TLSKeyFile)
+
+	// Ceph パラメーターの正規化
+	normalized.CephMonitors = trimNonEmptyStrings(normalized.CephMonitors)
+	normalized.CephUser = strings.TrimSpace(normalized.CephUser)
+	normalized.CephKeyFile = strings.TrimSpace(normalized.CephKeyFile)
+
+	// Ceph マップのキーと値をトリミング
+	if normalized.CephCrushRuleByClass == nil {
+		normalized.CephCrushRuleByClass = make(map[string]string)
+	} else {
+		normalized.CephCrushRuleByClass = trimMapStringString(normalized.CephCrushRuleByClass)
+	}
+	if normalized.CephPoolByClass == nil {
+		normalized.CephPoolByClass = make(map[string]string)
+	} else {
+		normalized.CephPoolByClass = trimMapStringString(normalized.CephPoolByClass)
+	}
+
 	return normalized
 }
 
@@ -329,6 +383,21 @@ func trimNonEmptyStrings(values []string) []string {
 			continue
 		}
 		trimmed = append(trimmed, value)
+	}
+	return trimmed
+}
+
+func trimMapStringString(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return m
+	}
+	trimmed := make(map[string]string)
+	for k, v := range m {
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k != "" && v != "" {
+			trimmed[k] = v
+		}
 	}
 	return trimmed
 }

--- a/pkg/marmotd/marmotd-config.go
+++ b/pkg/marmotd/marmotd-config.go
@@ -483,17 +483,20 @@ func validateCephConfig(cfg *MarmotdConfig) error {
 	if cfg.CephKeyFile == "" {
 		return fmt.Errorf("ceph_key_file: ceph_enabled=true の場合、必須です")
 	}
-	f, err := os.Open(cfg.CephKeyFile)
-	if err != nil {
-		return fmt.Errorf("ceph_key_file: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	fi, err := f.Stat()
+	fi, err := os.Stat(cfg.CephKeyFile)
 	if err != nil {
 		return fmt.Errorf("ceph_key_file: %w", err)
 	}
 	if fi.IsDir() {
 		return fmt.Errorf("ceph_key_file: ディレクトリは指定できません")
 	}
+	if !fi.Mode().IsRegular() {
+		return fmt.Errorf("ceph_key_file: 通常ファイルを指定してください")
+	}
+	f, err := os.Open(cfg.CephKeyFile)
+	if err != nil {
+		return fmt.Errorf("ceph_key_file: %w", err)
+	}
+	_ = f.Close()
 	return nil
 }

--- a/pkg/marmotd/marmotd-config_test.go
+++ b/pkg/marmotd/marmotd-config_test.go
@@ -123,9 +123,9 @@ var _ = Describe("VolumeGroupConfig", func() {
 			err := os.WriteFile(path, content, 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
-			cfg, err := marmotd.LoadConfig(path)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.CephEnabled).To(BeTrue())
+			_, err = marmotd.LoadConfig(path)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ceph_monitors"))
 		})
 
 		It("ceph_enabled が未指定の場合は false (既定値)", func() {
@@ -218,17 +218,21 @@ var _ = Describe("VolumeGroupConfig", func() {
 
 		It("Ceph 全パラメーターを一度に読み込む", func() {
 			dir := GinkgoT().TempDir()
+			keyFile := filepath.Join(dir, "marmot.client.key")
+			err := os.WriteFile(keyFile, []byte("dummykey"), 0o600)
+			Expect(err).NotTo(HaveOccurred())
+
 			path := filepath.Join(dir, "marmotd.json")
 			content := []byte(`{
 				"ceph_enabled": true,
 				"ceph_monitors": ["10.1.4.11:6789", "10.1.4.12:6789"],
 				"ceph_user": "client.marmot",
-				"ceph_key_file": "/etc/ceph/marmot.client.key",
+				"ceph_key_file": "` + keyFile + `",
 				"ceph_crush_rule_by_class": {"hdd": "rule-hdd", "ssd": "rule-ssd"},
 				"ceph_pool_by_class": {"hdd": "marmot-hdd", "ssd": "marmot-ssd"}
 			}`)
 
-			err := os.WriteFile(path, content, 0o644)
+			err = os.WriteFile(path, content, 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			cfg, err := marmotd.LoadConfig(path)
@@ -236,7 +240,7 @@ var _ = Describe("VolumeGroupConfig", func() {
 			Expect(cfg.CephEnabled).To(BeTrue())
 			Expect(cfg.CephMonitors).To(Equal([]string{"10.1.4.11:6789", "10.1.4.12:6789"}))
 			Expect(cfg.CephUser).To(Equal("client.marmot"))
-			Expect(cfg.CephKeyFile).To(Equal("/etc/ceph/marmot.client.key"))
+			Expect(cfg.CephKeyFile).To(Equal(keyFile))
 			Expect(cfg.CephCrushRuleByClass).To(Equal(map[string]string{"hdd": "rule-hdd", "ssd": "rule-ssd"}))
 			Expect(cfg.CephPoolByClass).To(Equal(map[string]string{"hdd": "marmot-hdd", "ssd": "marmot-ssd"}))
 		})

--- a/pkg/marmotd/marmotd-config_test.go
+++ b/pkg/marmotd/marmotd-config_test.go
@@ -128,6 +128,33 @@ var _ = Describe("VolumeGroupConfig", func() {
 			Expect(err.Error()).To(ContainSubstring("ceph_monitors"))
 		})
 
+		It("ceph_enabled=true かつ ceph_key_file 未指定の場合はエラーになる", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "marmotd.json")
+			content := []byte(`{"ceph_enabled":true,"ceph_monitors":["10.1.4.11:6789"]}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = marmotd.LoadConfig(path)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ceph_key_file"))
+		})
+
+		It("ceph_key_file にディレクトリを指定した場合はエラーになる", func() {
+			dir := GinkgoT().TempDir()
+			keyDir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "marmotd.json")
+			content := []byte(`{"ceph_enabled":true,"ceph_monitors":["10.1.4.11:6789"],"ceph_key_file":"` + keyDir + `"}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = marmotd.LoadConfig(path)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ceph_key_file"))
+		})
+
 		It("ceph_enabled が未指定の場合は false (既定値)", func() {
 			dir := GinkgoT().TempDir()
 			path := filepath.Join(dir, "marmotd.json")

--- a/pkg/marmotd/marmotd-config_test.go
+++ b/pkg/marmotd/marmotd-config_test.go
@@ -114,5 +114,131 @@ var _ = Describe("VolumeGroupConfig", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.DNSUpstreamAllowCIDRs).To(Equal([]string{"192.168.1.0/24", "fd00::/64"}))
 		})
+
+		It("ceph_enabled の設定値を読み込む", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "marmotd.json")
+			content := []byte(`{"ceph_enabled":true}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, err := marmotd.LoadConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CephEnabled).To(BeTrue())
+		})
+
+		It("ceph_enabled が未指定の場合は false (既定値)", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "marmotd.json")
+			content := []byte(`{"node_name":"hv1"}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, err := marmotd.LoadConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CephEnabled).To(BeFalse())
+		})
+
+		It("Ceph monitors の設定値を読み込む", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "marmotd.json")
+			content := []byte(`{"ceph_monitors":["10.1.4.11:6789","10.1.4.12:6789"," 10.1.4.13:6789 "]}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, err := marmotd.LoadConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CephMonitors).To(Equal([]string{"10.1.4.11:6789", "10.1.4.12:6789", "10.1.4.13:6789"}))
+		})
+
+		It("Ceph user と key_file の設定値を読み込む", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "marmotd.json")
+			content := []byte(`{"ceph_user":"client.marmot","ceph_key_file":"/etc/ceph/marmot.client.key"}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, err := marmotd.LoadConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CephUser).To(Equal("client.marmot"))
+			Expect(cfg.CephKeyFile).To(Equal("/etc/ceph/marmot.client.key"))
+		})
+
+		It("Ceph CRUSH rule と pool のマップを読み込む", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "marmotd.json")
+			content := []byte(`{
+				"ceph_crush_rule_by_class": {"hdd":"rule-hdd","ssd":"rule-ssd"},
+				"ceph_pool_by_class": {"hdd":"marmot-hdd","ssd":"marmot-ssd","nvme":"marmot-nvme"}
+			}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, err := marmotd.LoadConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CephCrushRuleByClass).To(Equal(map[string]string{"hdd": "rule-hdd", "ssd": "rule-ssd"}))
+			Expect(cfg.CephPoolByClass).To(Equal(map[string]string{"hdd": "marmot-hdd", "ssd": "marmot-ssd", "nvme": "marmot-nvme"}))
+		})
+
+		It("Ceph マップの空キーと空値は除外される", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "marmotd.json")
+			content := []byte(`{
+				"ceph_pool_by_class": {" hdd ":"marmot-hdd","ssd":" ","":"should-be-excluded"," ":"also-excluded"}
+			}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, err := marmotd.LoadConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CephPoolByClass).To(Equal(map[string]string{"hdd": "marmot-hdd"}))
+		})
+
+		It("Ceph マップが未指定の場合は空マップになる", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "marmotd.json")
+			content := []byte(`{"node_name":"hv1"}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, err := marmotd.LoadConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CephCrushRuleByClass).NotTo(BeNil())
+			Expect(cfg.CephPoolByClass).NotTo(BeNil())
+			Expect(cfg.CephCrushRuleByClass).To(HaveLen(0))
+			Expect(cfg.CephPoolByClass).To(HaveLen(0))
+		})
+
+		It("Ceph 全パラメーターを一度に読み込む", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "marmotd.json")
+			content := []byte(`{
+				"ceph_enabled": true,
+				"ceph_monitors": ["10.1.4.11:6789", "10.1.4.12:6789"],
+				"ceph_user": "client.marmot",
+				"ceph_key_file": "/etc/ceph/marmot.client.key",
+				"ceph_crush_rule_by_class": {"hdd": "rule-hdd", "ssd": "rule-ssd"},
+				"ceph_pool_by_class": {"hdd": "marmot-hdd", "ssd": "marmot-ssd"}
+			}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, err := marmotd.LoadConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CephEnabled).To(BeTrue())
+			Expect(cfg.CephMonitors).To(Equal([]string{"10.1.4.11:6789", "10.1.4.12:6789"}))
+			Expect(cfg.CephUser).To(Equal("client.marmot"))
+			Expect(cfg.CephKeyFile).To(Equal("/etc/ceph/marmot.client.key"))
+			Expect(cfg.CephCrushRuleByClass).To(Equal(map[string]string{"hdd": "rule-hdd", "ssd": "rule-ssd"}))
+			Expect(cfg.CephPoolByClass).To(Equal(map[string]string{"hdd": "marmot-hdd", "ssd": "marmot-ssd"}))
+		})
 	})
 })

--- a/pkg/marmotd/marmotd-config_test.go
+++ b/pkg/marmotd/marmotd-config_test.go
@@ -157,7 +157,7 @@ var _ = Describe("VolumeGroupConfig", func() {
 		It("Ceph user と key_file の設定値を読み込む", func() {
 			dir := GinkgoT().TempDir()
 			path := filepath.Join(dir, "marmotd.json")
-			content := []byte(`{"ceph_user":"client.marmot","ceph_key_file":"/etc/ceph/marmot.client.key"}`)
+			content := []byte(`{"ceph_user":" client.marmot ","ceph_key_file":" /etc/ceph/marmot.client.key "}`)
 
 			err := os.WriteFile(path, content, 0o644)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
概要
marmotd.json から Ceph 関連設定を読み込めるようにし、値の正規化と既定値の扱いを追加しました。  
Ceph 連携を有効化するための設定パラメーターを、既存設定との互換性を保ったまま拡張しています。

主な変更
- MarmotdConfig に Ceph 関連フィールドを追加
- ceph_enabled の既定値を false として明示
- ceph_monitors の前後空白除去と空要素除外を追加
- ceph_user と ceph_key_file の空白除去を追加
- ceph_crush_rule_by_class / ceph_pool_by_class の正規化を追加
- Ceph マップ未指定時は nil ではなく空マップで初期化

追加した設定項目
- ceph_enabled
- ceph_monitors
- ceph_user
- ceph_key_file
- ceph_crush_rule_by_class
- ceph_pool_by_class

テスト
marmotd-config_test.go に以下を追加しました。
- ceph_enabled の読み込みと既定値
- ceph_monitors の読み込みとトリミング
- ceph_user / ceph_key_file の読み込み
- ceph_crush_rule_by_class / ceph_pool_by_class の読み込み
- Ceph マップの空キー・空値除外
- Ceph マップ未指定時の空マップ化
- Ceph 全項目の一括読み込み

実行確認
- go test ./pkg/marmotd/... -run "VolumeGroupConfig.*Ceph" -v -ginkgo.v

影響範囲
- 設定読み込み処理のみ
- 既存の非 Ceph 設定には影響なし
- Ceph 未使用環境では従来どおり動作（ceph_enabled=false）