### PR TITLE
mactl status のボリューム集計のバグ修正

### DIFF
--- a/pkg/marmotd/host.go
+++ b/pkg/marmotd/host.go
@@ -114,6 +114,7 @@ func (m *Marmot) CollectHostStatus() (api.HostStatus, error) {
 		return status, err
 	}
 	status.Capacity = capacity
+	applyHostVolumeCapacity(capacity, nodeName, m)
 
 	// 割当情報を収集
 	allocation, err := m.collectHostAllocation()
@@ -124,6 +125,44 @@ func (m *Marmot) CollectHostStatus() (api.HostStatus, error) {
 	status.Allocation = allocation
 
 	return status, nil
+}
+
+func applyHostVolumeCapacity(capacity *api.HostCapacity, nodeName string, m *Marmot) {
+	if capacity == nil || m == nil || m.Db == nil {
+		return
+	}
+
+	volumes, err := m.Db.GetVolumes()
+	if err != nil {
+		slog.Warn("GetVolumes() failed while collecting host volume capacity", "err", err, "nodeName", nodeName)
+		return
+	}
+
+	diskCount, diskCapacityGB := aggregateHostVolumeCapacityByNode(volumes, nodeName)
+	capacity.DiskCount = util.IntPtrInt(diskCount)
+	capacity.DiskCapacityGB = util.IntPtrInt(diskCapacityGB)
+}
+
+func aggregateHostVolumeCapacityByNode(volumes []api.Volume, nodeName string) (int, int) {
+	targetNode := strings.TrimSpace(nodeName)
+	if targetNode == "" {
+		return 0, 0
+	}
+
+	diskCount := 0
+	diskCapacityGB := 0
+	for _, vol := range volumes {
+		if vol.Metadata.NodeName == nil || strings.TrimSpace(*vol.Metadata.NodeName) != targetNode {
+			continue
+		}
+
+		diskCount++
+		if vol.Spec.Size != nil && *vol.Spec.Size > 0 {
+			diskCapacityGB += *vol.Spec.Size
+		}
+	}
+
+	return diskCount, diskCapacityGB
 }
 
 // 指定インターフェースのIPv4アドレスを取得する。

