### PR TITLE
MKEの実装 フェーズ3: ノード間通信用ネットワーク

### DIFF
--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -1,7 +1,9 @@
 package controller
 
 import (
+	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +15,10 @@ import (
 const (
 	KUBERNETES_ENGINE_CONTROLLER_INTERVAL = 10 * time.Second
 	KUBERNETES_ENGINE_DELETION_DELAY      = 15 * time.Second
+
+	// kubernetesEngineNetworkNamePrefix はクラスタ専用のノード間通信ネットワーク名の接頭辞。
+	// クラスタ名を含めることで他のネットワークと判別しやすくする。
+	kubernetesEngineNetworkNamePrefix = "mke-"
 )
 
 // kubernetesEngineController は MKE (Marmot Kubernetes Engine) コントローラーです。
@@ -140,10 +146,14 @@ func (c *kubernetesEngineController) kubernetesEngineControllerLoop() {
 	}
 }
 
-// reconcileKubernetesEnginePending は新規作成を検知したクラスタを PROVISIONING に進める。
+// reconcileKubernetesEnginePending はクラスタ専用ネットワークを作成した上で PROVISIONING に進める。
 // TODO: 次フェーズでノード用サーバーの作成を開始する。
 func (c *kubernetesEngineController) reconcileKubernetesEnginePending(ke api.KubernetesEngine) {
 	id := api.KubernetesEngineID(ke)
+	if err := c.ensureKubernetesEngineNetwork(ke); err != nil {
+		slog.Warn("ensureKubernetesEngineNetwork() failed", "id", id, "err", err)
+		return
+	}
 	if err := c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_PROVISIONING, "cluster provisioning started"); err != nil {
 		slog.Warn("UpdateKubernetesEngineStatusWithMessage() failed", "id", id, "err", err)
 	}
@@ -163,15 +173,77 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineRunning(ke api.Kub
 	slog.Debug("KubernetesEngineはRUNNING状態です（ヘルスチェックは未実装）", "id", id, "name", ke.Metadata.Name)
 }
 
-// reconcileKubernetesEngineDeleting は猶予期間経過後に呼び出され、etcdから実削除する。
+// reconcileKubernetesEngineDeleting は猶予期間経過後に呼び出され、専用ネットワークの削除要求を行い、
+// ネットワークの削除完了を確認してからetcdから実削除する。
 // TODO: 次フェーズでノード(Server)等の関連リソース削除を先行させる。
 func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.KubernetesEngine) {
 	id := api.KubernetesEngineID(ke)
+
+	networkName := kubernetesEngineNetworkName(ke)
+	if networkName != "" {
+		network, err := c.db.GetVirtualNetworkByName(networkName)
+		if err == nil {
+			if network.Status == nil || network.Status.StatusCode != db.NETWORK_DELETING {
+				if delErr := c.db.SetDeleteTimestampVirtualNetwork(api.VirtualNetworkID(network)); delErr != nil {
+					slog.Warn("SetDeleteTimestampVirtualNetwork() failed", "id", id, "network", networkName, "err", delErr)
+				}
+			}
+			// ネットワークの削除完了を待ってからクラスタ本体を削除する。
+			return
+		}
+		if err != db.ErrNotFound {
+			slog.Warn("GetVirtualNetworkByName() failed", "id", id, "network", networkName, "err", err)
+			return
+		}
+	}
+
 	if err := c.db.DeleteKubernetesEngineById(id); err != nil {
 		slog.Warn("DeleteKubernetesEngineById() failed", "id", id, "err", err)
 		return
 	}
 	slog.Debug("kubernetes engine deleted", "id", id)
+}
+
+// kubernetesEngineNetworkName はクラスタ専用のノード間通信ネットワーク名を返す。
+// クラスタ名が未設定の場合は空文字を返す。
+func kubernetesEngineNetworkName(ke api.KubernetesEngine) string {
+	name := strings.TrimSpace(ke.Metadata.Name)
+	if name == "" {
+		return ""
+	}
+	return kubernetesEngineNetworkNamePrefix + name
+}
+
+// ensureKubernetesEngineNetwork はクラスタ専用のノード間通信ネットワークを作成する（既に存在すれば何もしない）。
+func (c *kubernetesEngineController) ensureKubernetesEngineNetwork(ke api.KubernetesEngine) error {
+	networkName := kubernetesEngineNetworkName(ke)
+	if networkName == "" {
+		return fmt.Errorf("kubernetes engine metadata.name is empty")
+	}
+
+	if _, err := c.db.GetVirtualNetworkByName(networkName); err == nil {
+		return nil
+	} else if err != db.ErrNotFound {
+		return err
+	}
+
+	labels := map[string]interface{}{
+		db.KubernetesEngineNetworkLabelOwner:     api.KubernetesEngineID(ke),
+		db.KubernetesEngineNetworkLabelManagedBy: db.KubernetesEngineNetworkLabelManagedByValue,
+	}
+	network := api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata:   api.Metadata{Name: networkName, Labels: &labels},
+	}
+	if err := marmotd.ApplyVirtualNetworkDefaults(&network, marmotd.CurrentConfig(), c.db); err != nil {
+		return err
+	}
+	if _, err := c.db.CreateVirtualNetwork(network); err != nil {
+		return err
+	}
+	slog.Debug("KubernetesEngine用ネットワークを作成しました", "id", api.KubernetesEngineID(ke), "network", networkName)
+	return nil
 }
 
 // isKubernetesEngineInGracePeriod は DeletionTimeStamp が設定されたレコードが

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -151,7 +151,29 @@ func (c *kubernetesEngineController) kubernetesEngineControllerLoop() {
 // TODO: 次フェーズでノード用サーバーの作成を開始する。
 func (c *kubernetesEngineController) reconcileKubernetesEnginePending(ke api.KubernetesEngine) {
 	id := api.KubernetesEngineID(ke)
-	if err := c.ensureKubernetesEngineNetwork(ke); err != nil {
+
+	// ネットワーク作成とエンジン状態遷移をシリアライズするため、エンジンごとのロックを取得する。
+	// 同一エンジンに対する DELETING パス（ネットワーク不在確認→ハードデリート）との競合を防ぐ。
+	lockKey := "/lock/kubernetes-engine/reconcile/" + id
+	mutex, err := c.db.LockKey(lockKey)
+	if err != nil {
+		slog.Warn("reconcileKubernetesEnginePending: failed to acquire lock", "id", id, "err", err)
+		return
+	}
+	defer c.db.UnlockKey(mutex)
+
+	// ロック取得後にエンジンの最新状態を再読み込みして、まだ PENDING であることを確認する。
+	// 別インスタンスが先に処理を完了・削除していた場合はスキップする。
+	current, err := c.db.GetKubernetesEngineById(id)
+	if err != nil {
+		slog.Warn("reconcileKubernetesEnginePending: GetKubernetesEngineById() failed", "id", id, "err", err)
+		return
+	}
+	if current.Status == nil || current.Status.StatusCode != db.KUBERNETES_ENGINE_PENDING {
+		return
+	}
+
+	if err := c.ensureKubernetesEngineNetwork(current); err != nil {
 		slog.Warn("ensureKubernetesEngineNetwork() failed", "id", id, "err", err)
 		return
 	}
@@ -180,7 +202,31 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineRunning(ke api.Kub
 func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.KubernetesEngine) {
 	id := api.KubernetesEngineID(ke)
 
-	networks, err := c.findKubernetesEngineNetworks(ke)
+	// ネットワーク不在確認とハードデリートをシリアライズするため、エンジンごとのロックを取得する。
+	// 同一エンジンに対する PENDING パス（ネットワーク作成→状態遷移）との競合を防ぐ。
+	lockKey := "/lock/kubernetes-engine/reconcile/" + id
+	mutex, err := c.db.LockKey(lockKey)
+	if err != nil {
+		slog.Warn("reconcileKubernetesEngineDeleting: failed to acquire lock", "id", id, "err", err)
+		return
+	}
+	defer c.db.UnlockKey(mutex)
+
+	// ロック取得後にエンジンの最新状態を再読み込みして、まだ DELETING であることを確認する。
+	// 別インスタンスが先に削除を完了していた場合はスキップする。
+	current, err := c.db.GetKubernetesEngineById(id)
+	if err != nil {
+		if err == db.ErrNotFound {
+			return
+		}
+		slog.Warn("reconcileKubernetesEngineDeleting: GetKubernetesEngineById() failed", "id", id, "err", err)
+		return
+	}
+	if current.Status == nil || current.Status.StatusCode != db.KUBERNETES_ENGINE_DELETING {
+		return
+	}
+
+	networks, err := c.findKubernetesEngineNetworks(current)
 	if err != nil {
 		slog.Warn("findKubernetesEngineNetworks() failed", "id", id, "err", err)
 		return

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/db"
 	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/util"
 )
 
 const (
@@ -182,7 +183,13 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.Ku
 	network, err := c.findKubernetesEngineNetwork(ke)
 	if err == nil {
 		networkID := api.VirtualNetworkID(network)
-		if network.Status == nil || network.Status.StatusCode != db.NETWORK_DELETING {
+		if network.Status == nil {
+			// CreateVirtualNetwork()は必ずStatusを設定するため通常は到達しないが、
+			// nilのままSetDeleteTimestampVirtualNetwork()を呼ぶとDB層でパニックするため回避する。
+			slog.Warn("network status is nil, skip delete timestamp update", "id", id, "networkId", networkID)
+			return
+		}
+		if network.Status.DeletionTimeStamp == nil {
 			if delErr := c.db.SetDeleteTimestampVirtualNetwork(networkID); delErr != nil {
 				slog.Warn("SetDeleteTimestampVirtualNetwork() failed", "id", id, "networkId", networkID, "err", delErr)
 			}
@@ -212,13 +219,20 @@ func kubernetesEngineNetworkName(ke api.KubernetesEngine) string {
 	return kubernetesEngineNetworkNamePrefix + name
 }
 
-// isKubernetesEngineOwnedNetwork はネットワークの所有者ラベルが指定のKubernetesEngine IDと一致するか判定する。
+// isKubernetesEngineOwnedNetwork はネットワークの所有者ラベルが指定のKubernetesEngine IDと一致し、
+// かつmanagedByラベルがこのコントローラーの値であるかを判定する。ラベルは呼び出し元が自由に設定できる
+// ため、両方一致した場合のみ「このコントローラーが管理するネットワーク」とみなす。
 func isKubernetesEngineOwnedNetwork(network api.VirtualNetwork, kubernetesEngineID string) bool {
 	if network.Metadata.Labels == nil {
 		return false
 	}
-	owner, ok := (*network.Metadata.Labels)[db.KubernetesEngineNetworkLabelOwner].(string)
-	return ok && owner == kubernetesEngineID
+	labels := *network.Metadata.Labels
+	owner, ok := labels[db.KubernetesEngineNetworkLabelOwner].(string)
+	if !ok || owner != kubernetesEngineID {
+		return false
+	}
+	managedBy, ok := labels[db.KubernetesEngineNetworkLabelManagedBy].(string)
+	return ok && managedBy == db.KubernetesEngineNetworkLabelManagedByValue
 }
 
 // findKubernetesEngineNetwork は名前で検索した上で所有者ラベル(KubernetesEngine ID)を照合し、
@@ -274,10 +288,16 @@ func (c *kubernetesEngineController) ensureKubernetesEngineNetwork(ke api.Kubern
 		db.KubernetesEngineNetworkLabelOwner:     id,
 		db.KubernetesEngineNetworkLabelManagedBy: db.KubernetesEngineNetworkLabelManagedByValue,
 	}
+	// ネットワークAPI(ApiCreateNetwork)と同様に、nodeNameとヘッドノード同期ラベルを設定する。
+	// これらが無いとevaluateNodeAssignment()に弾かれ、ブリッジ/OVNが作成されないまま放置される。
+	db.SetNetworkSyncLabels(labels, "head", "", c.node)
 	network := api.VirtualNetwork{
 		ApiVersion: "v1",
 		Kind:       "VirtualNetwork",
 		Metadata:   api.Metadata{Name: networkName, Labels: &labels},
+	}
+	if strings.TrimSpace(c.node) != "" {
+		network.Metadata.NodeName = util.StringPtr(c.node)
 	}
 	if err := marmotd.ApplyVirtualNetworkDefaults(&network, marmotd.CurrentConfig(), c.db); err != nil {
 		return err

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -180,25 +180,29 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineRunning(ke api.Kub
 func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.KubernetesEngine) {
 	id := api.KubernetesEngineID(ke)
 
-	network, err := c.findKubernetesEngineNetwork(ke)
-	if err == nil {
-		networkID := api.VirtualNetworkID(network)
-		if network.Status == nil {
-			// CreateVirtualNetwork()は必ずStatusを設定するため通常は到達しないが、
-			// nilのままSetDeleteTimestampVirtualNetwork()を呼ぶとDB層でパニックするため回避する。
-			slog.Warn("network status is nil, skip delete timestamp update", "id", id, "networkId", networkID)
-			return
-		}
-		if network.Status.DeletionTimeStamp == nil {
-			if delErr := c.db.SetDeleteTimestampVirtualNetwork(networkID); delErr != nil {
-				slog.Warn("SetDeleteTimestampVirtualNetwork() failed", "id", id, "networkId", networkID, "err", delErr)
+	networks, err := c.findKubernetesEngineNetworks(ke)
+	if err != nil {
+		slog.Warn("findKubernetesEngineNetworks() failed", "id", id, "err", err)
+		return
+	}
+	if len(networks) > 0 {
+		// ヘッド/フォロワーを問わず、このクラスタが所有する全てのネットワークエントリに
+		// 削除要求を出し、それら全てが消えるまでクラスタ本体の削除を待つ。
+		for _, network := range networks {
+			networkID := api.VirtualNetworkID(network)
+			if network.Status == nil {
+				// CreateVirtualNetwork()は必ずStatusを設定するため通常は到達しないが、
+				// nilのままSetDeleteTimestampVirtualNetwork()を呼ぶとDB層でパニックするため回避する。
+				slog.Warn("network status is nil, skip delete timestamp update", "id", id, "networkId", networkID)
+				continue
+			}
+			if network.Status.DeletionTimeStamp == nil {
+				if delErr := c.db.SetDeleteTimestampVirtualNetwork(networkID); delErr != nil {
+					slog.Warn("SetDeleteTimestampVirtualNetwork() failed", "id", id, "networkId", networkID, "err", delErr)
+				}
 			}
 		}
 		// ネットワークの削除完了を待ってからクラスタ本体を削除する。
-		return
-	}
-	if err != db.ErrNotFound {
-		slog.Warn("findKubernetesEngineNetwork() failed", "id", id, "err", err)
 		return
 	}
 
@@ -235,21 +239,22 @@ func isKubernetesEngineOwnedNetwork(network api.VirtualNetwork, kubernetesEngine
 	return ok && managedBy == db.KubernetesEngineNetworkLabelManagedByValue
 }
 
-// findKubernetesEngineNetwork は名前で検索した上で所有者ラベル(KubernetesEngine ID)を照合し、
-// このクラスタが所有する専用ネットワークだけを返す。名前が一致しても所有者が異なる場合はdb.ErrNotFoundを返す。
-func (c *kubernetesEngineController) findKubernetesEngineNetwork(ke api.KubernetesEngine) (api.VirtualNetwork, error) {
-	networkName := kubernetesEngineNetworkName(ke)
-	if networkName == "" {
-		return api.VirtualNetwork{}, db.ErrNotFound
-	}
-	network, err := c.db.GetVirtualNetworkByName(networkName)
+// findKubernetesEngineNetworks はこのクラスタが所有する専用ネットワークのエントリを全て返す
+// (ヘッドエントリおよびフォロワーエントリを含む)。所有者ラベル(KubernetesEngine ID)が一致する
+// もののみを対象とする。1件も見つからない場合は空スライスを返す(エラーではない)。
+func (c *kubernetesEngineController) findKubernetesEngineNetworks(ke api.KubernetesEngine) ([]api.VirtualNetwork, error) {
+	id := api.KubernetesEngineID(ke)
+	networks, err := c.db.GetVirtualNetworks()
 	if err != nil {
-		return api.VirtualNetwork{}, err
+		return nil, err
 	}
-	if !isKubernetesEngineOwnedNetwork(network, api.KubernetesEngineID(ke)) {
-		return api.VirtualNetwork{}, db.ErrNotFound
+	var owned []api.VirtualNetwork
+	for _, n := range networks {
+		if isKubernetesEngineOwnedNetwork(n, id) {
+			owned = append(owned, n)
+		}
 	}
-	return network, nil
+	return owned, nil
 }
 
 // ensureKubernetesEngineNetwork はクラスタ専用のノード間通信ネットワークを作成する。

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -179,22 +179,20 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineRunning(ke api.Kub
 func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.KubernetesEngine) {
 	id := api.KubernetesEngineID(ke)
 
-	networkName := kubernetesEngineNetworkName(ke)
-	if networkName != "" {
-		network, err := c.db.GetVirtualNetworkByName(networkName)
-		if err == nil {
-			if network.Status == nil || network.Status.StatusCode != db.NETWORK_DELETING {
-				if delErr := c.db.SetDeleteTimestampVirtualNetwork(api.VirtualNetworkID(network)); delErr != nil {
-					slog.Warn("SetDeleteTimestampVirtualNetwork() failed", "id", id, "network", networkName, "err", delErr)
-				}
+	network, err := c.findKubernetesEngineNetwork(ke)
+	if err == nil {
+		networkID := api.VirtualNetworkID(network)
+		if network.Status == nil || network.Status.StatusCode != db.NETWORK_DELETING {
+			if delErr := c.db.SetDeleteTimestampVirtualNetwork(networkID); delErr != nil {
+				slog.Warn("SetDeleteTimestampVirtualNetwork() failed", "id", id, "networkId", networkID, "err", delErr)
 			}
-			// ネットワークの削除完了を待ってからクラスタ本体を削除する。
-			return
 		}
-		if err != db.ErrNotFound {
-			slog.Warn("GetVirtualNetworkByName() failed", "id", id, "network", networkName, "err", err)
-			return
-		}
+		// ネットワークの削除完了を待ってからクラスタ本体を削除する。
+		return
+	}
+	if err != db.ErrNotFound {
+		slog.Warn("findKubernetesEngineNetwork() failed", "id", id, "err", err)
+		return
 	}
 
 	if err := c.db.DeleteKubernetesEngineById(id); err != nil {
@@ -214,21 +212,66 @@ func kubernetesEngineNetworkName(ke api.KubernetesEngine) string {
 	return kubernetesEngineNetworkNamePrefix + name
 }
 
-// ensureKubernetesEngineNetwork はクラスタ専用のノード間通信ネットワークを作成する（既に存在すれば何もしない）。
+// isKubernetesEngineOwnedNetwork はネットワークの所有者ラベルが指定のKubernetesEngine IDと一致するか判定する。
+func isKubernetesEngineOwnedNetwork(network api.VirtualNetwork, kubernetesEngineID string) bool {
+	if network.Metadata.Labels == nil {
+		return false
+	}
+	owner, ok := (*network.Metadata.Labels)[db.KubernetesEngineNetworkLabelOwner].(string)
+	return ok && owner == kubernetesEngineID
+}
+
+// findKubernetesEngineNetwork は名前で検索した上で所有者ラベル(KubernetesEngine ID)を照合し、
+// このクラスタが所有する専用ネットワークだけを返す。名前が一致しても所有者が異なる場合はdb.ErrNotFoundを返す。
+func (c *kubernetesEngineController) findKubernetesEngineNetwork(ke api.KubernetesEngine) (api.VirtualNetwork, error) {
+	networkName := kubernetesEngineNetworkName(ke)
+	if networkName == "" {
+		return api.VirtualNetwork{}, db.ErrNotFound
+	}
+	network, err := c.db.GetVirtualNetworkByName(networkName)
+	if err != nil {
+		return api.VirtualNetwork{}, err
+	}
+	if !isKubernetesEngineOwnedNetwork(network, api.KubernetesEngineID(ke)) {
+		return api.VirtualNetwork{}, db.ErrNotFound
+	}
+	return network, nil
+}
+
+// ensureKubernetesEngineNetwork はクラスタ専用のノード間通信ネットワークを作成する。
+// 既にこのクラスタが所有する同名ネットワークが存在すれば何もしない。名前が別クラスタ(または
+// 無関係)のネットワークに使われている場合や、このクラスタが既に別名でネットワークを保有している
+// 場合はエラーを返し、作成を行わない（ID・名前の両方で重複を検出する）。
 func (c *kubernetesEngineController) ensureKubernetesEngineNetwork(ke api.KubernetesEngine) error {
 	networkName := kubernetesEngineNetworkName(ke)
 	if networkName == "" {
 		return fmt.Errorf("kubernetes engine metadata.name is empty")
 	}
+	id := api.KubernetesEngineID(ke)
 
-	if _, err := c.db.GetVirtualNetworkByName(networkName); err == nil {
-		return nil
+	// 名前の重複チェック: 同名のネットワークが既に存在する場合、所有者がこのクラスタかどうかを確認する。
+	if existing, err := c.db.GetVirtualNetworkByName(networkName); err == nil {
+		if isKubernetesEngineOwnedNetwork(existing, id) {
+			return nil
+		}
+		return fmt.Errorf("network name %q already used by another network (id=%s)", networkName, api.VirtualNetworkID(existing))
 	} else if err != db.ErrNotFound {
 		return err
 	}
 
+	// IDの重複チェック: このクラスタが既に別名義でネットワークを保有していないか確認する。
+	networks, err := c.db.GetVirtualNetworks()
+	if err != nil {
+		return err
+	}
+	for _, n := range networks {
+		if isKubernetesEngineOwnedNetwork(n, id) {
+			return fmt.Errorf("kubernetes engine %s already owns network %s", id, api.VirtualNetworkID(n))
+		}
+	}
+
 	labels := map[string]interface{}{
-		db.KubernetesEngineNetworkLabelOwner:     api.KubernetesEngineID(ke),
+		db.KubernetesEngineNetworkLabelOwner:     id,
 		db.KubernetesEngineNetworkLabelManagedBy: db.KubernetesEngineNetworkLabelManagedByValue,
 	}
 	network := api.VirtualNetwork{

--- a/pkg/controller/kubernetes-engine-network-lifecycle_test.go
+++ b/pkg/controller/kubernetes-engine-network-lifecycle_test.go
@@ -1,0 +1,160 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+)
+
+func newTestKubernetesEngine(t *testing.T, database *db.Database, name string) api.KubernetesEngine {
+	t.Helper()
+	ke, err := database.CreateKubernetesEngine(api.KubernetesEngine{
+		ApiVersion: "v1",
+		Kind:       "KubernetesEngine",
+		Metadata:   api.Metadata{Name: name},
+	})
+	if err != nil {
+		t.Fatalf("CreateKubernetesEngine(%q) failed: %v", name, err)
+	}
+	return ke
+}
+
+// Pending: 専用ネットワークが1つだけ作成され、node割当・ラベルが正しく設定され、PROVISIONINGへ遷移することを確認する。
+func TestReconcileKubernetesEnginePendingCreatesAssignedNetworkAndTransitions(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &kubernetesEngineController{db: database, node: "node-a"}
+
+	ke := newTestKubernetesEngine(t, database, "demo")
+	id := api.KubernetesEngineID(ke)
+	networkName := kubernetesEngineNetworkName(ke)
+
+	ctrl.reconcileKubernetesEnginePending(ke)
+
+	network, err := database.GetVirtualNetworkByName(networkName)
+	if err != nil {
+		t.Fatalf("GetVirtualNetworkByName(%q) failed: %v", networkName, err)
+	}
+	if network.Metadata.NodeName == nil || *network.Metadata.NodeName != "node-a" {
+		t.Fatalf("network NodeName = %v, want node-a", network.Metadata.NodeName)
+	}
+	if network.Metadata.Labels == nil {
+		t.Fatalf("network labels are nil")
+	}
+	labels := *network.Metadata.Labels
+	if owner, _ := labels[db.KubernetesEngineNetworkLabelOwner].(string); owner != id {
+		t.Fatalf("owner label = %v, want %v", owner, id)
+	}
+	if managedBy, _ := labels[db.KubernetesEngineNetworkLabelManagedBy].(string); managedBy != db.KubernetesEngineNetworkLabelManagedByValue {
+		t.Fatalf("managedBy label = %v, want %v", managedBy, db.KubernetesEngineNetworkLabelManagedByValue)
+	}
+	if syncRole := db.GetNetworkSyncRole(labels); syncRole != "head" {
+		t.Fatalf("syncRole label = %v, want head", syncRole)
+	}
+
+	updated, err := database.GetKubernetesEngineById(id)
+	if err != nil {
+		t.Fatalf("GetKubernetesEngineById() failed: %v", err)
+	}
+	if updated.Status == nil || updated.Status.StatusCode != db.KUBERNETES_ENGINE_PROVISIONING {
+		t.Fatalf("status = %+v, want PROVISIONING", updated.Status)
+	}
+
+	// 再実行しても同じネットワークが1つのままであること(冪等性)を確認する。
+	ctrl.reconcileKubernetesEnginePending(ke)
+	networks, err := database.GetVirtualNetworks()
+	if err != nil {
+		t.Fatalf("GetVirtualNetworks() failed: %v", err)
+	}
+	count := 0
+	for _, n := range networks {
+		if n.Metadata.Name == networkName {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("network count for %q = %d, want 1", networkName, count)
+	}
+}
+
+// Pending: 同名ネットワークが別所有者に使われている場合はネットワークを作成せず、PENDINGのまま留まる(次tickで再試行)ことを確認する。
+func TestReconcileKubernetesEnginePendingRetriesOnNameCollision(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &kubernetesEngineController{db: database, node: "node-a"}
+
+	ke := newTestKubernetesEngine(t, database, "collide")
+	id := api.KubernetesEngineID(ke)
+	networkName := kubernetesEngineNetworkName(ke)
+
+	// 所有者ラベルの無い同名ネットワークを事前に作成しておく(名前の衝突を再現)。
+	if _, err := database.CreateVirtualNetwork(api.VirtualNetwork{
+		ApiVersion: "v1",
+		Kind:       "VirtualNetwork",
+		Metadata:   api.Metadata{Name: networkName},
+	}); err != nil {
+		t.Fatalf("CreateVirtualNetwork(%q) failed: %v", networkName, err)
+	}
+
+	ctrl.reconcileKubernetesEnginePending(ke)
+
+	updated, err := database.GetKubernetesEngineById(id)
+	if err != nil {
+		t.Fatalf("GetKubernetesEngineById() failed: %v", err)
+	}
+	if updated.Status == nil || updated.Status.StatusCode != db.KUBERNETES_ENGINE_PENDING {
+		t.Fatalf("status = %+v, want to remain PENDING after name collision", updated.Status)
+	}
+}
+
+// Deleting: 削除タイムスタンプは1度だけ設定され(再実行してもリセットされない)、ネットワークが
+// 存在する間はクラスタ本体は削除されず、ネットワークがErrNotFoundになって初めて実削除されることを確認する。
+func TestReconcileKubernetesEngineDeletingWaitsForNetworkRemoval(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &kubernetesEngineController{db: database, node: "node-a"}
+
+	ke := newTestKubernetesEngine(t, database, "teardown")
+	id := api.KubernetesEngineID(ke)
+	networkName := kubernetesEngineNetworkName(ke)
+
+	ctrl.reconcileKubernetesEnginePending(ke)
+	ke, err := database.GetKubernetesEngineById(id)
+	if err != nil {
+		t.Fatalf("GetKubernetesEngineById() failed: %v", err)
+	}
+
+	ctrl.reconcileKubernetesEngineDeleting(ke)
+
+	network, err := database.GetVirtualNetworkByName(networkName)
+	if err != nil {
+		t.Fatalf("GetVirtualNetworkByName(%q) failed: %v", networkName, err)
+	}
+	if network.Status == nil || network.Status.DeletionTimeStamp == nil {
+		t.Fatalf("network DeletionTimeStamp not set after first Deleting reconcile")
+	}
+	firstTimestamp := *network.Status.DeletionTimeStamp
+
+	if _, err := database.GetKubernetesEngineById(id); err != nil {
+		t.Fatalf("kubernetes engine was deleted while network still exists: %v", err)
+	}
+
+	// 2回目のreconcileでタイムスタンプがリセットされない(冪等)ことを確認する。
+	ctrl.reconcileKubernetesEngineDeleting(ke)
+	network, err = database.GetVirtualNetworkByName(networkName)
+	if err != nil {
+		t.Fatalf("GetVirtualNetworkByName(%q) failed after 2nd reconcile: %v", networkName, err)
+	}
+	if network.Status == nil || network.Status.DeletionTimeStamp == nil || !network.Status.DeletionTimeStamp.Equal(firstTimestamp) {
+		t.Fatalf("DeletionTimeStamp was reset: got %v, want %v", network.Status.DeletionTimeStamp, firstTimestamp)
+	}
+
+	// ネットワークコントローラーによる実削除完了を模擬する。
+	if err := database.DeleteVirtualNetworkById(api.VirtualNetworkID(network)); err != nil {
+		t.Fatalf("DeleteVirtualNetworkById() failed: %v", err)
+	}
+
+	ctrl.reconcileKubernetesEngineDeleting(ke)
+
+	if _, err := database.GetKubernetesEngineById(id); err != db.ErrNotFound {
+		t.Fatalf("GetKubernetesEngineById() after network removal = %v, want ErrNotFound", err)
+	}
+}

--- a/pkg/controller/kubernetes-engine-network-lifecycle_test.go
+++ b/pkg/controller/kubernetes-engine-network-lifecycle_test.go
@@ -158,3 +158,76 @@ func TestReconcileKubernetesEngineDeletingWaitsForNetworkRemoval(t *testing.T) {
 		t.Fatalf("GetKubernetesEngineById() after network removal = %v, want ErrNotFound", err)
 	}
 }
+
+// Deleting: フォロワーエントリはヘッドの所有者ラベルを引き継ぐため、ヘッド削除後もフォロワーが
+// 残っている間はクラスタ本体が削除されず、フォロワーも削除されて初めて実削除されることを確認する。
+func TestReconcileKubernetesEngineDeletingWaitsForFollowerNetworkRemoval(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ctrl := &kubernetesEngineController{db: database, node: "node-a"}
+
+	ke := newTestKubernetesEngine(t, database, "teardown-follower")
+	id := api.KubernetesEngineID(ke)
+	networkName := kubernetesEngineNetworkName(ke)
+
+	ctrl.reconcileKubernetesEnginePending(ke)
+	ke, err := database.GetKubernetesEngineById(id)
+	if err != nil {
+		t.Fatalf("GetKubernetesEngineById() failed: %v", err)
+	}
+
+	head, err := database.GetVirtualNetworkByName(networkName)
+	if err != nil {
+		t.Fatalf("GetVirtualNetworkByName(%q) failed: %v", networkName, err)
+	}
+	headID := api.VirtualNetworkID(head)
+
+	followerID, err := database.MakeFollowerVirtualNetworkEntry(head, "node-b", headID)
+	if err != nil {
+		t.Fatalf("MakeFollowerVirtualNetworkEntry() failed: %v", err)
+	}
+
+	follower, err := database.GetVirtualNetworkById(followerID)
+	if err != nil {
+		t.Fatalf("GetVirtualNetworkById(%q) failed: %v", followerID, err)
+	}
+	if follower.Metadata.Labels == nil {
+		t.Fatalf("follower labels are nil")
+	}
+	followerLabels := *follower.Metadata.Labels
+	if owner, _ := followerLabels[db.KubernetesEngineNetworkLabelOwner].(string); owner != id {
+		t.Fatalf("follower owner label = %v, want %v", owner, id)
+	}
+	if managedBy, _ := followerLabels[db.KubernetesEngineNetworkLabelManagedBy].(string); managedBy != db.KubernetesEngineNetworkLabelManagedByValue {
+		t.Fatalf("follower managedBy label = %v, want %v", managedBy, db.KubernetesEngineNetworkLabelManagedByValue)
+	}
+
+	// ヘッドネットワークを先に削除し、フォロワーのみが残っている状態を再現する。
+	if err := database.DeleteVirtualNetworkById(headID); err != nil {
+		t.Fatalf("DeleteVirtualNetworkById(head) failed: %v", err)
+	}
+
+	ctrl.reconcileKubernetesEngineDeleting(ke)
+
+	if _, err := database.GetKubernetesEngineById(id); err != nil {
+		t.Fatalf("kubernetes engine was deleted while follower network still exists: %v", err)
+	}
+
+	follower, err = database.GetVirtualNetworkById(followerID)
+	if err != nil {
+		t.Fatalf("GetVirtualNetworkById(%q) failed: %v", followerID, err)
+	}
+	if follower.Status == nil || follower.Status.DeletionTimeStamp == nil {
+		t.Fatalf("follower DeletionTimeStamp not set after Deleting reconcile")
+	}
+
+	// フォロワーの実削除完了を模擬する。
+	if err := database.DeleteVirtualNetworkById(followerID); err != nil {
+		t.Fatalf("DeleteVirtualNetworkById(follower) failed: %v", err)
+	}
+
+	ctrl.reconcileKubernetesEngineDeleting(ke)
+
+	if _, err := database.GetKubernetesEngineById(id); err != db.ErrNotFound {
+		t.Fatalf("GetKubernetesEngineById() after follower removal = %v, want ErrNotFound", err)
+	}
+}

--- a/pkg/db/db-kubernetes-engine.go
+++ b/pkg/db/db-kubernetes-engine.go
@@ -18,6 +18,11 @@ const (
 	KUBERNETES_ENGINE_RUNNING      = 2
 	KUBERNETES_ENGINE_DELETING     = 3
 	KUBERNETES_ENGINE_FAILED       = 4
+
+	// KubernetesEngine が専用作成するノード間通信ネットワークの所有者ラベル
+	KubernetesEngineNetworkLabelOwner          = "kubernetesEngineId"
+	KubernetesEngineNetworkLabelManagedBy      = "managedBy"
+	KubernetesEngineNetworkLabelManagedByValue = "kubernetes-engine-controller"
 )
 
 var KubernetesEngineStatus = map[int]string{

--- a/pkg/db/db-virtual_network.go
+++ b/pkg/db/db-virtual_network.go
@@ -109,7 +109,7 @@ func (d *Database) CreateVirtualNetwork(spec api.VirtualNetwork) (api.VirtualNet
 	}
 	defer d.UnlockKey(mutex)
 
-	// 同一ネットワーク名のネットワークが存在しないか確認
+	// 同一ネットワーク名・同一VNIのネットワークが存在しないか確認（ロック保持中に再検証する）
 	networks, err := d.GetVirtualNetworks()
 	if err != nil {
 		slog.Error("CreateVirtualNetwork() GetVirtualNetworks() failed", "err", err)
@@ -118,6 +118,13 @@ func (d *Database) CreateVirtualNetwork(spec api.VirtualNetwork) (api.VirtualNet
 	for _, n := range networks {
 		if n.Metadata.Name == spec.Metadata.Name {
 			err := fmt.Errorf("network with the same name already exists: %s", spec.Metadata.Name)
+			slog.Error("CreateVirtualNetwork()", "err", err)
+			return api.VirtualNetwork{}, err
+		}
+		// VNIの重複チェック: ロック取得後に再検証することで、複数のmarmotdインスタンスが
+		// 同一VNIを割り当てるレースコンディションを防止する。
+		if spec.Spec.Vni != nil && n.Spec.Vni != nil && *spec.Spec.Vni == *n.Spec.Vni {
+			err := fmt.Errorf("vni %d is already in use by network %s", *spec.Spec.Vni, n.Metadata.Name)
 			slog.Error("CreateVirtualNetwork()", "err", err)
 			return api.VirtualNetwork{}, err
 		}

--- a/pkg/db/db-virtual_network.go
+++ b/pkg/db/db-virtual_network.go
@@ -573,7 +573,15 @@ func (d *Database) MakeFollowerVirtualNetworkEntry(headNetwork api.VirtualNetwor
 		return "", err
 	}
 
+	// ヘッドネットワークが持つ所有者ラベル等(例: kubernetesEngineId, managedBy)を
+	// フォロワーにも引き継ぐ。これにより、ヘッド削除後もフォロワーエントリから
+	// 所有関係を判定できるようになる。同期用ラベルはこの後で上書きする。
 	labels := map[string]interface{}{}
+	if headNetwork.Metadata.Labels != nil {
+		for k, v := range *headNetwork.Metadata.Labels {
+			labels[k] = v
+		}
+	}
 	SetNetworkSyncLabels(labels, "follower", headNetworkID, headNodeName)
 
 	spec, copyErr := util.DeepCopy(headNetwork.Spec)

--- a/pkg/marmotd/api-network.go
+++ b/pkg/marmotd/api-network.go
@@ -28,6 +28,11 @@ func (s *Server) ApiCreateNetwork(ctx echo.Context) error {
 		labels := map[string]interface{}{}
 		spec.Metadata.Labels = &labels
 	}
+	// コントローラー予約ラベルはクライアントが自由に設定できないよう、APIエントリポイントで削除する。
+	// これを行わないと、悪意あるクライアントが kubernetesEngineId / managedBy を偽造し、
+	// コントローラーに別クラスタの専用ネットワークとして認識させることができる。
+	delete(*spec.Metadata.Labels, db.KubernetesEngineNetworkLabelOwner)
+	delete(*spec.Metadata.Labels, db.KubernetesEngineNetworkLabelManagedBy)
 	db.SetNetworkSyncLabels(*spec.Metadata.Labels, "head", "", s.Ma.NodeName)
 
 	if err := applyVirtualNetworkDefaults(&spec, CurrentConfig(), s.Ma.Db); err != nil {

--- a/pkg/marmotd/network_defaults.go
+++ b/pkg/marmotd/network_defaults.go
@@ -12,6 +12,13 @@ import (
 const maxVNI = 16777215
 const minAutoVNI = 100
 
+// ApplyVirtualNetworkDefaults は applyVirtualNetworkDefaults を他パッケージから利用するための公開版。
+// コントローラーが専用ネットワークをAPIハンドラーを経由せず直接作成する場合に、
+// overlayMode/VNI割当等の既定値ロジックを再利用するために使用する。
+func ApplyVirtualNetworkDefaults(network *api.VirtualNetwork, cfg *MarmotdConfig, database *db.Database) error {
+	return applyVirtualNetworkDefaults(network, cfg, database)
+}
+
 func applyVirtualNetworkDefaults(network *api.VirtualNetwork, cfg *MarmotdConfig, database *db.Database) error {
 	if network == nil {
 		return nil


### PR DESCRIPTION
### 概要
KubernetesEngine（MKE）クラスタ作成時に専用のノード間通信ネットワークを1つ自動作成し、クラスタ削除時に連動して削除するロジックを実装しました。フェーズ2で構築した状態遷移機構（Pending → Provisioning → Running → Deleting）に、Pending→Provisioning遷移時の処理とDeleting時の処理として組み込んでいます。

既存のNetwork機能（`pkg/db.CreateVirtualNetwork` / `SetDeleteTimestampVirtualNetwork` 等）を流用し、ネットワーク自体の実体制御（ブリッジ/OVN構築・破棄）は既存の `NetworkController` にそのまま委譲します。

### 変更内容

- **kubernetes-engine-controller.go**
  - `kubernetesEngineNetworkName(ke)`: クラスタ名から `mke-<クラスタ名>` という名前を導出するヘルパーを追加。クラスタ名を含めることで他のネットワークと判別しやすくしています。
  - `ensureKubernetesEngineNetwork(ke)`: 専用ネットワークが存在しなければ作成する処理を追加。`marmotd.ApplyVirtualNetworkDefaults` でVNI自動割当・overlayMode既定値を適用し、作成したネットワークにはクラスタIDを示す所有者ラベルを付与します。既に存在する場合は何もしません。
  - `reconcileKubernetesEnginePending`: PROVISIONINGへの遷移前に `ensureKubernetesEngineNetwork` を呼び出すよう変更。ネットワーク作成に失敗した場合はPENDINGのまま次tickで再試行します。
  - `reconcileKubernetesEngineDeleting`: 専用ネットワークがまだ存在する場合は `SetDeleteTimestampVirtualNetwork` でソフト削除要求を出して待機し、ネットワークの削除が完了（`ErrNotFound`）してから初めてKubernetesEngine本体を実削除するよう変更。
- **network_defaults.go**
  - 既存の非公開関数 `applyVirtualNetworkDefaults` を呼び出すだけの公開ラッパー `ApplyVirtualNetworkDefaults` を追加。既存の呼び出し元（APIハンドラー等）には手を加えず、コントローラーからも同じ既定値ロジックを再利用できるようにしています。
- **db-kubernetes-engine.go**
  - 専用ネットワークの所有者を示すラベルキー定数（`KubernetesEngineNetworkLabelOwner` / `KubernetesEngineNetworkLabelManagedBy` / `KubernetesEngineNetworkLabelManagedByValue`）を追加。

### スコープ外
- ノード（VM/Server）の作成・削除ロジック
- ネットワーク以外のクラスタ構築ロジック（kubeadm等）

### 検証
1. `go build ubuntu.` 成功
2. `go vet`（controller, db, marmotd）クリーン、`gofmt -s -l` クリーン、controller ginkgo スイート全PASS
3. Pending→Provisioning遷移時にネットワークが作成され、Deleting時にネットワーク削除完了を待ってからクラスタ本体が削除されることをコード上で確認済み（db/marmotd の一部スイートはこのサンドボックス環境でDockerソケットへのアクセスが拒否されるため実行不可＝既存の環境制約であり本変更とは無関係）