### PR TITLE
MKE実装の準備 P0

### DIFF
--- a/cmd/marmotd/mke.json
+++ b/cmd/marmotd/mke.json
@@ -1,0 +1,8 @@
+{
+    "kubernetes_version": "v1.36.2",
+    "containerd_version": "2.3.1",
+    "etcd_version": "3.6.8",
+    "cni_version": "0.4.0",
+    "default_cni_type": "bridge",
+    "runc_version": "1.4.0"
+}

--- a/cmd/marmotd/testdata/mke.json
+++ b/cmd/marmotd/testdata/mke.json
@@ -1,0 +1,8 @@
+{
+    "kubernetes_version": "v1.36.2",
+    "containerd_version": "2.3.1",
+    "etcd_version": "3.6.8",
+    "cni_version": "0.4.0",
+    "default_cni_type": "bridge",
+    "runc_version": "1.4.0"
+}

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -1,0 +1,84 @@
+package controller
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/takara9/marmot/pkg/marmotd"
+)
+
+const (
+	KUBERNETES_ENGINE_CONTROLLER_INTERVAL = 10 * time.Second
+)
+
+// kubernetesEngineController は MKS (Marmot Kubernetes Engine) コントローラーの雛形です。
+// mke.json の読み込みと定期ループの骨組みのみを提供し、
+// KubernetesEngine リソースのetcd監視・クラスタのライフサイクル管理は今後実装します。
+type kubernetesEngineController struct {
+	node     string
+	mkeConf  *marmotd.MKEConfig
+	stopChan chan struct{}
+	doneChan chan struct{}
+	stopOnce sync.Once
+}
+
+// KubernetesEngineコントローラーの開始
+// mkeConfigPath に空文字を渡した場合は既定パス(marmotd.DefaultMKEConfigPath)を使用します。
+func StartKubernetesEngineController(node string, etcdUrl string, mkeConfigPath string) (*kubernetesEngineController, error) {
+	var c kubernetesEngineController
+	c.node = node
+
+	if mkeConfigPath == "" {
+		mkeConfigPath = marmotd.DefaultMKEConfigPath
+	}
+
+	cfg, err := marmotd.LoadMKEConfig(mkeConfigPath)
+	if err != nil {
+		slog.Error("Failed to load MKE config", "path", mkeConfigPath, "err", err)
+		return nil, err
+	}
+	c.mkeConf = cfg
+	slog.Info("MKE設定を読み込みました", "path", mkeConfigPath, "kubernetesVersion", cfg.KubernetesVersion)
+
+	c.stopChan = make(chan struct{})
+	c.doneChan = make(chan struct{})
+
+	// 定期実行の開始（10秒間隔）
+	ticker := time.NewTicker(KUBERNETES_ENGINE_CONTROLLER_INTERVAL)
+	go func() {
+		defer ticker.Stop()
+		defer close(c.doneChan)
+		for {
+			select {
+			case <-ticker.C:
+				c.kubernetesEngineControllerLoop()
+			case <-c.stopChan:
+				slog.Debug("KubernetesEngineコントローラー停止")
+				return
+			}
+		}
+	}()
+	return &c, nil
+}
+
+// KubernetesEngineコントローラーの停止
+func (c *kubernetesEngineController) Stop() {
+	if c == nil {
+		return
+	}
+	c.stopOnce.Do(func() {
+		if c.stopChan != nil {
+			close(c.stopChan)
+		}
+	})
+	if c.doneChan != nil {
+		<-c.doneChan
+	}
+}
+
+// KubernetesEngineコントローラーの制御ループ（雛形）
+// TODO: /marmot 配下のKubernetesEngineオブジェクト監視、クラスタのライフサイクル管理を実装する
+func (c *kubernetesEngineController) kubernetesEngineControllerLoop() {
+	slog.Debug("KubernetesEngineコントローラーの制御ループ実行", "CONTROLLER", time.Now().Format("2006-01-02 15:04:05"))
+}

