### PR TITLE
カンマ区切りで複数オブジェクトを削除可能に

### DIFF
--- a/cmd/mactl/cmd/del.go
+++ b/cmd/mactl/cmd/del.go
@@ -95,19 +95,16 @@ func parseCommaSeparatedNames(rawNames []string) ([]string, error) {
 		}
 	}
 
-	names := make([]string, 0, len(rawNames))
-	for _, raw := range rawNames {
-		for _, part := range strings.Split(raw, ",") {
-			name := strings.TrimSpace(part)
-			if name == "" {
-				continue
-			}
-			names = append(names, name)
-		}
-	}
+	joined := strings.Join(rawNames, " ")
+	parts := strings.Split(joined, ",")
 
-	if len(names) == 0 {
-		return nil, fmt.Errorf("server name is required")
+	names := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return nil, fmt.Errorf("server name must not be empty")
+		}
+		names = append(names, name)
 	}
 
 	return names, nil

--- a/cmd/mactl/cmd/del.go
+++ b/cmd/mactl/cmd/del.go
@@ -47,7 +47,7 @@ var delCmd = &cobra.Command{
 			return nil
 		}
 
-		if len(args) != 2 {
+		if len(args) < 2 {
 			return fmt.Errorf("del requires RESOURCE and NAME unless -f is specified")
 		}
 

--- a/cmd/mactl/cmd/del.go
+++ b/cmd/mactl/cmd/del.go
@@ -78,7 +78,24 @@ var delCmd = &cobra.Command{
 }
 
 func parseCommaSeparatedNames(rawNames []string) ([]string, error) {
-	names := make([]string, 0)
+	if len(rawNames) == 0 {
+		return nil, fmt.Errorf("server name is required")
+	}
+
+	// Require commas between every adjacent argument to avoid allowing space-separated deletes,
+	// e.g. "del server a b".
+	if len(rawNames) > 1 {
+		for i := 0; i < len(rawNames)-1; i++ {
+			left := strings.TrimSpace(rawNames[i])
+			right := strings.TrimSpace(rawNames[i+1])
+			if strings.HasSuffix(left, ",") || strings.HasPrefix(right, ",") {
+				continue
+			}
+			return nil, fmt.Errorf("multiple server names must be comma-separated")
+		}
+	}
+
+	names := make([]string, 0, len(rawNames))
 	for _, raw := range rawNames {
 		for _, part := range strings.Split(raw, ",") {
 			name := strings.TrimSpace(part)

--- a/cmd/mactl/cmd/del.go
+++ b/cmd/mactl/cmd/del.go
@@ -52,10 +52,48 @@ var delCmd = &cobra.Command{
 		}
 
 		resourceName := normalizeResourceName(args[0])
+
+		if strings.EqualFold(resourceName, "server") {
+			objectNames, err := parseCommaSeparatedNames(args[1:])
+			if err != nil {
+				return err
+			}
+
+			for _, objectName := range objectNames {
+				if err := deleteResourceByTypeAndName(resourceName, objectName); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		if len(args) != 2 {
+			return fmt.Errorf("del requires exactly one NAME for resource %q", resourceName)
+		}
+
 		objectName := args[1]
 
 		return deleteResourceByTypeAndName(resourceName, objectName)
 	},
+}
+
+func parseCommaSeparatedNames(rawNames []string) ([]string, error) {
+	names := make([]string, 0)
+	for _, raw := range rawNames {
+		for _, part := range strings.Split(raw, ",") {
+			name := strings.TrimSpace(part)
+			if name == "" {
+				continue
+			}
+			names = append(names, name)
+		}
+	}
+
+	if len(names) == 0 {
+		return nil, fmt.Errorf("server name is required")
+	}
+
+	return names, nil
 }
 
 

--- a/cmd/mactl/cmd/del_command_test.go
+++ b/cmd/mactl/cmd/del_command_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDelCommandAllowsMultipleServerNameArgs(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	configPath := filepath.Join(homeDir, ".marmot")
+	configBody := "current: 0\nendpoints:\n  - http://127.0.0.1:1\n"
+	if err := os.WriteFile(configPath, []byte(configBody), 0600); err != nil {
+		t.Fatalf("failed to write client config: %v", err)
+	}
+
+	err := delCmd.RunE(delCmd, []string{"server", "biz,", "rest1,", "rest2"})
+	if err == nil {
+		t.Fatalf("expected command to continue past arg validation")
+	}
+
+	if strings.Contains(err.Error(), "del requires RESOURCE and NAME unless -f is specified") {
+		t.Fatalf("server multi-name args were rejected by initial validation: %v", err)
+	}
+
+	if strings.Contains(err.Error(), "del requires exactly one NAME") {
+		t.Fatalf("server multi-name args were rejected by single-name validation: %v", err)
+	}
+}

--- a/cmd/mactl/cmd/del_test.go
+++ b/cmd/mactl/cmd/del_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCommaSeparatedNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "issue 603 sample with commas and spaces",
+			input: []string{"biz,", "rest1,", "rest2,", "rest3,", "db"},
+			want:  []string{"biz", "rest1", "rest2", "rest3", "db"},
+		},
+		{
+			name:  "single arg with comma list",
+			input: []string{"biz,rest1,rest2,rest3,db"},
+			want:  []string{"biz", "rest1", "rest2", "rest3", "db"},
+		},
+		{
+			name:    "empty values only",
+			input:   []string{" , ", ""},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCommaSeparatedNames(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parsed names mismatch: got=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/mactl/mactl-delete-server-multi-e2e_test.go
+++ b/cmd/mactl/mactl-delete-server-multi-e2e_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+)
+
+var _ = Describe("MactlDeleteServerMultiE2E", Ordered, func() {
+	var mockServer *mockServerHandle
+	var containerID string
+	var testHomeDir string
+
+	BeforeAll(func(specCtx SpecContext) {
+		cleanupTestEnvironment()
+		var err error
+		testHomeDir, err = setupMactlTestHome()
+		Expect(err).NotTo(HaveOccurred())
+		if err := ensureMactlTestBinary(); err != nil {
+			Fail(fmt.Sprintf("Failed to build mactl test binary: %v", err))
+		}
+
+		var etcdEp string
+		containerID, etcdEp, err = startEtcdContainer()
+		if err != nil {
+			Fail(fmt.Sprintf("Failed to start container: %v", err))
+		}
+
+		mockServer, err = startMockServer(etcdEp, "testdata/marmotd.json")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(loginAsAdmin()).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func(specCtx SpecContext) {
+		if mockServer != nil {
+			mockServer.Stop()
+		}
+
+		if strings.TrimSpace(containerID) != "" {
+			cmd := exec.Command("docker", "kill", containerID)
+			_, _ = cmd.CombinedOutput()
+			cmd = exec.Command("docker", "rm", containerID)
+			_, _ = cmd.CombinedOutput()
+		}
+
+		if strings.TrimSpace(testHomeDir) != "" {
+			_ = os.RemoveAll(testHomeDir)
+		}
+		_ = os.Remove("bin/mactl-test")
+		_ = os.Remove("/var/actions-runner/_work/marmot/marmot/cmd/mactl/bin/mactl-test")
+		cleanupTestEnvironment()
+	})
+
+	It("mactl delete server biz,rest1,rest2,rest3,db で一括削除できる", func() {
+		names := []string{"biz", "rest1", "rest2", "rest3", "db"}
+		tempDir, err := os.MkdirTemp("", "mactl-issue603-")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tempDir)
+
+		createdIDs := make(map[string]string, len(names))
+		for _, name := range names {
+			yamlPath := fmt.Sprintf("%s/%s.yaml", tempDir, name)
+			yamlBody := fmt.Sprintf(`apiVersion: v1
+kind: Server
+metadata:
+    name: %s
+    comment: "issue-603 e2e"
+spec:
+    cpu: 1
+    memory: 1024
+`, name)
+			err = os.WriteFile(yamlPath, []byte(yamlBody), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "create", "--configfile", yamlPath, "--output", "json")
+			stdoutStderr, err := cmd.CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), "create failed for %s: %s", name, string(stdoutStderr))
+
+			var reply api.Success
+			err = json.Unmarshal(stdoutStderr, &reply)
+			Expect(err).NotTo(HaveOccurred(), "unexpected create output for %s: %s", name, string(stdoutStderr))
+			createdIDs[name] = reply.Id
+		}
+
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
+			stdoutStderr, err := cmd.CombinedOutput()
+			g.Expect(err).NotTo(HaveOccurred())
+
+			var servers []api.Server
+			err = json.Unmarshal(stdoutStderr, &servers)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			found := map[string]bool{}
+			for _, server := range servers {
+				found[server.Metadata.Name] = true
+			}
+			for _, name := range names {
+				g.Expect(found[name]).To(BeTrue(), "server %s not found in list", name)
+			}
+		}, 120*time.Second, 5*time.Second).Should(Succeed())
+
+		cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "delete", "server", "biz,rest1,rest2,rest3,db")
+		stdoutStderr, err := cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), "bulk delete failed: %s", string(stdoutStderr))
+
+		for _, name := range names {
+			serverID := createdIDs[name]
+			Eventually(func(g Gomega) {
+				detailCmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "detail", serverID, "--output", "json")
+				stdoutStderr, err := detailCmd.CombinedOutput()
+
+				if err != nil {
+					body := string(stdoutStderr)
+					if strings.Contains(strings.ToLower(body), "not found") || strings.Contains(body, "IDが存在しません") {
+						return
+					}
+				}
+				g.Expect(err).NotTo(HaveOccurred(), "detail failed for %s(id=%s): %s", name, serverID, string(stdoutStderr))
+
+				var server api.Server
+				err = json.Unmarshal(stdoutStderr, &server)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(server.Status.StatusCode).To(Equal(int(db.SERVER_DELETING)))
+			}, 120*time.Second, 5*time.Second).Should(Succeed())
+		}
+
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("./bin/mactl-test", "--api", "testdata/.marmot", "server", "list", "--output", "json")
+			stdoutStderr, err := cmd.CombinedOutput()
+			g.Expect(err).NotTo(HaveOccurred())
+
+			var servers []api.Server
+			err = json.Unmarshal(stdoutStderr, &servers)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(len(servers)).To(Equal(0))
+		}, 120*time.Second, 5*time.Second).Should(Succeed())
+	})
+})

