### PR TITLE
MKE (Marmot Kubernetes Engine) フェーズ2: コントローラーの骨格とライフサイクル状態機械

### DIFF
--- a/cmd/marmotd/marmotd-main.go
+++ b/cmd/marmotd/marmotd-main.go
@@ -175,6 +175,13 @@ func main() {
 		return
 	}
 
+	// KubernetesEngineコントローラー（MKE）
+	_, err = controller.StartKubernetesEngineController(cfg.NodeName, cfg.EtcdURL, "")
+	if err != nil {
+		slog.Error("Failed to start kubernetes engine controller", "err", err)
+		return
+	}
+
 	// DNSサーバーコントローラー
 	_, err = internaldns.StartInternalDNSServer(context.Background(), cfg.NodeName, cfg.EtcdURL, cfg) // DNSサーバーコントローラーの開始
 	if err != nil {

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -113,11 +113,14 @@ func (c *kubernetesEngineController) kubernetesEngineControllerLoop() {
 			continue
 		}
 
-		if item.Status.DeletionTimeStamp != nil &&
-			time.Since(*item.Status.DeletionTimeStamp) > KUBERNETES_ENGINE_DELETION_DELAY &&
-			item.Status.StatusCode != db.KUBERNETES_ENGINE_DELETING {
-			_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_DELETING, "")
-			continue
+		if item.Status.DeletionTimeStamp != nil {
+			if time.Since(*item.Status.DeletionTimeStamp) <= KUBERNETES_ENGINE_DELETION_DELAY {
+				continue
+			}
+			if item.Status.StatusCode != db.KUBERNETES_ENGINE_DELETING {
+				_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_DELETING, "")
+				continue
+			}
 		}
 
 		switch item.Status.StatusCode {

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -114,7 +114,7 @@ func (c *kubernetesEngineController) kubernetesEngineControllerLoop() {
 		}
 
 		if item.Status.DeletionTimeStamp != nil {
-			if time.Since(*item.Status.DeletionTimeStamp) <= KUBERNETES_ENGINE_DELETION_DELAY {
+			if isKubernetesEngineInGracePeriod(item) {
 				continue
 			}
 			if item.Status.StatusCode != db.KUBERNETES_ENGINE_DELETING {
@@ -172,4 +172,13 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.Ku
 		return
 	}
 	slog.Debug("kubernetes engine deleted", "id", id)
+}
+
+// isKubernetesEngineInGracePeriod は DeletionTimeStamp が設定されたレコードが
+// まだ猶予期間内かどうかを返す。期間内は true を返し、ループはそのレコードをスキップする。
+func isKubernetesEngineInGracePeriod(ke api.KubernetesEngine) bool {
+	if ke.Status == nil || ke.Status.DeletionTimeStamp == nil {
+		return false
+	}
+	return time.Since(*ke.Status.DeletionTimeStamp) <= KUBERNETES_ENGINE_DELETION_DELAY
 }

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -5,19 +5,25 @@ import (
 	"sync"
 	"time"
 
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
 	"github.com/takara9/marmot/pkg/marmotd"
 )
 
 const (
 	KUBERNETES_ENGINE_CONTROLLER_INTERVAL = 10 * time.Second
+	KUBERNETES_ENGINE_DELETION_DELAY      = 15 * time.Second
 )
 
-// kubernetesEngineController は MKS (Marmot Kubernetes Engine) コントローラーの雛形です。
-// mke.json の読み込みと定期ループの骨組みのみを提供し、
-// KubernetesEngine リソースのetcd監視・クラスタのライフサイクル管理は今後実装します。
+// kubernetesEngineController は MKE (Marmot Kubernetes Engine) コントローラーです。
+// mke.json の読み込みに加えて、/marmot/kubernetes-engine 配下を定期的にポーリングし、
+// KubernetesEngine リソースのライフサイクル状態（Pending→Provisioning→Running→Deleting）を
+// etcd に書き込みます。実際のクラスタ構築（VM作成・kubeadm等）は今後実装します。
 type kubernetesEngineController struct {
 	node     string
 	mkeConf  *marmotd.MKEConfig
+	marmot   *marmotd.Marmot
+	db       *db.Database
 	stopChan chan struct{}
 	doneChan chan struct{}
 	stopOnce sync.Once
@@ -27,6 +33,7 @@ type kubernetesEngineController struct {
 // mkeConfigPath に空文字を渡した場合は既定パス(marmotd.DefaultMKEConfigPath)を使用します。
 func StartKubernetesEngineController(node string, etcdUrl string, mkeConfigPath string) (*kubernetesEngineController, error) {
 	var c kubernetesEngineController
+	var err error
 	c.node = node
 
 	if mkeConfigPath == "" {
@@ -40,6 +47,13 @@ func StartKubernetesEngineController(node string, etcdUrl string, mkeConfigPath 
 	}
 	c.mkeConf = cfg
 	slog.Info("MKE設定を読み込みました", "path", mkeConfigPath, "kubernetesVersion", cfg.KubernetesVersion)
+
+	c.marmot, err = marmotd.NewMarmot(node, etcdUrl)
+	if err != nil {
+		slog.Error("Failed to create marmot instance for kubernetes engine controller", "err", err)
+		return nil, err
+	}
+	c.db = c.marmot.Db
 
 	c.stopChan = make(chan struct{})
 	c.doneChan = make(chan struct{})
@@ -77,8 +91,82 @@ func (c *kubernetesEngineController) Stop() {
 	}
 }
 
-// KubernetesEngineコントローラーの制御ループ（雛形）
-// TODO: /marmot 配下のKubernetesEngineオブジェクト監視、クラスタのライフサイクル管理を実装する
+// kubernetesEngineControllerLoop は /marmot/kubernetes-engine 配下を毎tickポーリングし、
+// 新規作成イベントの検知と状態遷移の駆動を行う（etcd watch APIは未使用、既存コントローラーと
+// 同様のポーリング方式）。
 func (c *kubernetesEngineController) kubernetesEngineControllerLoop() {
 	slog.Debug("KubernetesEngineコントローラーの制御ループ実行", "CONTROLLER", time.Now().Format("2006-01-02 15:04:05"))
+
+	items, err := c.db.GetKubernetesEngines()
+	if err != nil {
+		slog.Error("GetKubernetesEngines() failed", "err", err)
+		return
+	}
+
+	for _, item := range items {
+		id := api.KubernetesEngineID(item)
+
+		if item.Status == nil {
+			// 生成直後で状態未設定のレコードを検知した場合の雛形（通常は Create 時に PENDING が設定される）。
+			slog.Debug("KubernetesEngineの生成を検知しました", "id", id, "name", item.Metadata.Name)
+			_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_PENDING, "")
+			continue
+		}
+
+		if item.Status.DeletionTimeStamp != nil &&
+			time.Since(*item.Status.DeletionTimeStamp) > KUBERNETES_ENGINE_DELETION_DELAY &&
+			item.Status.StatusCode != db.KUBERNETES_ENGINE_DELETING {
+			_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_DELETING, "")
+			continue
+		}
+
+		switch item.Status.StatusCode {
+		case db.KUBERNETES_ENGINE_PENDING:
+			c.reconcileKubernetesEnginePending(item)
+		case db.KUBERNETES_ENGINE_PROVISIONING:
+			c.reconcileKubernetesEngineProvisioning(item)
+		case db.KUBERNETES_ENGINE_RUNNING:
+			c.reconcileKubernetesEngineRunning(item)
+		case db.KUBERNETES_ENGINE_DELETING:
+			c.reconcileKubernetesEngineDeleting(item)
+		case db.KUBERNETES_ENGINE_FAILED:
+			slog.Debug("FAILED 状態のKubernetesEngineを検出", "id", id)
+		default:
+			slog.Warn("不明なKubernetesEngine状態", "id", id, "statusCode", item.Status.StatusCode)
+		}
+	}
+}
+
+// reconcileKubernetesEnginePending は新規作成を検知したクラスタを PROVISIONING に進める。
+// TODO: 次フェーズでノード用サーバーの作成を開始する。
+func (c *kubernetesEngineController) reconcileKubernetesEnginePending(ke api.KubernetesEngine) {
+	id := api.KubernetesEngineID(ke)
+	if err := c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_PROVISIONING, "cluster provisioning started"); err != nil {
+		slog.Warn("UpdateKubernetesEngineStatusWithMessage() failed", "id", id, "err", err)
+	}
+}
+
+// reconcileKubernetesEngineProvisioning はノード起動状況を確認して RUNNING に進める処理の差し込み口。
+// TODO: 次フェーズでノード(Server)の起動完了を確認し、全ノード Running になった時点で RUNNING に遷移させる。
+func (c *kubernetesEngineController) reconcileKubernetesEngineProvisioning(ke api.KubernetesEngine) {
+	id := api.KubernetesEngineID(ke)
+	slog.Debug("KubernetesEngineはPROVISIONING状態です（ノード起動確認は未実装）", "id", id, "name", ke.Metadata.Name)
+}
+
+// reconcileKubernetesEngineRunning はRUNNING状態のヘルスチェック用の差し込み口。
+// TODO: 次フェーズでノードの状態監視を行い、異常時はFAILED等へ遷移させる。
+func (c *kubernetesEngineController) reconcileKubernetesEngineRunning(ke api.KubernetesEngine) {
+	id := api.KubernetesEngineID(ke)
+	slog.Debug("KubernetesEngineはRUNNING状態です（ヘルスチェックは未実装）", "id", id, "name", ke.Metadata.Name)
+}
+
+// reconcileKubernetesEngineDeleting は猶予期間経過後に呼び出され、etcdから実削除する。
+// TODO: 次フェーズでノード(Server)等の関連リソース削除を先行させる。
+func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.KubernetesEngine) {
+	id := api.KubernetesEngineID(ke)
+	if err := c.db.DeleteKubernetesEngineById(id); err != nil {
+		slog.Warn("DeleteKubernetesEngineById() failed", "id", id, "err", err)
+		return
+	}
+	slog.Debug("kubernetes engine deleted", "id", id)
 }

--- a/pkg/controller/kubernetes-engine-controller_test.go
+++ b/pkg/controller/kubernetes-engine-controller_test.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+)
+
+func TestIsKubernetesEngineInGracePeriod(t *testing.T) {
+	withinDelay := time.Now().Add(-5 * time.Second)
+	expiredDelay := time.Now().Add(-(KUBERNETES_ENGINE_DELETION_DELAY + time.Second))
+
+	tests := []struct {
+		name string
+		ke   api.KubernetesEngine
+		want bool
+	}{
+		{
+			name: "no status: not in grace period",
+			ke:   api.KubernetesEngine{},
+			want: false,
+		},
+		{
+			name: "nil DeletionTimeStamp: not in grace period",
+			ke:   api.KubernetesEngine{Status: &api.Status{StatusCode: db.KUBERNETES_ENGINE_RUNNING}},
+			want: false,
+		},
+		{
+			name: "timestamp within delay: record is in grace period and must be preserved",
+			ke: api.KubernetesEngine{
+				Status: &api.Status{
+					StatusCode:        db.KUBERNETES_ENGINE_DELETING,
+					DeletionTimeStamp: &withinDelay,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "timestamp past delay: grace period expired and record may be hard-deleted",
+			ke: api.KubernetesEngine{
+				Status: &api.Status{
+					StatusCode:        db.KUBERNETES_ENGINE_DELETING,
+					DeletionTimeStamp: &expiredDelay,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isKubernetesEngineInGracePeriod(tt.ke)
+			if got != tt.want {
+				t.Fatalf("isKubernetesEngineInGracePeriod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/db/db-kubernetes-engine.go
+++ b/pkg/db/db-kubernetes-engine.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -11,18 +13,41 @@ import (
 )
 
 const (
-	KUBERNETES_ENGINE_PENDING  = 0
-	KUBERNETES_ENGINE_DELETING = 1
+	KUBERNETES_ENGINE_PENDING      = 0
+	KUBERNETES_ENGINE_PROVISIONING = 1
+	KUBERNETES_ENGINE_RUNNING      = 2
+	KUBERNETES_ENGINE_DELETING     = 3
+	KUBERNETES_ENGINE_FAILED       = 4
 )
 
 var KubernetesEngineStatus = map[int]string{
-	KUBERNETES_ENGINE_PENDING:  "PENDING",
-	KUBERNETES_ENGINE_DELETING: "DELETING",
+	KUBERNETES_ENGINE_PENDING:      "PENDING",
+	KUBERNETES_ENGINE_PROVISIONING: "PROVISIONING",
+	KUBERNETES_ENGINE_RUNNING:      "RUNNING",
+	KUBERNETES_ENGINE_DELETING:     "DELETING",
+	KUBERNETES_ENGINE_FAILED:       "FAILED",
 }
 
 // CreateKubernetesEngine は KubernetesEngine を etcd に登録する。
 // この時点ではコントローラーによる実クラスタ構築は行わず、PENDING状態で書き込むのみ。
 func (d *Database) CreateKubernetesEngine(spec api.KubernetesEngine) (api.KubernetesEngine, error) {
+	mutex, err := d.LockKey("/lock/kubernetes-engine/create")
+	if err != nil {
+		return api.KubernetesEngine{}, err
+	}
+	defer d.UnlockKey(mutex)
+
+	current, err := d.GetKubernetesEngines()
+	if err != nil && err != ErrNotFound {
+		return api.KubernetesEngine{}, err
+	}
+	name := strings.TrimSpace(spec.Metadata.Name)
+	for _, k := range current {
+		if strings.TrimSpace(k.Metadata.Name) == name {
+			return api.KubernetesEngine{}, fmt.Errorf("kubernetes engine with name %q already exists", name)
+		}
+	}
+
 	kubernetesEngine, err := util.DeepCopy(spec)
 	if err != nil {
 		return api.KubernetesEngine{}, err
@@ -88,6 +113,9 @@ func (d *Database) GetKubernetesEngineById(id string) (api.KubernetesEngine, err
 	return rec, nil
 }
 
+// DeleteKubernetesEngineById は etcd から即座にレコードを削除する（ハードデリート）。
+// API経由の削除要求は SetDeleteTimestampKubernetesEngine で DELETING 状態に遷移させ、
+// コントローラーが猶予期間経過後にこの関数を呼び出して実削除する想定。
 func (d *Database) DeleteKubernetesEngineById(id string) error {
 	lockKey := "/lock/kubernetes-engine/" + id
 	mutex, err := d.LockKey(lockKey)
@@ -96,4 +124,85 @@ func (d *Database) DeleteKubernetesEngineById(id string) error {
 	}
 	defer d.UnlockKey(mutex)
 	return d.DeleteJSON(KubernetesEnginePrefix + "/" + id)
+}
+
+// SetDeleteTimestampKubernetesEngine は DeletionTimeStamp を設定して DELETING 状態に遷移させる。
+func (d *Database) SetDeleteTimestampKubernetesEngine(id string) error {
+	for {
+		rec, err := d.GetKubernetesEngineById(id)
+		if err != nil {
+			return err
+		}
+		if rec.Status == nil {
+			rec.Status = &api.Status{}
+		}
+		rec.Status.StatusCode = KUBERNETES_ENGINE_DELETING
+		rec.Status.Status = util.StringPtr(KubernetesEngineStatus[KUBERNETES_ENGINE_DELETING])
+		rec.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
+		if rec.Status.DeletionTimeStamp == nil {
+			rec.Status.DeletionTimeStamp = util.TimePtr(time.Now())
+		}
+		rec.Status.Message = nil
+
+		err = d.putKubernetesEngineById(rec)
+		if err == ErrUpdateConflict {
+			continue
+		}
+		return err
+	}
+}
+
+// UpdateKubernetesEngineStatusWithMessage は状態コードとメッセージを更新する。
+// コントローラーがライフサイクルの状態遷移（Pending→Provisioning→Running等）を
+// 進める際に使用する。
+func (d *Database) UpdateKubernetesEngineStatusWithMessage(id string, status int, message string) error {
+	for {
+		rec, err := d.GetKubernetesEngineById(id)
+		if err != nil {
+			return err
+		}
+		if rec.Status == nil {
+			rec.Status = &api.Status{}
+		}
+		statusChanged := rec.Status.StatusCode != status
+		rec.Status.StatusCode = status
+		rec.Status.Status = util.StringPtr(KubernetesEngineStatus[status])
+		rec.Status.LastUpdateTimeStamp = util.TimePtr(time.Now())
+		trimmed := strings.TrimSpace(message)
+		if statusChanged {
+			rec.Status.Message = nil
+		}
+		if trimmed != "" {
+			rec.Status.Message = util.StringPtr(trimmed)
+		}
+
+		err = d.putKubernetesEngineById(rec)
+		if err == ErrUpdateConflict {
+			continue
+		}
+		return err
+	}
+}
+
+func (d *Database) putKubernetesEngineById(rec api.KubernetesEngine) error {
+	id := api.KubernetesEngineID(rec)
+	if strings.TrimSpace(id) == "" {
+		return ErrNotFound
+	}
+
+	lockKey := "/lock/kubernetes-engine/" + id
+	mutex, err := d.LockKey(lockKey)
+	if err != nil {
+		return err
+	}
+	defer d.UnlockKey(mutex)
+
+	key := KubernetesEnginePrefix + "/" + id
+	var current api.KubernetesEngine
+	resp, err := d.GetJSON(key, &current)
+	if err != nil {
+		return err
+	}
+	api.SetKubernetesEngineID(&rec, id)
+	return d.PutJSONCAS(key, resp.Kvs[0].ModRevision, &rec)
 }

--- a/pkg/marmotd/api-kubernetes-engine.go
+++ b/pkg/marmotd/api-kubernetes-engine.go
@@ -51,7 +51,8 @@ func (s *Server) ApiDeleteKubernetesEngineById(ctx echo.Context, id string) erro
 		}
 		return ctx.JSON(http.StatusInternalServerError, api.Error{Code: 1, Message: err.Error()})
 	}
-	if err := s.Ma.Db.DeleteKubernetesEngineById(id); err != nil {
+	// 実削除はコントローラーが DELETING 状態を検知し、猶予期間経過後に行う。
+	if err := s.Ma.Db.SetDeleteTimestampKubernetesEngine(id); err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			return ctx.JSON(http.StatusNotFound, api.Error{Code: 1, Message: "IDが存在しません"})
 		}


### PR DESCRIPTION
## 概要

フェーズ1で追加した `KubernetesEngine` リソースに対して、コントローラーの骨格（`/marmot/kubernetes-engine` プレフィックスのポーリングによる生成イベント検知の雛形）と、クラスタのライフサイクル状態遷移（Pending → Provisioning → Running → Deleting）をetcdへの状態書き込みのみで実装する。実際のクラスタ構築（ノード用サーバー作成・kubeadm等）は次フェーズ以降で実装する。

## 変更内容

### DB層 (db-kubernetes-engine.go)
- 状態定数を拡張: `PENDING` / `PROVISIONING` / `RUNNING` / `DELETING` / `FAILED`（フェーズ1では `PENDING`/`DELETING` のみだったものを拡張）
- `CreateKubernetesEngine`: ロック取得の上で `metadata.name` の重複チェックを追加（他リソース（VpnGateway等）と同じ規約。IDはフェーズ1のUUIDリトライループで既に一意性を保証済み）
- `SetDeleteTimestampKubernetesEngine`: 削除要求時に `DeletionTimeStamp` を設定して `DELETING` へ遷移させる（即時ハードデリートではなく、他リソースと同じ猶予期間付き削除方式に変更）
- `UpdateKubernetesEngineStatusWithMessage` / `putKubernetesEngineById`（CAS付き更新）を新規追加

### コントローラー層 (kubernetes-engine-controller.go)
- フェーズ0の雛形（mke.json読み込み+空ループ）を拡張し、`/marmot/kubernetes-engine` 配下を10秒間隔でポーリング（既存コントローラー群と同じ方式、etcd Watch APIは未使用）
- 状態未設定レコードの検知、`DeletionTimeStamp` 経過チェック、状態ごとの `reconcile*` 関数への振り分けを実装
- 各 `reconcile` 関数は状態遷移の骨格のみを実装し、実際のクラスタ構築ロジックはTODOコメントで次フェーズに委譲。`Deleting` のみ猶予期間（15秒）経過後の実削除まで実装済み

### API層 (api-kubernetes-engine.go)
- 削除APIを即時ハードデリートから `SetDeleteTimestampKubernetesEngine` によるDELETING状態遷移方式に変更（`VpnGateway` と同じ設計）

### 起動処理 (marmotd-main.go)
- `StartKubernetesEngineController` をmarmotd起動シーケンスに追加（既定のMKE設定パスを使用）

## スコープ外（次フェーズ以降）

- 実際のノード用サーバー作成・kubeadmによるクラスタ構築
- ノード起動状況の確認によるPROVISIONING→RUNNING遷移
- RUNNING状態のヘルスチェック・異常検知

## 検証

1. **ビルド成功**: `go build ubuntu.` / `go vet ubuntu.` 成功
2. **単体テスト**: controller テストスイート成功（`gofmt -s -l` も編集ファイルすべてでクリーン）
3. **シナリオ確認**: Create(PENDING) → コントローラーがPROVISIONINGへ遷移 → Delete API呼び出しでDELETING遷移＋DeletionTimeStamp設定 → 猶予期間経過後にetcdから実削除、という一連の状態遷移をコード上で確認