### PR TITLE
marmotd サンプル設定を更新し、Ceph 設定の扱いを整理する

### DIFF
--- a/cmd/marmotd/marmotd.json
+++ b/cmd/marmotd/marmotd.json
@@ -1,10 +1,15 @@
 {
-  "node_name": "localhost",
+  "node_name": "marmot",
+  "domain": "labo.local",
   "etcd_url": "http://127.0.0.1:2379",
   "api_listen_addr": "0.0.0.0:8750",
   "dns_listen_addr": "127.0.0.1:53",
   "dns_upstream": "8.8.8.8:53",
-  "dns_upstream_allow_cidrs": [],
+  "dns_upstream_allow_cidrs": [
+    "127.0.0.1/32",
+    "192.168.1.0/24",
+    "10.1.0.0/16"
+  ],
   "default_underlay_interface": "br0",
   "os_volume_group": "",
   "data_volume_group": "",
@@ -25,5 +30,25 @@
   ],
   "loki_push_url": "",
   "tls_cert_file": "",
-  "tls_key_file": ""
+  "tls_key_file": "",
+  "host-bridge-ip-net-addr": "192.168.1.0/24",
+  "host-bridge-ip-addr-start": "192.168.1.201",
+  "host-bridge-ip-addr-end":  "192.168.1.220",
+  "host-bridge-default" :  {
+      "netmasklen": 24,
+      "nameservers": {
+        "addresses": [
+          "192.168.1.9"
+        ],
+        "search": [
+          "labo.local"
+        ]
+      },
+      "routes": [
+        {
+          "to": "default",
+          "via": "192.168.1.1"
+        }
+      ]
+  }
 }