--- a/cmd/mactl/mactl-delete-server-multi-e2e_test.go
+++ b/cmd/mactl/mactl-delete-server-multi-e2e_test.go
@@ -63,7 +63,10 @@ var _ = Describe("MactlDeleteServerMultiE2E", Ordered, func() {
 		names := []string{"biz", "rest1", "rest2", "rest3", "db"}
 		tempDir, err := os.MkdirTemp("", "mactl-issue603-")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.RemoveAll(tempDir)
+		defer func() {
+			err := os.RemoveAll(tempDir)
+			Expect(err).NotTo(HaveOccurred())
+		}()
 
 		createdIDs := make(map[string]string, len(names))
 		for _, name := range names {


### PR DESCRIPTION
## 概要
Issue #603 に対応し、mactl の delete コマンドで server 名をカンマ区切りで複数指定できるようにしました。  
これにより、以下のように 1 コマンドで複数サーバーを削除できます。

- mactl delete server biz,rest1,rest2,rest3,db

## 背景
これまでは server 削除時、1 回の実行で 1 つの NAME しか指定できず、複数台削除にはコマンドの繰り返し実行が必要でした。  
運用上の利便性向上のため、複数 NAME を一括処理できるよう改善しました。

## 変更内容
- server リソース指定時のみ、NAME 引数のカンマ区切り複数指定を許可
- カンマと空白を正規化して順次削除実行
- server 以外のリソースは従来どおり単一 NAME 指定を維持
- 実装箇所
- del.go
- del_test.go
- mactl-delete-server-multi-e2e_test.go

## テスト
- ビルド
- go build ./cmd/mactl
- 単体テスト
- go test ./cmd/mactl/cmd -run TestParseCommaSeparatedNames -count=1
- E2E（モックサーバー）
- go test ./cmd/mactl -run TestUtil -count=1 -ginkgo.focus='MactlDeleteServerMultiE2E'

## 期待効果
- 複数サーバー削除のオペレーションを 1 コマンド化できる
- 手作業回数と打鍵ミスリスクを削減できる

## 影響範囲
- mactl delete server の引数解釈ロジックのみ
- API や server 側実装には変更なし