### PR TITLE
mactl stop/start/restart SERVERNAMEの実装

### DIFF
--- a/cmd/mactl/cmd/server_lifecycle_by_name.go
+++ b/cmd/mactl/cmd/server_lifecycle_by_name.go
@@ -129,11 +129,15 @@ func resolveServerIDByName(m *client.MarmotEndpoint, name string) (string, strin
 func printLifecycleResult(byteBody []byte, textMessage string) error {
 	switch outputStyle {
 	case "text":
-		var data interface{}
-		if err := json.Unmarshal(byteBody, &data); err != nil {
-			return err
+		id, err := extractResponseID(byteBody)
+		if err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
 		}
-		fmt.Println(textMessage, data.(map[string]interface{})["id"])
+		displayID := id
+		if displayID == "" {
+			displayID = "<nil>"
+		}
+		fmt.Println(textMessage, displayID)
 		return nil
 	case "json":
 		fmt.Println(string(byteBody))

--- a/cmd/mactl/cmd/server_lifecycle_by_name.go
+++ b/cmd/mactl/cmd/server_lifecycle_by_name.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/client"
+	"go.yaml.in/yaml/v3"
+)
+
+var startCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start resources",
+}
+
+var startServerCmd = &cobra.Command{
+	Use:   "server SERVER-NAME",
+	Short: "Start a server by name",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		m, err := getClientConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get API client config: %w", err)
+		}
+
+		serverID, serverName, err := resolveServerIDByName(m, args[0])
+		if err != nil {
+			return err
+		}
+
+		byteBody, _, err := m.StartServerById(serverID)
+		if err != nil {
+			return fmt.Errorf("failed to start server %q: %w", serverName, err)
+		}
+
+		return printLifecycleResult(byteBody, "サーバーが起動されました。ID:")
+	},
+}
+
+var stopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop resources",
+}
+
+var stopServerCmd = &cobra.Command{
+	Use:   "server SERVER-NAME",
+	Short: "Stop a server by name",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		m, err := getClientConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get API client config: %w", err)
+		}
+
+		serverID, serverName, err := resolveServerIDByName(m, args[0])
+		if err != nil {
+			return err
+		}
+
+		byteBody, _, err := m.StopServerById(serverID)
+		if err != nil {
+			return fmt.Errorf("failed to stop server %q: %w", serverName, err)
+		}
+
+		return printLifecycleResult(byteBody, "サーバーが停止されました。ID:")
+	},
+}
+
+var restartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restart resources",
+}
+
+var restartServerCmd = &cobra.Command{
+	Use:   "server SERVER-NAME",
+	Short: "Restart a server by name",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		m, err := getClientConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get API client config: %w", err)
+		}
+
+		serverID, serverName, err := resolveServerIDByName(m, args[0])
+		if err != nil {
+			return err
+		}
+
+		if _, _, err := m.StopServerById(serverID); err != nil {
+			return fmt.Errorf("failed to stop server %q for restart: %w", serverName, err)
+		}
+
+		byteBody, _, err := m.StartServerById(serverID)
+		if err != nil {
+			return fmt.Errorf("failed to start server %q for restart: %w", serverName, err)
+		}
+
+		return printLifecycleResult(byteBody, "サーバーが再起動されました。ID:")
+	},
+}
+
+func resolveServerIDByName(m *client.MarmotEndpoint, name string) (string, string, error) {
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return "", "", fmt.Errorf("server name is required")
+	}
+
+	list, _, err := m.GetServers()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to list servers: %w", err)
+	}
+
+	var servers []api.Server
+	if err := json.Unmarshal(list, &servers); err != nil {
+		return "", "", fmt.Errorf("failed to parse servers: %w", err)
+	}
+
+	server, err := findServerByName(servers, trimmedName)
+	if err != nil {
+		return "", "", err
+	}
+
+	return string(api.ServerID(*server)), trimmedName, nil
+}
+
+func printLifecycleResult(byteBody []byte, textMessage string) error {
+	switch outputStyle {
+	case "text":
+		var data interface{}
+		if err := json.Unmarshal(byteBody, &data); err != nil {
+			return err
+		}
+		fmt.Println(textMessage, data.(map[string]interface{})["id"])
+		return nil
+	case "json":
+		fmt.Println(string(byteBody))
+		return nil
+	case "yaml":
+		var data interface{}
+		if err := json.Unmarshal(byteBody, &data); err != nil {
+			return err
+		}
+		yamlBytes, err := yaml.Marshal(data)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(yamlBytes))
+		return nil
+	default:
+		return fmt.Errorf("output style must set text/json/yaml")
+	}
+}
+
+func init() {
+	startCmd.AddCommand(startServerCmd)
+	stopCmd.AddCommand(stopServerCmd)
+	restartCmd.AddCommand(restartServerCmd)
+
+	rootCmd.AddCommand(startCmd)
+	rootCmd.AddCommand(stopCmd)
+	rootCmd.AddCommand(restartCmd)
+}

