### PR TITLE
概要 Issue #588 の提案に対応し、marmotd の内部 DNS で marmotd サブドメイン付き FQDN の名前解決を可能に

### DIFF
--- a/pkg/internal-dns/dns-server.go
+++ b/pkg/internal-dns/dns-server.go
@@ -122,21 +122,24 @@ func (c *controller) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	q := r.Question[0]
-	// 末尾のドットを除去してetcdのキーを作成 (example.com. -> /dns/example.com)
-	etcdKey := DomainToMarmotPath(q.Name)
+	lookupKeys := DomainToMarmotPaths(q.Name)
 
 	// etcd から IP アドレスを取得
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	resp, err := c.db.Cli.Get(ctx, etcdKey)
-	if err != nil {
-		slog.Error("検索の失敗 Failed to query etcd", "err", err)
-		dns.HandleFailed(w, r)
-		return
-	}
+	for _, etcdKey := range lookupKeys {
+		resp, err := c.db.Cli.Get(ctx, etcdKey)
+		if err != nil {
+			slog.Error("検索の失敗 Failed to query etcd", "err", err)
+			dns.HandleFailed(w, r)
+			return
+		}
 
-	if len(resp.Kvs) > 0 {
+		if len(resp.Kvs) == 0 {
+			continue
+		}
+
 		ip, ipStr, err := decodeDNSRecordIP(resp.Kvs[0].Value)
 		if err != nil {
 			slog.Error("Failed to decode DNS record", "err", err, "key", etcdKey)
@@ -234,9 +237,7 @@ func shouldForwardUpstream(remoteAddr net.Addr, allowedCIDRs []netip.Prefix) boo
 
 // DomainToMarmotPath はドメイン名を /marmot/dns/ 形式のパスに変換します
 func DomainToMarmotPath(domain string) string {
-	// 末尾のドットを削除し、ドットで分割
-	domain = strings.TrimSuffix(domain, ".")
-	parts := strings.Split(domain, ".")
+	parts := splitDomainLabels(domain)
 
 	// スライスの要素を逆順に入れ替え
 	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
@@ -245,4 +246,38 @@ func DomainToMarmotPath(domain string) string {
 
 	// プレフィックス を先頭につけて結合
 	return db.InternalDNSPrefix + "/" + strings.Join(parts, "/")
+}
+
+// DomainToMarmotPaths は問い合わせドメインから探索候補キーを返す。
+// 1) 完全修飾名を逆順化したキー
+// 2) host.network 形式へのフォールバックキー
+func DomainToMarmotPaths(domain string) []string {
+	full := DomainToMarmotPath(domain)
+	parts := splitDomainLabels(domain)
+
+	paths := []string{full}
+	if len(parts) >= 2 {
+		fallback := db.InternalDNSPrefix + "/" + parts[1] + "/" + parts[0]
+		if fallback != full {
+			paths = append(paths, fallback)
+		}
+	}
+
+	return paths
+}
+
+func splitDomainLabels(domain string) []string {
+	domain = strings.TrimSuffix(domain, ".")
+	parts := strings.Split(domain, ".")
+
+	filtered := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+
+	return filtered
 }

--- a/pkg/internal-dns/dns-server_test.go
+++ b/pkg/internal-dns/dns-server_test.go
@@ -104,6 +104,39 @@ func TestDomainToMarmotPath(t *testing.T) {
 	}
 }
 
+func TestDomainToMarmotPaths(t *testing.T) {
+	tests := []struct {
+		domain string
+		want   []string
+	}{
+		{
+			domain: "vm1.test-net-1.",
+			want:   []string{"/marmot/dns/test-net-1/vm1"},
+		},
+		{
+			domain: "server1.host-bridge.marmot1.labo.local",
+			want: []string{
+				"/marmot/dns/local/labo/marmot1/host-bridge/server1",
+				"/marmot/dns/host-bridge/server1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.domain, func(t *testing.T) {
+			got := DomainToMarmotPaths(tt.domain)
+			if len(got) != len(tt.want) {
+				t.Fatalf("candidate count mismatch: want=%d got=%d (%v)", len(tt.want), len(got), got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("candidate mismatch at %d: want=%q got=%q", i, tt.want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
 func TestShouldForwardUpstream(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## 概要
Issue #588 の提案に対応し、marmotd の内部 DNS で `marmotd` サブドメイン付き FQDN の名前解決を可能にしました。

これにより、例えば以下の問い合わせに対応できます。

- `server1.host-bridge.marmot1.labo.local`

## 背景
従来の内部 DNS は、主に `server.network` 形式（例: `server1.host-bridge`）を前提に etcd キーを参照していました。  
そのため、`marmotd` 単位のサブドメインを含む FQDN 問い合わせでは、登録済みレコードとキー不一致が起きるケースがありました。

## 変更内容
- DNS 問い合わせ時の etcd キー探索を複数候補化
1. 完全 FQDN を逆順化したキーを最初に探索
2. 見つからない場合、`host.network` 形式の既存キーにフォールバック

- 具体例
- 問い合わせ: `server1.host-bridge.marmot1.labo.local`
- 第1候補: `/marmot/dns/local/labo/marmot1/host-bridge/server1`
- 第2候補: `/marmot/dns/host-bridge/server1`

## 変更ファイル
- dns-server.go
- dns-server_test.go

## テスト
- 追加テスト
- `TestDomainToMarmotPaths`

- 実行結果
- `go test ./pkg/internal-dns -count=1`  
- `ok`

## 互換性・影響範囲
- 既存の `server.network` 形式の解決は維持
- API や DB スキーマ変更なし
- 影響範囲は internal-dns の問い合わせ解決ロジックに限定