--- a/pkg/marmotd/mke-config.go
+++ b/pkg/marmotd/mke-config.go
@@ -1,0 +1,76 @@
+package marmotd
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// DefaultMKEConfigPath は MKS (Marmot Kubernetes Engine) の既定設定ファイルパスです。
+const DefaultMKEConfigPath = "/etc/marmot/mke.json"
+
+// MKEConfig は /etc/marmot/mke.json で設定可能な MKS (Marmot Kubernetes Engine) の
+// 初期設定情報を保持します。KubernetesEngineコントローラーが、クラスタ構築時の
+// デフォルトバージョン等として参照します。
+type MKEConfig struct {
+	// デプロイする Kubernetes のバージョン
+	// 例: "v1.36.2"
+	KubernetesVersion string `json:"kubernetes_version"`
+
+	// containerd のバージョン
+	// 例: "2.3.1"
+	ContainerdVersion string `json:"containerd_version"`
+
+	// クラスタ専用 etcd のバージョン
+	// 例: "3.6.8"
+	EtcdVersion string `json:"etcd_version"`
+
+	// CNI プラグインのバージョン
+	// 例: "0.4.0"
+	CNIVersion string `json:"cni_version"`
+
+	// 既定で使用する CNI の種類
+	// 例: "bridge"
+	DefaultCNIType string `json:"default_cni_type"`
+
+	// runc のバージョン
+	// 例: "1.4.0"
+	RuncVersion string `json:"runc_version"`
+}
+
+// defaultMKEConfig はコンフィグファイルが存在しない場合や、一部フィールドが
+// 指定されていない場合に使用されるデフォルト値を返します。
+func defaultMKEConfig() *MKEConfig {
+	return &MKEConfig{
+		KubernetesVersion: "v1.36.2",
+		ContainerdVersion: "2.3.1",
+		EtcdVersion:       "3.6.8",
+		CNIVersion:        "0.4.0",
+		DefaultCNIType:    "bridge",
+		RuncVersion:       "1.4.0",
+	}
+}
+
+// LoadMKEConfig は path で指定された JSON ファイルを読み込み MKEConfig を返します。
+// ファイルが存在しない場合はデフォルト値を持つ設定を返します。
+// ファイルが存在するが一部フィールドが省略されている場合は、デフォルト値で補完されます。
+func LoadMKEConfig(path string) (*MKEConfig, error) {
+	cfg := defaultMKEConfig()
+
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return cfg, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	dec := json.NewDecoder(f)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/pkg/marmotd/mke-config_test.go
+++ b/pkg/marmotd/mke-config_test.go
@@ -1,0 +1,47 @@
+package marmotd_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/takara9/marmot/pkg/marmotd"
+)
+
+var _ = Describe("MKEConfig", func() {
+	Describe("LoadMKEConfig", func() {
+		It("cmd/marmotd/testdata/mke.json を読み込む", func() {
+			cfg, err := marmotd.LoadMKEConfig("../../cmd/marmotd/testdata/mke.json")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.KubernetesVersion).To(Equal("v1.36.2"))
+			Expect(cfg.ContainerdVersion).To(Equal("2.3.1"))
+			Expect(cfg.EtcdVersion).To(Equal("3.6.8"))
+			Expect(cfg.CNIVersion).To(Equal("0.4.0"))
+			Expect(cfg.DefaultCNIType).To(Equal("bridge"))
+			Expect(cfg.RuncVersion).To(Equal("1.4.0"))
+		})
+
+		It("ファイルが存在しない場合はデフォルト値を返す", func() {
+			cfg, err := marmotd.LoadMKEConfig("/path/does/not/exist/mke.json")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.KubernetesVersion).To(Equal("v1.36.2"))
+			Expect(cfg.DefaultCNIType).To(Equal("bridge"))
+		})
+
+		It("一部フィールドのみ指定された場合はデフォルト値で補完する", func() {
+			dir := GinkgoT().TempDir()
+			path := filepath.Join(dir, "mke.json")
+			content := []byte(`{"kubernetes_version":"v1.99.0"}`)
+
+			err := os.WriteFile(path, content, 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, err := marmotd.LoadMKEConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.KubernetesVersion).To(Equal("v1.99.0"))
+			Expect(cfg.DefaultCNIType).To(Equal("bridge"))
+			Expect(cfg.RuncVersion).To(Equal("1.4.0"))
+		})
+	})
+})


### PR DESCRIPTION
## 概要

MKS (Marmot Kubernetes Engine) 実装のフェーズ0（準備）として、既存の Server/Network/Volume コントローラーのパターンを踏襲した KubernetesEngine 用の雛形を追加します。

参考: [docs/MEMO-marmot-kubernetes-engine.md](docs/MEMO-marmot-kubernetes-engine.md)

## 変更内容

- **cmd/marmotd/mke.json**（新規）
  - MKS の初期設定情報ファイルの雛形（`kubernetes_version` / `containerd_version` / `etcd_version` / `cni_version` / `default_cni_type` / `runc_version`）
- **cmd/marmotd/testdata/mke.json**（新規）
  - テスト用に配置した `mke.json` のコピー（`marmotd.json` / `testdata/marmotd.json` と同じ配置パターン）
- **pkg/marmotd/mke-config.go**（新規）
  - 既存の `MarmotdConfig` / `LoadConfig` と同じパターンで `MKEConfig` 構造体と `LoadMKEConfig()` を追加
  - 設定ファイルが存在しない場合はデフォルト値、一部フィールドのみ指定された場合はデフォルト値で補完
- **pkg/marmotd/mke-config_test.go**（新規）
  - `testdata/mke.json` を実際に読み込んで値を検証するテストを含む3ケース（正常読み込み／ファイル未存在時のデフォルト値／一部フィールドのみ指定時の補完）
- **pkg/controller/kubernetes-engine-controller.go**（新規）
  - `host-controller.go` と同じ Start/Stop + ticker ループのパターンで `StartKubernetesEngineController()` を追加
  - 起動時に `mke.json` を読み込み、定期ループの骨組みのみを提供する雛形（クラスタのetcd監視・ライフサイクル管理は未実装、TODOコメントで明示）

## 対応範囲外（今後の対応）

- KubernetesEngine の API/etcdスキーマ定義
- 実際のクラスタ構築ロジック（PKI発行、systemdユニット管理、ネットワーク作成等）
- `marmotd-main.go` への新コントローラーの組み込み

## 動作確認

1. ビルド成功: `go build ./...`
2. 単体テスト成功: `MKEConfig` 関連3件 Pass
3. `gofmt -s -l` によるフォーマット確認: 差分なし
