### PR TITLE
marmotd のサンプル設定を更新して、host-bridge と DNS 設定を追加する

### DIFF
--- a/cmd/marmotd/marmotd.json
+++ b/cmd/marmotd/marmotd.json
@@ -1,15 +1,20 @@
 {
-  "node_name": "localhost",
+  "node_name": "marmot1",
+  "domain": "labo.local",
   "etcd_url": "http://127.0.0.1:2379",
   "api_listen_addr": "0.0.0.0:8750",
   "dns_listen_addr": "127.0.0.1:53",
   "dns_upstream": "8.8.8.8:53",
-  "dns_upstream_allow_cidrs": [],
+  "dns_upstream_allow_cidrs": [
+    "127.0.0.1/32",
+    "192.168.1.0/24",
+    "10.1.0.0/16"
+  ],
   "default_underlay_interface": "br0",
   "os_volume_group": "",
   "data_volume_group": "",
   "deletion_delay_seconds": 10,
-  "session_idle_timeout": "1h",
+  "session_idle_timeout": "5d",
   "image_create_from_vm_timeout_seconds": 600,
   "image_create_from_url_timeout_seconds": 1800,
   "image_download_timeout_seconds": 1800,
@@ -25,5 +30,31 @@
   ],
   "loki_push_url": "",
   "tls_cert_file": "",
-  "tls_key_file": ""
+  "tls_key_file": "",
+  "host-bridge-ip-net-addr": "192.168.1.0/16",
+  "host-bridge-ip-addr-start": "192.168.1.220",
+  "host-bridge-ip-addr-end":  "192.168.1.254",
+  "host-bridge-default" :  {
+      "netmasklen": 24,
+      "nameservers": {
+        "addresses": [
+          "192.168.1.9"
+        ],
+        "search": [
+          "labo.local"
+        ]
+      },
+      "routes": [
+        {
+          "to": "default",
+          "via": "192.168.1.1"
+        }
+      ]
+  },
+  "ceph_enabled": false,
+  "ceph_pool_by_class": [
+      { "storageClass": "hdd",  "pool": "marmot-hdd" },
+      { "storageClass": "ssd",  "pool": "marmot-ssd" },
+      { "storageClass": "nvme", "pool": "marmot-nvme" }
+  ]
 }


### PR DESCRIPTION
## 概要
marmotd のサンプル設定ファイルに、ローカル環境でそのまま使いやすいように host-bridge や DNS 関連の設定を追加します。

## 変更内容
- サンプル設定に以下を追加
  - node 名と domain 設定
  - DNS upstream allow CIDRs
  - host-bridge の IP ネットワーク設定
  - host-bridge のデフォルトネットワーク設定（netmask / nameserver / route）
- 既存の設定値を維持しつつ、実運用に近い初期設定例として整理

## 背景
これまでのサンプル設定では、host-bridge の IP 管理や DNS ルーティングに関する設定が不足しており、ローカル検証や開発環境での利用時に手動で追記が必要でした。
今回の更新で、構成を確認しやすいサンプルとして使えるようにします。