--- a/pkg/marmotd/host.go
+++ b/pkg/marmotd/host.go
@@ -134,7 +134,6 @@ func applyHostVolumeCapacity(capacity *api.HostCapacity, nodeName string, m *Mar
 
 	volumes, err := m.Db.GetVolumes()
 	if err != nil {
-		slog.Warn("GetVolumes() failed while collecting host volume capacity", "err", err, "nodeName", nodeName)
 		return
 	}
 

--- a/pkg/marmotd/host.go
+++ b/pkg/marmotd/host.go
@@ -134,6 +134,7 @@ func applyHostVolumeCapacity(capacity *api.HostCapacity, nodeName string, m *Mar
 
 	volumes, err := m.Db.GetVolumes()
 	if err != nil {
+		slog.Warn("GetVolumes() failed while collecting host volume capacity", "err", err, "nodeName", nodeName)
 		return
 	}
 

--- a/pkg/marmotd/host_volume_aggregate_test.go
+++ b/pkg/marmotd/host_volume_aggregate_test.go
@@ -1,0 +1,57 @@
+package marmotd
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestAggregateHostVolumeCapacityByNode(t *testing.T) {
+	volumes := []api.Volume{
+		{Metadata: api.Metadata{NodeName: util.StringPtr("hv1")}, Spec: api.VolSpec{Type: util.StringPtr("qcow2"), Size: util.IntPtrInt(16)}},
+		{Metadata: api.Metadata{NodeName: util.StringPtr("hv1")}, Spec: api.VolSpec{Type: util.StringPtr("ceph"), Size: util.IntPtrInt(10)}},
+		{Metadata: api.Metadata{NodeName: util.StringPtr("hv1")}, Spec: api.VolSpec{Type: util.StringPtr("lvm"), Size: nil}},
+		{Metadata: api.Metadata{NodeName: util.StringPtr("hv1")}, Spec: api.VolSpec{Type: util.StringPtr("lvm"), Size: util.IntPtrInt(0)}},
+		{Metadata: api.Metadata{NodeName: util.StringPtr("hv1")}, Spec: api.VolSpec{Type: util.StringPtr("ceph"), Size: util.IntPtrInt(-2)}},
+		{Metadata: api.Metadata{NodeName: util.StringPtr("hv2")}, Spec: api.VolSpec{Type: util.StringPtr("qcow2"), Size: util.IntPtrInt(99)}},
+		{Metadata: api.Metadata{NodeName: nil}, Spec: api.VolSpec{Type: util.StringPtr("ceph"), Size: util.IntPtrInt(50)}},
+	}
+
+	diskCount, diskCapacityGB := aggregateHostVolumeCapacityByNode(volumes, "hv1")
+	if diskCount != 5 {
+		t.Fatalf("diskCount=%d, want 5", diskCount)
+	}
+	if diskCapacityGB != 26 {
+		t.Fatalf("diskCapacityGB=%d, want 26", diskCapacityGB)
+	}
+}
+
+func TestAggregateHostVolumeCapacityByNodeTrimmedNodeName(t *testing.T) {
+	volumes := []api.Volume{
+		{Metadata: api.Metadata{NodeName: util.StringPtr(" hv1 ")}, Spec: api.VolSpec{Size: util.IntPtrInt(8)}},
+		{Metadata: api.Metadata{NodeName: util.StringPtr("hv1")}, Spec: api.VolSpec{Size: util.IntPtrInt(4)}},
+	}
+
+	diskCount, diskCapacityGB := aggregateHostVolumeCapacityByNode(volumes, "  hv1")
+	if diskCount != 2 {
+		t.Fatalf("diskCount=%d, want 2", diskCount)
+	}
+	if diskCapacityGB != 12 {
+		t.Fatalf("diskCapacityGB=%d, want 12", diskCapacityGB)
+	}
+}
+
+func TestAggregateHostVolumeCapacityByNodeEmptyNodeName(t *testing.T) {
+	volumes := []api.Volume{
+		{Metadata: api.Metadata{NodeName: util.StringPtr("hv1")}, Spec: api.VolSpec{Size: util.IntPtrInt(10)}},
+	}
+
+	diskCount, diskCapacityGB := aggregateHostVolumeCapacityByNode(volumes, "   ")
+	if diskCount != 0 {
+		t.Fatalf("diskCount=%d, want 0", diskCount)
+	}
+	if diskCapacityGB != 0 {
+		t.Fatalf("diskCapacityGB=%d, want 0", diskCapacityGB)
+	}
+}


### PR DESCRIPTION
## 概要
mactl status で表示されるディスク本数・ディスク容量が実際の Volume オブジェクトと一致しない問題を修正しました。  
集計処理を HostStatus 収集経路に追加し、ノード単位で正しい値を返すようにしています。

Closes #626

## 背景
現状の mactl status は host capacity の diskCount / diskCapacityGB を表示しますが、これらが未設定のため 0 表示になるケースがありました。  
本修正では、HostStatus 収集時に Volume 一覧を集計して値を設定します。

## 変更内容
- HostStatus 収集時に Volume 集計を実施
- 対象ノードに割り当てられた Volume をカウント
- 容量は spec.size の正の値のみ合計
- DB 取得エラー時は HostStatus 更新処理を継続（警告ログのみ）

変更ファイル:
- host.go
- host_volume_aggregate_test.go

## 集計ルール
- 集計対象: metadata.nodeName が現在ノードと一致する Volume
- 件数: 対象 Volume の件数
- 容量: spec.size > 0 のみ合計
- 種別: qcow2 / lvm / ceph を区別せず集計対象に含める

## 非対象
- API スキーマ変更
- mactl の表示フォーマット変更
- Volume コントローラー側の責務変更

## テスト
実施済み:
- go test ./pkg/marmotd -run TestAggregateHostVolumeCapacityByNode -count=1
- go test ./pkg/marmotd -run TestHostIDInternal -count=1
- go test ./pkg/marmotd -run ^$

## 確認観点（実環境）
- mactl get vol -a の件数と mactl status のディスク本数が一致すること
- mactl get vol -a の SIZE 合計と mactl status のディスク容量が一致すること