--- a/cmd/mactl/cmd/server_lifecycle_by_name_test.go
+++ b/cmd/mactl/cmd/server_lifecycle_by_name_test.go
@@ -28,3 +28,29 @@ func TestRootHasKubectlLikeServerLifecycleCommands(t *testing.T) {
 		}
 	}
 }
+
+func TestPrintLifecycleResultTextUsesResponseID(t *testing.T) {
+	withOutputStyle("text", t, func() {
+		out := captureStdoutForIDTest(t, func() {
+			if err := printLifecycleResult([]byte(`{"id":"srv-123","metadata":{"id":"meta-999"}}`), "MSG"); err != nil {
+				t.Fatalf("printLifecycleResult() unexpected err: %v", err)
+			}
+		})
+
+		if !contains(out, "MSG meta-999") {
+			t.Fatalf("stdout = %q, want contains %q", out, "MSG meta-999")
+		}
+	})
+}
+
+func contains(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/mactl/cmd/server_lifecycle_by_name_test.go
+++ b/cmd/mactl/cmd/server_lifecycle_by_name_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import "testing"
+
+func TestRootHasKubectlLikeServerLifecycleCommands(t *testing.T) {
+	testCases := []struct {
+		path       []string
+		parentName string
+	}{
+		{path: []string{"start", "server"}, parentName: "start"},
+		{path: []string{"stop", "server"}, parentName: "stop"},
+		{path: []string{"restart", "server"}, parentName: "restart"},
+	}
+
+	for _, tc := range testCases {
+		cmd, _, err := rootCmd.Find(tc.path)
+		if err != nil {
+			t.Fatalf("Find(%v) returned error: %v", tc.path, err)
+		}
+		if cmd == nil {
+			t.Fatalf("Find(%v) returned nil command", tc.path)
+		}
+		if cmd.Name() != "server" {
+			t.Fatalf("Find(%v) resolved to %q, want %q", tc.path, cmd.Name(), "server")
+		}
+		if cmd.Parent() == nil || cmd.Parent().Name() != tc.parentName {
+			t.Fatalf("Find(%v) parent = %v, want %q", tc.path, cmd.Parent(), tc.parentName)
+		}
+	}
+}


### PR DESCRIPTION
## 概要
Issue #604 の要望に対応し、サーバー操作コマンドを K8s ライクな語順で実行できるようにしました。

- mactl stop server SERVER-NAME
- mactl start server SERVER-NAME
- mactl restart server SERVER-NAME

既存の ID 指定コマンドは互換維持のため変更していません。

## 変更内容
- ルートコマンド配下に start / stop / restart を追加し、それぞれに server サブコマンドを追加
- server サブコマンドは SERVER-NAME を受け取り、サーバー一覧から対象 ID を解決して既存 API を呼び出し
- restart は stop -> start の順で実行
- 出力形式は既存の output オプションに合わせて text/json/yaml をサポート
- コマンド配線のテストを追加

対象ファイル:
- server_lifecycle_by_name.go
- server_lifecycle_by_name_test.go

## 非対象
- 既存の server 配下 ID 指定コマンドの仕様変更
- API 定義の変更

## 動作確認
- go build ./cmd/mactl
- go test ./cmd/mactl/cmd -run TestRootHasKubectlLikeServerLifecycleCommands -count=1
- go test ./cmd/mactl/cmd -count=1

## 期待効果
- コマンドの語順が直感的になり、推測しやすい操作体系になる
- 既存運用との後方互換を維持したまま利用者体験を改善できる
