### PR TITLE
Cephハンドラー関数の修正とテスト追加

### DIFF
--- a/pkg/marmotd/ceph_integration.go
+++ b/pkg/marmotd/ceph_integration.go
@@ -47,6 +47,14 @@ func cephSecretUUIDForServer(serverID string) string {
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(seed)).String()
 }
 
+func normalizeCephServerID(serverID string) (string, error) {
+	trimmed := strings.TrimSpace(serverID)
+	if trimmed == "" {
+		return "", fmt.Errorf("server id is required")
+	}
+	return trimmed, nil
+}
+
 func isCephVolume(volume api.Volume) bool {
 	return volume.Spec.Type != nil && strings.EqualFold(strings.TrimSpace(*volume.Spec.Type), "ceph")
 }
@@ -75,6 +83,10 @@ func buildCephDiskSpec(volume api.Volume, serverID string, dev string, bus uint)
 	if !CurrentConfig().CephEnabled {
 		return virt.DiskSpec{}, fmt.Errorf("ceph is disabled")
 	}
+	resolvedServerID, err := normalizeCephServerID(serverID)
+	if err != nil {
+		return virt.DiskSpec{}, err
+	}
 	if len(cfg.Monitors) == 0 {
 		return virt.DiskSpec{}, fmt.Errorf("ceph monitors are required")
 	}
@@ -99,7 +111,7 @@ func buildCephDiskSpec(volume api.Volume, serverID string, dev string, bus uint)
 		return virt.DiskSpec{}, fmt.Errorf("ceph monitors are required")
 	}
 
-	secretUUID := cephSecretUUIDForServer(serverID)
+	secretUUID := cephSecretUUIDForServer(resolvedServerID)
 	return virt.DiskSpec{
 		Dev:            dev,
 		Bus:            bus,
@@ -130,16 +142,20 @@ func resolveCephDeleteTarget(volume api.Volume, cfg ceph.Config) (pool, image st
 	return req.Pool, req.Image, nil
 }
 
-func cephSecretSpecForServer(serverID string) libvirtxml.Secret {
-	secretUUID := cephSecretUUIDForServer(serverID)
-	usageName := "marmot-ceph-" + strings.TrimSpace(serverID)
+func cephSecretSpecForServer(serverID string) (libvirtxml.Secret, error) {
+	resolvedServerID, err := normalizeCephServerID(serverID)
+	if err != nil {
+		return libvirtxml.Secret{}, err
+	}
+	secretUUID := cephSecretUUIDForServer(resolvedServerID)
+	usageName := "marmot-ceph-" + resolvedServerID
 	return libvirtxml.Secret{
 		UUID: secretUUID,
 		Usage: &libvirtxml.SecretUsage{
 			Type: "ceph",
 			Name: usageName,
 		},
-	}
+	}, nil
 }
 
 func hasCephStorage(storage *[]api.Volume) bool {
@@ -159,18 +175,29 @@ func prepareCephSecretForServer(l *virt.LibVirtEp, serverID string) error {
 	if !cfg.CephEnabled {
 		return nil
 	}
+	if _, err := normalizeCephServerID(serverID); err != nil {
+		return err
+	}
 	if l == nil {
 		return fmt.Errorf("libvirt endpoint is nil")
 	}
 	if strings.TrimSpace(cfg.CephKeyFile) == "" {
 		return fmt.Errorf("ceph key file is required")
 	}
-	return l.EnsureCephSecret(cephSecretSpecForServer(serverID), cfg.CephKeyFile)
+	secretSpec, err := cephSecretSpecForServer(serverID)
+	if err != nil {
+		return err
+	}
+	return l.EnsureCephSecret(secretSpec, cfg.CephKeyFile)
 }
 
 func removeCephSecretForServer(l *virt.LibVirtEp, serverID string) error {
 	if l == nil {
 		return nil
 	}
-	return l.RemoveCephSecretByUUID(cephSecretUUIDForServer(serverID))
+	resolvedServerID, err := normalizeCephServerID(serverID)
+	if err != nil {
+		return err
+	}
+	return l.RemoveCephSecretByUUID(cephSecretUUIDForServer(resolvedServerID))
 }

--- a/pkg/marmotd/ceph_integration_test.go
+++ b/pkg/marmotd/ceph_integration_test.go
@@ -102,6 +102,22 @@ var _ = Describe("Ceph integration helpers", Ordered, func() {
 		Expect(err.Error()).To(ContainSubstring("ceph monitors are required"))
 	})
 
+	It("rejects empty server id when building ceph disk spec", func() {
+		volume := api.Volume{
+			Spec: api.VolSpec{
+				Type:         util.StringPtr("ceph"),
+				Kind:         util.StringPtr("data"),
+				Size:         util.IntPtrInt(1),
+				StorageClass: util.StringPtr("ssd"),
+			},
+		}
+		api.SetVolumeID(&volume, "abcde")
+
+		_, err := buildCephDiskSpec(volume, "   ", "vdb", 11)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("server id is required"))
+	})
+
 	It("marks ceph storage as node-independent", func() {
 		storage := []api.Volume{
 			{
@@ -155,5 +171,11 @@ var _ = Describe("Ceph integration helpers", Ordered, func() {
 		Expect(removeCephSecretForServer(l, serverID)).To(Succeed())
 		_, err = l.Com.LookupSecretByUUIDString(secretUUID)
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("rejects empty server id when preparing ceph secret", func() {
+		err := prepareCephSecretForServer(nil, "\t")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("server id is required"))
 	})
 })


### PR DESCRIPTION
## 概要
Ceph 連携まわりのハンドラー補助処理を強化し、空の server ID による不正な secret 生成を防止しました。  
あわせて、Ceph 向け Ginkgo テストの実行対象を拡張し、同一 suite に追加された spec が確実に実行されるようにしました。

## 背景
- Ceph secret の UUID/usage は server ID を元に決定されるため、空文字や空白のみの ID を許すと意図しない共有値を生成するリスクがありました。
- Ceph テスト用 Makefile が単一ファイル固定だったため、同一 suite の別ファイルが実行されない状態でした。

## 変更内容
- Ceph helper に server ID の正規化・必須チェックを追加
  - ceph_integration.go
  - 空 server ID の場合はエラーを返すように変更
  - 対象:
    - buildCephDiskSpec
    - cephSecretSpecForServer
    - prepareCephSecretForServer
    - removeCephSecretForServer

- Ginkgo テスト追加
  - ceph_integration_test.go
  - 追加ケース:
    - 空 server ID で Ceph disk spec 構築を拒否
    - 空 server ID で Ceph secret 準備を拒否

- Ceph テスト実行対象の拡張
  - Makefile
  - test-ceph の focus-file を単一ファイル指定から正規表現に変更
  - ceph_.*_test.go を対象化し、ceph_integration と ceph_timeout の双方を実行

## 影響範囲
- Ceph 連携時のサーバー起動前 secret 準備および Ceph disk spec 構築処理
- Ceph 関連テスト実行導線
- Ceph 非利用経路への仕様変更はなし

## テスト
- Ceph suite 実行:
  - go test -run '^TestMarmotdCeph$' -ginkgo.focus-file 'ceph_.*_test.go' -ginkgo.v -ginkgo.fail-fast -ginkgo.show-node-events
  - 結果: 10 Passed, 0 Failed
- ビルド相当確認:
  - go test ./pkg/marmotd -run '^$'
  - 結果: ok

## 期待される効果
- 空 server ID 起因の Ceph secret 取り違えリスクを低減
- Ceph suite の新規 spec 追加漏れを防止し、CI での検出力を向上