### PR TITLE
Ansible対応問題修正

### DIFF
--- a/cmd/mactl/cmd/server_ansible.go
+++ b/cmd/mactl/cmd/server_ansible.go
@@ -450,6 +450,7 @@ func serverAnsibleCommandEnv() []string {
 	return append(env,
 		"ANSIBLE_HOST_KEY_CHECKING=False",
 		"ANSIBLE_DEPRECATION_WARNINGS=False",
+		"ANSIBLE_REMOTE_TEMP=/tmp",
 		"ANSIBLE_SSH_ARGS=-o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes",
 	)
 }

--- a/cmd/mactl/cmd/server_ansible_test.go
+++ b/cmd/mactl/cmd/server_ansible_test.go
@@ -241,6 +241,9 @@ func TestServerAnsibleCommandEnvWithoutConfig(t *testing.T) {
 	if !containsPrefix(env, "ANSIBLE_HOST_KEY_CHECKING=False") {
 		t.Fatalf("serverAnsibleCommandEnv() should include ANSIBLE_HOST_KEY_CHECKING when ansible.cfg is absent")
 	}
+	if !containsPrefix(env, "ANSIBLE_REMOTE_TEMP=/tmp") {
+		t.Fatalf("serverAnsibleCommandEnv() should include ANSIBLE_REMOTE_TEMP=/tmp when ansible.cfg is absent")
+	}
 }
 
 func TestServerAnsibleCommandEnvWithConfig(t *testing.T) {
@@ -259,6 +262,9 @@ func TestServerAnsibleCommandEnvWithConfig(t *testing.T) {
 	env := serverAnsibleCommandEnv()
 	if containsPrefix(env, "ANSIBLE_HOST_KEY_CHECKING=False") {
 		t.Fatalf("serverAnsibleCommandEnv() must not inject ansible env vars when ansible.cfg exists")
+	}
+	if containsPrefix(env, "ANSIBLE_REMOTE_TEMP=/tmp") {
+		t.Fatalf("serverAnsibleCommandEnv() must not inject ANSIBLE_REMOTE_TEMP when ansible.cfg exists")
 	}
 }
 

--- a/cmd/mactl/cmd/ssh.go
+++ b/cmd/mactl/cmd/ssh.go
@@ -130,7 +130,94 @@ func rewriteSSHArgsForMarmot(servers []api.Server, sshArgs []string) ([]string, 
 	}
 
 	sshArgs[connectIdx] = buildSSHTargetAddress(sshUser, targetAddress)
-	return sshArgs, nil
+	return normalizeSSHArgsForExecution(sshArgs, connectIdx), nil
+}
+
+func normalizeSSHArgsForExecution(sshArgs []string, targetIdx int) []string {
+	separatorIdx := -1
+	for i, arg := range sshArgs {
+		if arg == "--" {
+			separatorIdx = i
+			break
+		}
+	}
+	if separatorIdx < 0 {
+		return sshArgs
+	}
+
+	normalized := make([]string, 0, len(sshArgs)-1)
+	normalized = append(normalized, sshArgs[:separatorIdx]...)
+	normalized = append(normalized, sshArgs[separatorIdx+1:]...)
+	if targetIdx > separatorIdx {
+		targetIdx--
+	}
+	if targetIdx < 0 || targetIdx >= len(normalized) {
+		return normalized
+	}
+
+	beforeTarget := append([]string{}, normalized[:targetIdx]...)
+	target := normalized[targetIdx]
+	optionTail, commandTail := splitSSHOptionPrefix(normalized[targetIdx+1:])
+
+	result := make([]string, 0, len(normalized)-1)
+	result = append(result, beforeTarget...)
+	result = append(result, optionTail...)
+	result = append(result, target)
+	result = append(result, commandTail...)
+	return result
+}
+
+func splitSSHOptionPrefix(args []string) ([]string, []string) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	consumesNext := map[string]bool{
+		"-b": true,
+		"-c": true,
+		"-D": true,
+		"-E": true,
+		"-F": true,
+		"-I": true,
+		"-i": true,
+		"-J": true,
+		"-L": true,
+		"-l": true,
+		"-m": true,
+		"-O": true,
+		"-o": true,
+		"-p": true,
+		"-Q": true,
+		"-R": true,
+		"-S": true,
+		"-W": true,
+		"-w": true,
+	}
+
+	optionArgs := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return optionArgs, append([]string{}, args[i+1:]...)
+		}
+		if !strings.HasPrefix(arg, "-") {
+			return optionArgs, append([]string{}, args[i:]...)
+		}
+
+		optionArgs = append(optionArgs, arg)
+		if len(arg) > 2 && (strings.HasPrefix(arg, "-o") || strings.HasPrefix(arg, "-i") || strings.HasPrefix(arg, "-l") || strings.HasPrefix(arg, "-p") || strings.HasPrefix(arg, "-J") || strings.HasPrefix(arg, "-W") || strings.HasPrefix(arg, "-L") || strings.HasPrefix(arg, "-R") || strings.HasPrefix(arg, "-S") || strings.HasPrefix(arg, "-b") || strings.HasPrefix(arg, "-c") || strings.HasPrefix(arg, "-D") || strings.HasPrefix(arg, "-E") || strings.HasPrefix(arg, "-F") || strings.HasPrefix(arg, "-I") || strings.HasPrefix(arg, "-m") || strings.HasPrefix(arg, "-Q") || strings.HasPrefix(arg, "-w")) {
+			continue
+		}
+		if consumesNext[arg] {
+			i++
+			if i >= len(args) {
+				return optionArgs, nil
+			}
+			optionArgs = append(optionArgs, args[i])
+		}
+	}
+
+	return optionArgs, nil
 }
 
 func parseSSHLoginTarget(value string) (string, string, error) {

--- a/cmd/mactl/cmd/ssh.go
+++ b/cmd/mactl/cmd/ssh.go
@@ -78,6 +78,30 @@ func findServerByName(servers []api.Server, name string) (*api.Server, error) {
 }
 
 func rewriteSSHArgsForMarmot(servers []api.Server, sshArgs []string) ([]string, error) {
+	// Backward-compatible support for mactl syntax:
+	//   mactl ssh SERVER -- [SSH-ARGS...]
+	// and for SERVER followed by ssh options without `--`.
+	if len(sshArgs) >= 2 && !strings.HasPrefix(sshArgs[0], "-") && (sshArgs[1] == "--" || strings.HasPrefix(sshArgs[1], "-")) {
+		target := sshArgs[0]
+		extra := sshArgs[1:]
+		if extra[0] == "--" {
+			extra = extra[1:]
+		}
+
+		sep := -1
+		for i, arg := range extra {
+			if arg == "--" {
+				sep = i
+				break
+			}
+		}
+		if sep >= 0 {
+			sshArgs = append(append(extra[:sep], target), extra[sep+1:]...)
+		} else {
+			sshArgs = append(extra, target)
+		}
+	}
+
 	connectIdx, err := findSSHConnectTargetIndex(sshArgs)
 	if err != nil {
 		return nil, err
@@ -87,7 +111,6 @@ func rewriteSSHArgsForMarmot(servers []api.Server, sshArgs []string) ([]string, 
 	if connectArg == "" {
 		return nil, fmt.Errorf("ssh target is required")
 	}
-
 	sshUser, serverName, err := parseSSHLoginTarget(connectArg)
 	if err != nil {
 		if strings.HasPrefix(connectArg, "-") {

--- a/cmd/mactl/cmd/ssh.go
+++ b/cmd/mactl/cmd/ssh.go
@@ -16,6 +16,8 @@ var sshExecCommand = exec.Command
 var sshCmd = &cobra.Command{
 	Use:   "ssh [USER@]SERVER-NAME -- [SSH-ARGS...]",
 	Short: "Connect to a server via SSH using host-bridge IP",
+	// Treat all ssh-style flags as positional args so options like -tt pass through unchanged.
+	DisableFlagParsing: true,
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
@@ -25,9 +27,12 @@ var sshCmd = &cobra.Command{
 			return fmt.Errorf("failed to get API client config: %w", err)
 		}
 
-		sshUser, serverName, err := parseSSHLoginTarget(args[0])
-		if err != nil {
-			return err
+		sshArgs := args
+		if len(sshArgs) > 0 && strings.TrimSpace(sshArgs[0]) == "ssh" {
+			sshArgs = sshArgs[1:]
+		}
+		if len(sshArgs) == 0 {
+			return fmt.Errorf("ssh target is required")
 		}
 
 		list, _, err := m.GetServers()
@@ -40,18 +45,11 @@ var sshCmd = &cobra.Command{
 			return fmt.Errorf("failed to parse servers: %w", err)
 		}
 
-		server, err := findServerByName(servers, serverName)
+		sshArgs, err = rewriteSSHArgsForMarmot(servers, sshArgs)
 		if err != nil {
 			return err
 		}
 
-		targetAddress, err := resolveHostBridgeAddress(*server)
-		if err != nil {
-			return fmt.Errorf("server %q %w", serverName, err)
-		}
-		sshTarget := buildSSHTargetAddress(sshUser, targetAddress)
-
-		sshArgs := composeSSHArgs(sshTarget, args[1:])
 		sshCommand := sshExecCommand("ssh", sshArgs...)
 		sshCommand.Stdin = os.Stdin
 		sshCommand.Stdout = os.Stdout
@@ -62,6 +60,54 @@ var sshCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+func findServerByName(servers []api.Server, name string) (*api.Server, error) {
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return nil, fmt.Errorf("server name is required")
+	}
+
+	for i := range servers {
+		if strings.TrimSpace(servers[i].Metadata.Name) == trimmedName {
+			return &servers[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("server %q not found", trimmedName)
+}
+
+func rewriteSSHArgsForMarmot(servers []api.Server, sshArgs []string) ([]string, error) {
+	connectIdx, err := findSSHConnectTargetIndex(sshArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	connectArg := strings.TrimSpace(sshArgs[connectIdx])
+	if connectArg == "" {
+		return nil, fmt.Errorf("ssh target is required")
+	}
+
+	sshUser, serverName, err := parseSSHLoginTarget(connectArg)
+	if err != nil {
+		if strings.HasPrefix(connectArg, "-") {
+			return nil, fmt.Errorf("ssh target is required")
+		}
+		return nil, err
+	}
+
+	server, err := findServerByName(servers, serverName)
+	if err != nil {
+		return nil, err
+	}
+
+	targetAddress, err := resolveHostBridgeAddress(*server)
+	if err != nil {
+		return nil, fmt.Errorf("server %q %w", serverName, err)
+	}
+
+	sshArgs[connectIdx] = buildSSHTargetAddress(sshUser, targetAddress)
+	return sshArgs, nil
 }
 
 func parseSSHLoginTarget(value string) (string, string, error) {
@@ -89,21 +135,6 @@ func buildSSHTargetAddress(user, ipAddress string) string {
 	return strings.TrimSpace(user) + "@" + strings.TrimSpace(ipAddress)
 }
 
-func findServerByName(servers []api.Server, name string) (*api.Server, error) {
-	trimmedName := strings.TrimSpace(name)
-	if trimmedName == "" {
-		return nil, fmt.Errorf("server name is required")
-	}
-
-	for i := range servers {
-		if strings.TrimSpace(servers[i].Metadata.Name) == trimmedName {
-			return &servers[i], nil
-		}
-	}
-
-	return nil, fmt.Errorf("server %q not found", trimmedName)
-}
-
 func resolveHostBridgeAddress(server api.Server) (string, error) {
 	if server.Spec.NetworkInterface == nil || len(*server.Spec.NetworkInterface) == 0 {
 		return "", fmt.Errorf("is not connected to host-bridge")
@@ -122,26 +153,60 @@ func resolveHostBridgeAddress(server api.Server) (string, error) {
 	return "", fmt.Errorf("is not connected to host-bridge")
 }
 
-func composeSSHArgs(targetAddress string, extraArgs []string) []string {
-	args := make([]string, 0, len(extraArgs)+1)
-	separator := -1
-	for i, arg := range extraArgs {
+func findSSHConnectTargetIndex(args []string) (int, error) {
+	if len(args) == 0 {
+		return -1, fmt.Errorf("ssh target is required")
+	}
+
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		return 0, nil
+	}
+
+	consumesNext := map[string]bool{
+		"-b": true,
+		"-c": true,
+		"-D": true,
+		"-E": true,
+		"-F": true,
+		"-I": true,
+		"-i": true,
+		"-J": true,
+		"-L": true,
+		"-l": true,
+		"-m": true,
+		"-O": true,
+		"-o": true,
+		"-p": true,
+		"-Q": true,
+		"-R": true,
+		"-S": true,
+		"-W": true,
+		"-w": true,
+	}
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
 		if arg == "--" {
-			separator = i
-			break
+			if i+1 >= len(args) {
+				return -1, fmt.Errorf("ssh target is required")
+			}
+			return i + 1, nil
+		}
+		if !strings.HasPrefix(arg, "-") {
+			return i, nil
+		}
+		if len(arg) > 2 && (strings.HasPrefix(arg, "-o") || strings.HasPrefix(arg, "-i") || strings.HasPrefix(arg, "-l") || strings.HasPrefix(arg, "-p") || strings.HasPrefix(arg, "-J") || strings.HasPrefix(arg, "-W") || strings.HasPrefix(arg, "-L") || strings.HasPrefix(arg, "-R") || strings.HasPrefix(arg, "-S") || strings.HasPrefix(arg, "-b") || strings.HasPrefix(arg, "-c") || strings.HasPrefix(arg, "-D") || strings.HasPrefix(arg, "-E") || strings.HasPrefix(arg, "-F") || strings.HasPrefix(arg, "-I") || strings.HasPrefix(arg, "-m") || strings.HasPrefix(arg, "-Q") || strings.HasPrefix(arg, "-w")) {
+			continue
+		}
+		if consumesNext[arg] {
+			i++
+			if i >= len(args) {
+				return -1, fmt.Errorf("ssh target is required")
+			}
 		}
 	}
 
-	if separator >= 0 {
-		args = append(args, extraArgs[:separator]...)
-		args = append(args, targetAddress)
-		args = append(args, extraArgs[separator+1:]...)
-		return args
-	}
-
-	args = append(args, extraArgs...)
-	args = append(args, targetAddress)
-	return args
+	return -1, fmt.Errorf("ssh target is required")
 }
 
 func init() {

--- a/cmd/mactl/cmd/ssh_test.go
+++ b/cmd/mactl/cmd/ssh_test.go
@@ -96,20 +96,73 @@ var _ = Describe("ssh helper functions", func() {
 		})
 	})
 
-	Describe("composeSSHArgs", func() {
-		It("appends target when no extra args", func() {
-			args := composeSSHArgs("192.168.10.50", nil)
-			Expect(args).To(Equal([]string{"192.168.10.50"}))
+	Describe("findSSHConnectTargetIndex", func() {
+		It("finds the first positional host after ssh options", func() {
+			idx, err := findSSHConnectTargetIndex([]string{"-i", "~/.ssh/id_ed25519", "-o", "StrictHostKeyChecking=no", "server-20", "hostname"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(idx).To(Equal(4))
 		})
 
-		It("places target after options", func() {
-			args := composeSSHArgs("192.168.10.50", []string{"-i", "~/.ssh/id_ed25519", "-o", "StrictHostKeyChecking=no"})
-			Expect(args).To(Equal([]string{"-i", "~/.ssh/id_ed25519", "-o", "StrictHostKeyChecking=no", "192.168.10.50"}))
+		It("accepts repeated tty shorthand option -tt", func() {
+			idx, err := findSSHConnectTargetIndex([]string{"-tt", "server-20", "hostname"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(idx).To(Equal(1))
 		})
 
-		It("supports remote command with -- separator", func() {
-			args := composeSSHArgs("192.168.10.50", []string{"-i", "~/.ssh/id_ed25519", "--", "uname", "-a"})
-			Expect(args).To(Equal([]string{"-i", "~/.ssh/id_ed25519", "192.168.10.50", "uname", "-a"}))
+		It("finds host after -l user option", func() {
+			idx, err := findSSHConnectTargetIndex([]string{"-l", "ubuntu", "server-20", "hostname"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(idx).To(Equal(2))
+		})
+	})
+
+	Describe("rewriteSSHArgsForMarmot", func() {
+		It("rewrites direct server target to host-bridge IP", func() {
+			servers := []api.Server{{
+				Metadata: api.Metadata{Name: "server-20"},
+				Spec: api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{{
+					Networkname: "host-bridge",
+					Address:     util.StringPtr("192.168.10.50"),
+				}}},
+			}}
+
+			args, err := rewriteSSHArgsForMarmot(servers, []string{"server-20", "hostname"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(args).To(Equal([]string{"192.168.10.50", "hostname"}))
+		})
+
+		It("rewrites ssh-style args while preserving options", func() {
+			servers := []api.Server{{
+				Metadata: api.Metadata{Name: "server-20"},
+				Spec: api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{{
+					Networkname: "host-bridge",
+					Address:     util.StringPtr("192.168.10.50"),
+				}}},
+			}}
+
+			args, err := rewriteSSHArgsForMarmot(servers, []string{"-i", "~/.ssh/id_ed25519", "-o", "StrictHostKeyChecking=no", "server-20", "hostname"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(args).To(Equal([]string{"-i", "~/.ssh/id_ed25519", "-o", "StrictHostKeyChecking=no", "192.168.10.50", "hostname"}))
+		})
+
+		It("keeps -tt and rewrites only destination", func() {
+			servers := []api.Server{{
+				Metadata: api.Metadata{Name: "server-20"},
+				Spec: api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{{
+					Networkname: "host-bridge",
+					Address:     util.StringPtr("192.168.10.50"),
+				}}},
+			}}
+
+			args, err := rewriteSSHArgsForMarmot(servers, []string{"-tt", "server-20", "hostname"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(args).To(Equal([]string{"-tt", "192.168.10.50", "hostname"}))
+		})
+	})
+
+	Describe("ssh command configuration", func() {
+		It("disables cobra flag parsing for ssh passthrough", func() {
+			Expect(sshCmd.DisableFlagParsing).To(BeTrue())
 		})
 	})
 })

--- a/cmd/mactl/cmd/ssh_test.go
+++ b/cmd/mactl/cmd/ssh_test.go
@@ -158,6 +158,20 @@ var _ = Describe("ssh helper functions", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(args).To(Equal([]string{"-tt", "192.168.10.50", "hostname"}))
 		})
+
+		It("moves ssh options before the destination when -- is used", func() {
+			servers := []api.Server{{
+				Metadata: api.Metadata{Name: "server-20"},
+				Spec: api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{{
+					Networkname: "host-bridge",
+					Address:     util.StringPtr("192.168.10.50"),
+				}}},
+			}}
+
+			args, err := rewriteSSHArgsForMarmot(servers, []string{"server-20", "--", "-i", "vmkey"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(args).To(Equal([]string{"-i", "vmkey", "192.168.10.50"}))
+		})
 	})
 
 	Describe("ssh command configuration", func() {

--- a/cmd/mactl/cmd/ssh_test.go
+++ b/cmd/mactl/cmd/ssh_test.go
@@ -172,6 +172,20 @@ var _ = Describe("ssh helper functions", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(args).To(Equal([]string{"-i", "vmkey", "192.168.10.50"}))
 		})
+
+		It("keeps the README example compatible when a user is specified", func() {
+			servers := []api.Server{{
+				Metadata: api.Metadata{Name: "server-20"},
+				Spec: api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{{
+					Networkname: "host-bridge",
+					Address:     util.StringPtr("192.168.10.50"),
+				}}},
+			}}
+
+			args, err := rewriteSSHArgsForMarmot(servers, []string{"ubuntu@server-20", "--", "-i", "vmkey"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(args).To(Equal([]string{"-i", "vmkey", "ubuntu@192.168.10.50"}))
+		})
 	})
 
 	Describe("ssh command configuration", func() {


### PR DESCRIPTION
## 概要
Ansible 実行時に発生していた接続・モジュール実行まわりの不具合を修正しました。  
主に、mactl-ssh を Ansible の ansible_ssh_executable として使った際の SSH オプション互換性と、リモート一時ディレクトリ作成失敗への対処を行っています。

## 背景
以下の問題が発生していました。

- Ansible から mactl-ssh を呼ぶと、-tt などの SSH オプションを mactl 側がフラグとして解釈して失敗する
- Gathering Facts でリモート一時ディレクトリ作成に失敗するケースがある

## 変更内容

### 1. mactl-ssh の SSH drop-in 互換性を改善
対象: ssh.go

- ssh サブコマンドで Cobra のフラグ解析を無効化し、SSH オプションをそのまま透過
- SSH 引数列から接続先トークンを検出し、Marmot のサーバー名を host-bridge の IP に置換
- オプション（例: -i, -o, -l, -tt）やリモートコマンドを保持したまま接続先のみを書き換えるよう修正

### 2. Ansible 実行時の remote temp を明示
対象: server_ansible.go

- ansible.cfg が存在しない場合に環境変数 ANSIBLE_REMOTE_TEMP=/tmp を追加
- 既存の ANSIBLE_HOST_KEY_CHECKING, ANSIBLE_DEPRECATION_WARNINGS, ANSIBLE_SSH_ARGS 注入方針は維持

### 3. テスト追加・更新
対象:
- ssh_test.go
- server_ansible_test.go

追加・更新内容:

- -tt を含む SSH 引数で接続先検出できること
- -tt を保持したまま接続先のみ IP へ置換されること
- ssh サブコマンドで DisableFlagParsing が有効であること
- ansible.cfg 有無による ANSIBLE_REMOTE_TEMP 注入有無の検証

## 影響範囲
- mactl の ssh サブコマンド動作
- mactl create 時のローカル Ansible 実行環境変数（ansible.cfg 未配置時のみ）

API 仕様や cloud-init 生成ロジックには今回変更を入れていません。

## 動作確認

- go test ./cmd/mactl/cmd -run 'ssh|NormalizeInvocationArgs|TestServerAnsibleCommandEnv' -count=1
- go build ./cmd/mactl

いずれも成功。

## 期待される効果
- ansible_ssh_executable に mactl-ssh を指定した場合でも、-tt などの SSH オプションで失敗しない
- Gathering Facts 時の remote temp 作成失敗を回避しやすくなる
