### PR TITLE
セッションのリストに接続元IPアドレスを表示

### DIFF
--- a/api/marmot-api-v1.go
+++ b/api/marmot-api-v1.go
@@ -68,6 +68,7 @@ type ApiKey struct {
 type ApiKeyCreateRequest struct {
 	Comment   *string    `json:"comment,omitempty" yaml:"comment,omitempty"`
 	ExpiresAt *time.Time `json:"expiresAt,omitempty" yaml:"expiresAt,omitempty"`
+	FromIP    *string    `json:"fromIP,omitempty" yaml:"fromIP,omitempty"`
 
 	// SessionType Session scope for the API key. Login sessions may be revoked automatically after inactivity; generated keys remain persistent until explicitly deleted.
 	SessionType *string `json:"sessionType,omitempty" yaml:"sessionType,omitempty"`
@@ -77,6 +78,7 @@ type ApiKeyCreateRequest struct {
 type ApiKeySpec struct {
 	Comment   *string    `json:"comment,omitempty" yaml:"comment,omitempty"`
 	ExpiresAt *time.Time `json:"expiresAt,omitempty" yaml:"expiresAt,omitempty"`
+	FromIP    *string    `json:"fromIP,omitempty" yaml:"fromIP,omitempty"`
 	IssuedAt  *time.Time `json:"issuedAt,omitempty" yaml:"issuedAt,omitempty"`
 	Revoked   *bool      `json:"revoked,omitempty" yaml:"revoked,omitempty"`
 

--- a/api/marmot-api-v1.yaml
+++ b/api/marmot-api-v1.yaml
@@ -2756,6 +2756,8 @@ components:
       properties:
         comment:
           type: string
+        fromIP:
+          type: string
         expiresAt:
           type: string
           format: date-time
@@ -2766,6 +2768,8 @@ components:
       type: object
       properties:
         comment:
+          type: string
+        fromIP:
           type: string
         tokenPrefix:
           type: string

--- a/cmd/mactl/cmd/user_session.go
+++ b/cmd/mactl/cmd/user_session.go
@@ -18,6 +18,7 @@ type sessionRow struct {
 	UserID     string `json:"userId" yaml:"userId"`
 	SessionID  string `json:"sessionId" yaml:"sessionId"`
 	Status     string `json:"status" yaml:"status"`
+	From       string `json:"from" yaml:"from"`
 	Comment    string `json:"comment" yaml:"comment"`
 	IssuedAt   string `json:"issuedAt" yaml:"issuedAt"`
 	LastUsedAt string `json:"lastUsedAt" yaml:"lastUsedAt"`
@@ -129,6 +130,7 @@ func collectUserSessionRows(m *client.MarmotEndpoint, userID string) ([]sessionR
 			UserID:     userID,
 			SessionID:  apiKeyIdentifier(key),
 			Status:     sessionStatusText(key),
+			From:       sessionFromIPText(key),
 			Comment:    sessionCommentText(key),
 			IssuedAt:   formatTimeText(key.Spec.IssuedAt),
 			LastUsedAt: formatTimeText(sessionLastUsedAt(key)),
@@ -175,6 +177,17 @@ func sessionCommentText(apiKey api.ApiKey) string {
 		return "-"
 	}
 	return comment
+}
+
+func sessionFromIPText(apiKey api.ApiKey) string {
+	if apiKey.Spec.FromIP == nil {
+		return "-"
+	}
+	from := strings.TrimSpace(*apiKey.Spec.FromIP)
+	if from == "" {
+		return "-"
+	}
+	return from
 }
 
 func sessionStatusText(apiKey api.ApiKey) string {
@@ -225,10 +238,18 @@ func timeSinceText(t *time.Time) string {
 }
 
 func printSessionRowsText(rows []sessionRow) {
-	fmt.Printf("%-24s  %-36s  %-8s  %-25s  %-8s  %-20s\n", "USER-ID", "SESSION-ID", "STATUS", "LAST-USED", "AGE", "COMMENT")
+	fmt.Printf("%-24s  %-8s  %-8s  %-39s  %-25s  %-8s  %-20s\n", "USER-ID", "SESSION-ID", "STATUS", "FROM", "LAST-USED", "AGE", "COMMENT")
 	for _, row := range rows {
-		fmt.Printf("%-24s  %-36s  %-8s  %-25s  %-8s  %-20s\n", row.UserID, row.SessionID, row.Status, row.LastUsedAt, row.Age, row.Comment)
+		fmt.Printf("%-24s  %-8s  %-8s  %-39s  %-25s  %-8s  %-20s\n", row.UserID, shortSessionID(row.SessionID), row.Status, row.From, row.LastUsedAt, row.Age, row.Comment)
 	}
+}
+
+func shortSessionID(sessionID string) string {
+	id := strings.TrimSpace(sessionID)
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
 }
 
 func printSessionRowsJSON(rows []sessionRow) {

--- a/cmd/mactl/cmd/user_session_test.go
+++ b/cmd/mactl/cmd/user_session_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/api"
+)
+
+func TestShortSessionID(t *testing.T) {
+	got := shortSessionID("12345678-aaaa-bbbb-cccc-1234567890ab")
+	if got != "12345678" {
+		t.Fatalf("shortSessionID() = %q, want %q", got, "12345678")
+	}
+
+	got = shortSessionID("abcd")
+	if got != "abcd" {
+		t.Fatalf("shortSessionID() = %q, want %q", got, "abcd")
+	}
+}
+
+func TestSessionFromIPText(t *testing.T) {
+	if got := sessionFromIPText(api.ApiKey{}); got != "-" {
+		t.Fatalf("sessionFromIPText() = %q, want %q", got, "-")
+	}
+
+	ip := "2001:db8::1"
+	k := api.ApiKey{Spec: api.ApiKeySpec{FromIP: &ip}}
+	if got := sessionFromIPText(k); got != ip {
+		t.Fatalf("sessionFromIPText() = %q, want %q", got, ip)
+	}
+}

--- a/pkg/db/db-auth.go
+++ b/pkg/db/db-auth.go
@@ -745,6 +745,7 @@ func (d *Database) CreateUserApiKey(userID string, req api.ApiKeyCreateRequest) 
 		},
 		Spec: api.ApiKeySpec{
 			Comment:     req.Comment,
+			FromIP:      req.FromIP,
 			ExpiresAt:   req.ExpiresAt,
 			IssuedAt:    util.TimePtr(time.Now()),
 			Revoked:     util.BoolPtr(false),

--- a/pkg/db/db-auth_test.go
+++ b/pkg/db/db-auth_test.go
@@ -139,18 +139,24 @@ var _ = Describe("Auth", Ordered, func() {
 		})
 
 		It("creates, resolves, and revokes API keys", func() {
+			fromIP := "192.0.2.10"
 			apiKey, token, err := d.CreateUserApiKey(userID, api.ApiKeyCreateRequest{
 				Comment: util.StringPtr("cli access"),
+				FromIP:  &fromIP,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			rawToken = token
 			Expect(apiKey.Metadata.Id).NotTo(BeEmpty())
+			Expect(apiKey.Spec.FromIP).NotTo(BeNil())
+			Expect(*apiKey.Spec.FromIP).To(Equal(fromIP))
 
 			keys, err := d.ListUserApiKeys(userID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(keys).To(HaveLen(1))
 			Expect(keys[0].Spec.Comment).NotTo(BeNil())
 			Expect(*keys[0].Spec.Comment).To(Equal("cli access"))
+			Expect(keys[0].Spec.FromIP).NotTo(BeNil())
+			Expect(*keys[0].Spec.FromIP).To(Equal(fromIP))
 
 			resolvedUser, resolvedKey, err := d.AuthenticateApiKey(rawToken)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/marmotd/api-auth.go
+++ b/pkg/marmotd/api-auth.go
@@ -3,6 +3,7 @@ package marmotd
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -60,6 +61,22 @@ func bearerTokenFromAuthzHeader(authz string) (string, bool) {
 	return token, true
 }
 
+func sourceIPFromContext(ctx echo.Context) string {
+	ip := strings.TrimSpace(ctx.RealIP())
+	if ip != "" {
+		return ip
+	}
+	remoteAddr := strings.TrimSpace(ctx.Request().RemoteAddr)
+	if remoteAddr == "" {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err == nil {
+		return strings.TrimSpace(host)
+	}
+	return remoteAddr
+}
+
 func validatePasswordPolicy(password string) error {
 	p := strings.TrimSpace(password)
 	if len(p) < 8 {
@@ -102,7 +119,11 @@ func (s *Server) ApiAuthLogin(ctx echo.Context) error {
 		return mapLoginError(ctx, err)
 	}
 	sessionType := db.ApiKeySessionTypeLogin
-	apiKey, rawToken, err := s.Ma.Db.CreateUserApiKey(userID, api.ApiKeyCreateRequest{Comment: util.StringPtr("login-session"), SessionType: &sessionType})
+	createReq := api.ApiKeyCreateRequest{Comment: util.StringPtr("login-session"), SessionType: &sessionType}
+	if fromIP := sourceIPFromContext(ctx); fromIP != "" {
+		createReq.FromIP = &fromIP
+	}
+	apiKey, rawToken, err := s.Ma.Db.CreateUserApiKey(userID, createReq)
 	if err != nil {
 		return mapAuthDBError(ctx, err)
 	}

--- a/pkg/marmotd/api_auth_handler_test.go
+++ b/pkg/marmotd/api_auth_handler_test.go
@@ -135,6 +135,36 @@ var _ = Describe("Auth API handlers", Ordered, func() {
 		Expect(badPassRec.Code).To(Equal(http.StatusUnauthorized), badPassRec.Body.String())
 	})
 
+	It("stores client source IP in login session", func() {
+		req := httptest.NewRequest(http.MethodPost, "/auth/login", strings.NewReader(`{"userId":"admin","password":"passw0rd"}`))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		req.Header.Set("X-Forwarded-For", "203.0.113.8, 10.0.0.1")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		err := s.ApiAuthLogin(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec.Code).To(Equal(http.StatusOK), rec.Body.String())
+
+		apiKeyID := strings.TrimSpace(rec.Header().Get("X-Marmot-ApiKey-Id"))
+		Expect(apiKeyID).NotTo(BeEmpty())
+
+		keys, err := d.ListUserApiKeys("admin")
+		Expect(err).NotTo(HaveOccurred())
+
+		found := false
+		for _, k := range keys {
+			if strings.TrimSpace(k.Metadata.Id) != apiKeyID {
+				continue
+			}
+			Expect(k.Spec.FromIP).NotTo(BeNil())
+			Expect(*k.Spec.FromIP).To(Equal("203.0.113.8"))
+			found = true
+			break
+		}
+		Expect(found).To(BeTrue())
+	})
+
 	It("supports user CRUD, role assignment, and password policy", func() {
 		token := login("admin", "passw0rd").AccessToken
 


### PR DESCRIPTION
## 概要
`mactl user session` で「どこからログインしているか」が分からない問題を解消するため、ログイン元 IP をセッション情報に保持・表示できるようにしました。  
あわせて、一覧の可読性向上のため `SESSION-ID` を先頭 8 文字表示に変更しています。

Closes #592

## 背景 / 課題
現状の `mactl user session` はセッションの状態や時刻は見えるものの、ログイン元端末（IPv4/IPv6）が表示されず、運用上の追跡が難しい状態でした。

## 変更内容
- OpenAPI の `ApiKeyCreateRequest` / `ApiKeySpec` に `fromIP` を追加
- ログイン処理で接続元 IP を取得し、セッション API キー作成時に `FromIP` として保存
- API キー永続化処理で `FromIP` を保持
- `mactl user session` の出力に `FROM` 列を追加
- `mactl user session` の `SESSION-ID` 表示を先頭 8 文字に変更
- 変更点に対するユニット/ハンドラテストを追加

## 期待される動作
- `mactl user session` 実行時に、各セッションの `FROM` 列へ IPv4/IPv6 のログイン元 IP が表示される
- `SESSION-ID` は先頭 8 文字のみ表示される

## 互換性
- 既存のセッション情報に `FromIP` がない場合は `-` を表示
- 既存 API の破壊的変更はなし（項目追加のみ）

## テスト
実施した確認:
- `go test ./cmd/mactl/cmd -run 'TestShortSessionID|TestSessionFromIPText'`
- `go test ./pkg/db -ginkgo.focus='User, role, and API key persistence'`
- `go test ./pkg/marmotd -run TestMarmotdCeph -ginkgo.focus='stores client source IP in login session'`

## 補足
- 変更範囲を最小化するため、OpenAPI 生成物は必要差分（`fromIP` 追加）に限定しています。