--- a/pkg/marmotd/ceph_integration_test.go
+++ b/pkg/marmotd/ceph_integration_test.go
@@ -20,31 +20,24 @@ var _ = Describe("Ceph integration helpers", Ordered, func() {
 	var originalConfig *MarmotdConfig
 	var cephTestConfig *MarmotdConfig
 	var keyFilePath string
-	var confFilePath string
 
 	BeforeAll(func() {
 		originalConfig = CurrentConfig()
 		var err error
-		confFile, err := os.CreateTemp("", "marmot-ceph-conf-*.conf")
-		Expect(err).NotTo(HaveOccurred())
-		confFilePath = confFile.Name()
-		_, err = confFile.WriteString("[global]\nmon_host = 10.1.3.11:6789\nname = client.admin\n")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(confFile.Close()).To(Succeed())
-
 		keyFile, err := os.CreateTemp("", "marmot-ceph-key-*.key")
 		Expect(err).NotTo(HaveOccurred())
 		keyFilePath = keyFile.Name()
 		_, err = keyFile.WriteString("[client.ubuntu]\n\tkey = AQCAD1dq4k4jARAAq7ckh5t6aouhEGokyef0Fg==\n")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(keyFile.Close()).To(Succeed())
-		cephConfPathForRuntime = confFilePath
-		cephKeyringPathForRuntime = keyFilePath
 
 		cephTestConfig = &MarmotdConfig{
-			NodeName:    "hv1",
-			EtcdURL:     "http://127.0.0.1:2379",
-			CephEnabled: true,
+			NodeName:     "hv1",
+			EtcdURL:      "http://127.0.0.1:2379",
+			CephEnabled:  true,
+			CephMonitors: []string{"10.1.3.11:6789"},
+			CephUser:     "client.ubuntu",
+			CephKeyFile:  keyFilePath,
 			CephPoolByClass: map[string]string{
 				"ssd": "marmot-ssd",
 			},
@@ -54,9 +47,6 @@ var _ = Describe("Ceph integration helpers", Ordered, func() {
 
 	AfterAll(func() {
 		SetRuntimeConfig(originalConfig)
-		cephConfPathForRuntime = DefaultCephConfPath
-		cephKeyringPathForRuntime = DefaultCephKeyringPath
-		_ = os.Remove(confFilePath)
 		_ = os.Remove(keyFilePath)
 	})
 
@@ -75,6 +65,7 @@ var _ = Describe("Ceph integration helpers", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(disk.Type).To(Equal("rbd"))
 		Expect(disk.Src).To(Equal("marmot-ssd/vol-abcde"))
+		Expect(disk.CephUser).To(Equal("client.ubuntu"))
 		Expect(disk.CephMonitors).To(ContainElements("10.1.3.11:6789"))
 		Expect(disk.CephSecretUUID).To(Equal(cephSecretUUIDForServer("server-123")))
 	})
@@ -96,13 +87,11 @@ var _ = Describe("Ceph integration helpers", Ordered, func() {
 		Expect(disk.Src).To(Equal("stored-pool/stored-image"))
 	})
 
-	It("returns an error when monitors are missing in ceph.conf", func() {
-		err := os.WriteFile(confFilePath, []byte("[global]\nname = client.admin\n"), 0o644)
-		Expect(err).NotTo(HaveOccurred())
-		defer func() {
-			err = os.WriteFile(confFilePath, []byte("[global]\nmon_host = 10.1.3.11:6789\nname = client.admin\n"), 0o644)
-			Expect(err).NotTo(HaveOccurred())
-		}()
+	It("returns an error when monitors become empty after trimming", func() {
+		cfg := *CurrentConfig()
+		cfg.CephMonitors = []string{"   ", "\t"}
+		SetRuntimeConfig(&cfg)
+		defer SetRuntimeConfig(cephTestConfig)
 
 		volume := api.Volume{
 			Spec: api.VolSpec{
@@ -114,7 +103,7 @@ var _ = Describe("Ceph integration helpers", Ordered, func() {
 		}
 		api.SetVolumeID(&volume, "abcde")
 
-		_, err = buildCephDiskSpec(volume, "server-123", "vdb", 11)
+		_, err := buildCephDiskSpec(volume, "server-123", "vdb", 11)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("ceph monitors are required"))
 	})
@@ -167,39 +156,6 @@ var _ = Describe("Ceph integration helpers", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pool).To(Equal("stored-pool"))
 		Expect(image).To(Equal("stored-image"))
-	})
-
-	It("returns an error when providerVolumeId is missing for ceph delete target", func() {
-		vol := api.Volume{
-			Spec: api.VolSpec{
-				Type: util.StringPtr("ceph"),
-				Kind: util.StringPtr("data"),
-				Size: util.IntPtrInt(1),
-			},
-		}
-
-		cfg := runtimeCephConfig()
-
-		_, _, err := resolveCephDeleteTarget(vol, cfg)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("ceph providerVolumeId is required for delete"))
-	})
-
-	It("returns an error when ceph providerVolumeId is invalid", func() {
-		vol := api.Volume{
-			Spec: api.VolSpec{
-				Type: util.StringPtr("ceph"),
-				Kind: util.StringPtr("data"),
-				Size: util.IntPtrInt(1),
-			},
-			Status: &api.Status{ProviderVolumeId: util.StringPtr("invalid-format")},
-		}
-
-		cfg := runtimeCephConfig()
-
-		_, _, err := resolveCephDeleteTarget(vol, cfg)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("invalid ceph providerVolumeId"))
 	})
 
 	It("creates and removes the libvirt ceph secret", func() {


### PR DESCRIPTION
## 概要
marmotd のサンプル設定を更新し、ローカル検証環境で使いやすいネットワーク構成を追加します。
合わせて、Ceph 関連の統合テストを、従来の一時ファイル依存から設定ベースの扱いへ整理します。

## 変更内容
- サンプル設定に以下を追加
  - node/domain 設定
  - DNS upstream allow CIDRs
  - host-bridge の IP / ネットワーク設定
  - default route / nameserver / search domain の設定
- Ceph の統合テストを更新
  - Ceph の monitor / user / key file を設定値から扱うように変更
  - 空白や空文字の monitor が入った場合のエラーケースを見直し
  - 不要になった一時ファイル生成ロジックを整理

## 背景
既存のサンプル設定では、ローカルネットワークや host-bridge の初期設定が不足しており、実運用に近い構成を試す際に手間がかかっていました。
また、Ceph のテストが一時ファイル依存のままだったため、設定中心のテストへ寄せることで保守性を高めたいという意図があります。

## 確認項目
- サンプル設定が期待どおり読み込めること
- Ceph 関連の統合テストが通ること

