### PR TITLE
サーバーに未接続時クライアントのバージョンのみ表示

### DIFF
--- a/cmd/mactl/cmd/version.go
+++ b/cmd/mactl/cmd/version.go
@@ -27,22 +27,23 @@ var versionCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		cv := strings.TrimSpace(version)
+		ver := api.Version{ClientVersion: cv}
+
 		JsonVersion, err := m.GetVersion()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to get server version: %v\n", err)
-			return err
-		}
-		sv := strings.TrimSpace(string(*JsonVersion.ServerVersion))
-		cv := strings.TrimSpace(version)
-		ver := api.Version{
-			ClientVersion: cv,
-			ServerVersion: &sv,
+		} else if JsonVersion != nil && JsonVersion.ServerVersion != nil {
+			sv := strings.TrimSpace(*JsonVersion.ServerVersion)
+			ver.ServerVersion = &sv
 		}
 
 		switch outputStyle {
 		case "text":
-			fmt.Println("Getting server Information...")
-			fmt.Println("Server version =", sv)
+			if ver.ServerVersion != nil {
+				fmt.Println("Getting server Information...")
+				fmt.Println("Server version =", *ver.ServerVersion)
+			}
 			fmt.Println("Client version =", cv)
 			return nil
 		case "json":

--- a/cmd/mactl/cmd/version_test.go
+++ b/cmd/mactl/cmd/version_test.go
@@ -13,7 +13,11 @@ func TestVersionPrintsClientVersionWhenServerUnreachable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateTemp() failed: %v", err)
 	}
-	defer os.Remove(tmp.Name())
+	defer func() {
+		if err := os.Remove(tmp.Name()); err != nil && !os.IsNotExist(err) {
+			t.Errorf("Remove() failed: %v", err)
+		}
+	}()
 
 	if _, err := tmp.WriteString("current: 0\nendpoints:\n  - http://127.0.0.1:1\n"); err != nil {
 		t.Fatalf("WriteString() failed: %v", err)

--- a/cmd/mactl/cmd/version_test.go
+++ b/cmd/mactl/cmd/version_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestVersionPrintsClientVersionWhenServerUnreachable(t *testing.T) {
+	tmp, err := os.CreateTemp("", "mactl-version-config-*.yaml")
+	if err != nil {
+		t.Fatalf("CreateTemp() failed: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.WriteString("current: 0\nendpoints:\n  - http://127.0.0.1:1\n"); err != nil {
+		t.Fatalf("WriteString() failed: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+
+	oldAPI := apiConfigFilename
+	oldOutput := outputStyle
+	apiConfigFilename = tmp.Name()
+	outputStyle = "text"
+	defer func() {
+		apiConfigFilename = oldAPI
+		outputStyle = oldOutput
+	}()
+
+	out, stderr, runErr := captureStdoutAndStderr(func() error {
+		return versionCmd.RunE(versionCmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("versionCmd.RunE() returned error: %v", runErr)
+	}
+
+	if !strings.Contains(out, "Client version =") {
+		t.Fatalf("stdout does not contain client version. stdout=%q", out)
+	}
+	if !strings.Contains(stderr, "failed to get server version:") {
+		t.Fatalf("stderr does not contain server failure message. stderr=%q", stderr)
+	}
+}
+
+func captureStdoutAndStderr(fn func() error) (stdout string, stderr string, runErr error) {
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		return "", "", err
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		_ = stdoutR.Close()
+		_ = stdoutW.Close()
+		return "", "", err
+	}
+
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+
+	runErr = fn()
+
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	var outBuf bytes.Buffer
+	_, _ = io.Copy(&outBuf, stdoutR)
+	_ = stdoutR.Close()
+
+	var errBuf bytes.Buffer
+	_, _ = io.Copy(&errBuf, stderrR)
+	_ = stderrR.Close()
+
+	return outBuf.String(), errBuf.String(), runErr
+}


### PR DESCRIPTION
Issue #601 の対応として、mactl version 実行時にサーバーへ接続できない場合でも、クライアントバージョンを表示できるように修正しました。  
これまでのようにサーバー疎通失敗でコマンド全体がエラー終了するのではなく、サーバー版取得失敗を標準エラーに通知しつつ、クライアント版表示は継続します。

変更内容
- version.go
  - クライアント版の組み立てを先に実施
  - サーバー版取得失敗時に即 return しないよう変更
  - サーバー版が取得できた場合のみ Server version 行を表示
- version_test.go
  - 新規テスト追加
  - 接続不能エンドポイント設定時に:
    - コマンドがエラー終了しないこと
    - Client version が標準出力に出ること
    - failed to get server version が標準エラーに出ること
    を検証

期待される挙動
- サーバー接続成功時:
  - Server version と Client version を表示
- サーバー接続失敗時:
  - 警告を標準エラーに表示
  - Client version は表示

テスト
- go test ./cmd/mactl/cmd -run TestVersionPrintsClientVersionWhenServerUnreachable
- go test ./cmd/mactl/cmd/...

影響範囲
- mactl version コマンドのエラーハンドリングと表示ロジックのみ
- 他コマンド・API 仕様への影響なし

関連
- Issue: #601

