### PR TITLE
mactl-ssh コマンドの実装

### DIFF
--- a/cmd/install.sh
+++ b/cmd/install.sh
@@ -4,6 +4,7 @@ BINDIR=.
 DISTDIR=/usr/local/marmot
 SERVER_EXE=marmotd
 CLIENT_CMD=mactl
+CLIENT_SSH_ALIAS=mactl-ssh
 CLIENT_CONFIG=config_marmot
 ADMIN_CMD=maadm
 
@@ -18,6 +19,8 @@ install -m 0644 ${BINDIR}/marmot.service /etc/systemd/system
 
 rm -f /usr/local/bin/${CLIENT_CMD}
 install -m 0755 ${BINDIR}/${CLIENT_CMD} /usr/local/bin
+rm -f /usr/local/bin/${CLIENT_SSH_ALIAS}
+ln -s /usr/local/bin/${CLIENT_CMD} /usr/local/bin/${CLIENT_SSH_ALIAS}
 rm -f /usr/local/bin/${ADMIN_CMD}
 install -m 0755 ${BINDIR}/${ADMIN_CMD} /usr/local/bin
 install -m 0644 ${BINDIR}/${CLIENT_CONFIG} ${HOME}/.${CLIENT_CONFIG}

--- a/cmd/mactl/cmd/root.go
+++ b/cmd/mactl/cmd/root.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -23,6 +25,14 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	normalizedArgs := normalizeInvocationArgs(os.Args)
+	if len(normalizedArgs) > 1 {
+		rootCmd.SetArgs(normalizedArgs[1:])
+	} else {
+		rootCmd.SetArgs([]string{})
+	}
+	defer rootCmd.SetArgs(nil)
+
 	//var err error
 	//m, err = getClientConfig()
 	//if err != nil {
@@ -35,6 +45,25 @@ func Execute() {
 		os.Exit(1)
 	}
 	os.Exit(0)
+}
+
+func normalizeInvocationArgs(args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
+
+	if strings.TrimSpace(filepath.Base(args[0])) != "mactl-ssh" {
+		return args
+	}
+
+	if len(args) > 1 && strings.TrimSpace(args[1]) == "ssh" {
+		return args
+	}
+
+	normalized := make([]string, 0, len(args)+1)
+	normalized = append(normalized, args[0], "ssh")
+	normalized = append(normalized, args[1:]...)
+	return normalized
 }
 
 func init() {

--- a/cmd/mactl/cmd/root_invocation_test.go
+++ b/cmd/mactl/cmd/root_invocation_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeInvocationArgs(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "non mactl-ssh keeps args",
+			in:   []string{"mactl", "get", "servers"},
+			want: []string{"mactl", "get", "servers"},
+		},
+		{
+			name: "mactl-ssh inserts ssh subcommand",
+			in:   []string{"mactl-ssh", "ubuntu@web01", "--", "hostname"},
+			want: []string{"mactl-ssh", "ssh", "ubuntu@web01", "--", "hostname"},
+		},
+		{
+			name: "mactl-ssh without args still inserts ssh",
+			in:   []string{"mactl-ssh"},
+			want: []string{"mactl-ssh", "ssh"},
+		},
+		{
+			name: "mactl-ssh with explicit ssh does not duplicate",
+			in:   []string{"mactl-ssh", "ssh", "web01"},
+			want: []string{"mactl-ssh", "ssh", "web01"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeInvocationArgs(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("normalizeInvocationArgs() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/tools/build-deb.sh
+++ b/tools/build-deb.sh
@@ -74,6 +74,7 @@ echo "バイナリをコピー中..."
 install -m 0755 "${BINDIR}/marmotd" "${PKG_DIR}/usr/local/marmot/marmotd"
 install -m 0755 "${BINDIR}/marmot-lb-agent" "${PKG_DIR}/usr/local/marmot/marmot-lb-agent"
 install -m 0755 "${BINDIR}/mactl"   "${PKG_DIR}/usr/local/bin/mactl"
+ln -s mactl "${PKG_DIR}/usr/local/bin/mactl-ssh"
 install -m 0755 "${BINDIR}/maadm"   "${PKG_DIR}/usr/local/bin/maadm"
 install -m 0644 "${ROOT_DIR}/pkg/controller/gateway-playbooks/gateway-iptables.yaml.tmpl" \
     "${PKG_DIR}/usr/local/marmot/gateway-playbooks/gateway-iptables.yaml.tmpl"

--- a/tools/update_marmot.sh
+++ b/tools/update_marmot.sh
@@ -23,6 +23,7 @@ BINDIR=$(pwd)
 DISTDIR=/usr/local/marmot
 SERVER_EXE=marmotd
 CLIENT_CMD=mactl
+CLIENT_SSH_ALIAS=mactl-ssh
 CLIENT_CONFIG=config_marmot
 ADMIN_CMD=maadm
 
@@ -33,6 +34,8 @@ install -m 0644 ${BINDIR}/marmot.service /etc/systemd/system
 
 rm -f /usr/local/bin/${CLIENT_CMD}
 install -m 0755 ${BINDIR}/${CLIENT_CMD} /usr/local/bin
+rm -f /usr/local/bin/${CLIENT_SSH_ALIAS}
+ln -s /usr/local/bin/${CLIENT_CMD} /usr/local/bin/${CLIENT_SSH_ALIAS}
 
 rm -f /usr/local/bin/${ADMIN_CMD}
 install -m 0755 ${BINDIR}/${ADMIN_CMD} /usr/local/bin


### PR DESCRIPTION
## 概要
Issue #612 対応として、Ansible などから 1 コマンドで SSH 接続しやすくするため、mactl-ssh コマンドを追加しました。  
実装は新規バイナリではなく、mactl へのシンボリックリンク方式を採用しています。

## 背景
- mactl ssh は便利だが、外部ツールからは mactl のサブコマンド形式が扱いづらい
- FQDN 依存ではなく、marmot 管理名で接続したいユースケースがある
- 1 コマンド形式の mactl-ssh があると、Ansible 連携が簡潔になる

## 変更内容
- mactl-ssh で起動された場合に、内部的に mactl ssh と同等動作になるよう起動引数を正規化
- インストール時に /usr/local/bin/mactl-ssh -> /usr/local/bin/mactl のシンボリックリンクを作成
- 更新スクリプトでも同様にシンボリックリンクを作成
- deb パッケージ生成時に mactl-ssh シンボリックリンクを同梱
- 起動引数正規化のユニットテストを追加

## 期待される効果
- Ansible から mactl-ssh SERVER ... の 1 コマンドで利用可能
- 既存の mactl ssh 実装（名前解決・接続ロジック）をそのまま再利用でき、保守性を維持

## 互換性・影響範囲
- 既存の mactl コマンド利用方法に変更なし
- API 仕様変更なし
- 既存の mactl ssh の挙動変更なし（エントリーポイント追加のみ）

## 動作確認
- go test ./cmd/mactl/cmd
- go build ./cmd/mactl
- 主要シナリオ
  - mactl-ssh USER@SERVER -- <remote-command> が mactl ssh と同等に解釈される
  - mactl-ssh ssh ... と明示した場合に ssh が重複しない

## 関連 Issue
- Closes #612

