### PR TITLE
MKE実装 フェーズ5: PKI（証明書発行）

### DIFF
--- a/pkg/controller/kubernetes-engine-pki.go
+++ b/pkg/controller/kubernetes-engine-pki.go
@@ -228,12 +228,16 @@ func newCertificateSerialNumber() (*big.Int, error) {
 	return rand.Int(rand.Reader, limit)
 }
 
-func withKubernetesEnginePkiLock(lockPath string, fn func() error) error {
+func withKubernetesEnginePkiLock(lockPath string, fn func() error) (retErr error) {
 	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return err
 	}
-	defer lockFile.Close()
+	defer func() {
+		if closeErr := lockFile.Close(); retErr == nil {
+			retErr = closeErr
+		}
+	}()
 
 	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
 		return err

--- a/pkg/controller/kubernetes-engine-pki.go
+++ b/pkg/controller/kubernetes-engine-pki.go
@@ -142,7 +142,15 @@ func IssueKubernetesEngineCertificate(pkiDir, clusterName string, req Kubernetes
 	if reqName == "" {
 		return "", "", fmt.Errorf("certificate request name is empty")
 	}
-
+	if reqName != filepath.Base(reqName) || reqName == "." || reqName == ".." || strings.Contains(reqName, "\\") {
+		return "", "", fmt.Errorf("certificate request name is invalid: %q", req.Name)
+	}
+	for _, r := range reqName {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return "", "", fmt.Errorf("certificate request name contains invalid character %q", r)
+	}
 	certPath, keyPath = KubernetesEngineCertPaths(pkiDir, name, reqName)
 	if certFileExists(certPath) && certFileExists(keyPath) {
 		return certPath, keyPath, nil

--- a/pkg/controller/kubernetes-engine-pki.go
+++ b/pkg/controller/kubernetes-engine-pki.go
@@ -1,0 +1,250 @@
+package controller
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultKubernetesEnginePkiDir はクラスタ専用CA・証明書を配置するディレクトリの親。
+	// 実際のファイルは "<DefaultKubernetesEnginePkiDir>/<cluster>" 配下に置かれる。
+	DefaultKubernetesEnginePkiDir = "/var/lib/marmot/mke/pki"
+
+	kubernetesEngineCAValidity   = 10 * 365 * 24 * time.Hour
+	kubernetesEngineCertValidity = 365 * 24 * time.Hour
+	kubernetesEngineCAKeyBits    = 4096
+	kubernetesEngineCertKeyBits  = 2048
+)
+
+// KubernetesEngineCertUsage は発行する証明書の用途(サーバー/クライアント)を表す。
+type KubernetesEngineCertUsage int
+
+const (
+	KubernetesEngineCertUsageServer KubernetesEngineCertUsage = iota
+	KubernetesEngineCertUsageClient
+)
+
+// KubernetesEngineCertRequest は証明書発行に必要なパラメータ。
+type KubernetesEngineCertRequest struct {
+	// Name はファイル名の基点(例: "kube-apiserver", "kubelet-node1")。
+	Name        string
+	CommonName  string
+	Usage       KubernetesEngineCertUsage
+	DNSNames    []string
+	IPAddresses []net.IP
+}
+
+func kubernetesEngineClusterPkiDir(pkiDir, clusterName string) string {
+	return filepath.Join(pkiDir, clusterName)
+}
+
+// KubernetesEngineCAPaths はクラスタ専用CAの証明書・秘密鍵のパスを返す。
+func KubernetesEngineCAPaths(pkiDir, clusterName string) (certPath, keyPath string) {
+	dir := kubernetesEngineClusterPkiDir(pkiDir, clusterName)
+	return filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key")
+}
+
+// KubernetesEngineCertPaths は発行済み証明書・秘密鍵のパスを返す。
+func KubernetesEngineCertPaths(pkiDir, clusterName, name string) (certPath, keyPath string) {
+	dir := kubernetesEngineClusterPkiDir(pkiDir, clusterName)
+	return filepath.Join(dir, name+".crt"), filepath.Join(dir, name+".key")
+}
+
+// validateKubernetesEnginePkiClusterName はクラスタ名がディレクトリ/ファイル名として
+// 安全であることを検証し、前後の空白を除いた名前を返す。
+func validateKubernetesEnginePkiClusterName(clusterName string) (string, error) {
+	name := strings.TrimSpace(clusterName)
+	if name == "" {
+		return "", fmt.Errorf("cluster name is empty")
+	}
+	if name == "." || name == ".." {
+		return "", fmt.Errorf("cluster name is invalid: %q", clusterName)
+	}
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return "", fmt.Errorf("cluster name contains invalid character %q", r)
+	}
+	return name, nil
+}
+
+// EnsureKubernetesEngineCA はクラスタ専用の自己署名CA(証明書・秘密鍵)を生成する。
+// 既に生成済みの場合は再生成せずそのパスを返す(冪等)。
+func EnsureKubernetesEngineCA(pkiDir, clusterName string) (certPath, keyPath string, err error) {
+	name, err := validateKubernetesEnginePkiClusterName(clusterName)
+	if err != nil {
+		return "", "", err
+	}
+	certPath, keyPath = KubernetesEngineCAPaths(pkiDir, name)
+	if certFileExists(certPath) && certFileExists(keyPath) {
+		return certPath, keyPath, nil
+	}
+
+	dir := kubernetesEngineClusterPkiDir(pkiDir, name)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", "", fmt.Errorf("failed to create pki dir: %w", err)
+	}
+
+	caKey, err := rsa.GenerateKey(rand.Reader, kubernetesEngineCAKeyBits)
+	if err != nil {
+		return "", "", err
+	}
+	serial, err := newCertificateSerialNumber()
+	if err != nil {
+		return "", "", err
+	}
+	now := time.Now()
+	caTemplate := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   fmt.Sprintf("mke-%s-ca", name),
+			Organization: []string{"marmot"},
+		},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(kubernetesEngineCAValidity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return "", "", err
+	}
+	if err := writePemFile(certPath, "CERTIFICATE", caDER, 0o644); err != nil {
+		return "", "", err
+	}
+	if err := writePemFile(keyPath, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(caKey), 0o600); err != nil {
+		_ = os.Remove(certPath)
+		return "", "", err
+	}
+	return certPath, keyPath, nil
+}
+
+// IssueKubernetesEngineCertificate はクラスタ専用CAで署名したリーフ証明書を発行する。
+// 既に同名の証明書が存在する場合は再発行せずそのパスを返す(冪等)。CAが未生成の場合はエラーになる。
+func IssueKubernetesEngineCertificate(pkiDir, clusterName string, req KubernetesEngineCertRequest) (certPath, keyPath string, err error) {
+	name, err := validateKubernetesEnginePkiClusterName(clusterName)
+	if err != nil {
+		return "", "", err
+	}
+	reqName := strings.TrimSpace(req.Name)
+	if reqName == "" {
+		return "", "", fmt.Errorf("certificate request name is empty")
+	}
+
+	certPath, keyPath = KubernetesEngineCertPaths(pkiDir, name, reqName)
+	if certFileExists(certPath) && certFileExists(keyPath) {
+		return certPath, keyPath, nil
+	}
+
+	caCertPath, caKeyPath := KubernetesEngineCAPaths(pkiDir, name)
+	caCert, caKey, err := loadKubernetesEngineCA(caCertPath, caKeyPath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to load cluster CA: %w", err)
+	}
+
+	var extKeyUsage []x509.ExtKeyUsage
+	switch req.Usage {
+	case KubernetesEngineCertUsageServer:
+		extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	case KubernetesEngineCertUsageClient:
+		extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	default:
+		return "", "", fmt.Errorf("unknown certificate usage: %v", req.Usage)
+	}
+
+	leafKey, err := rsa.GenerateKey(rand.Reader, kubernetesEngineCertKeyBits)
+	if err != nil {
+		return "", "", err
+	}
+	serial, err := newCertificateSerialNumber()
+	if err != nil {
+		return "", "", err
+	}
+	now := time.Now()
+	leafTemplate := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   req.CommonName,
+			Organization: []string{"marmot"},
+		},
+		NotBefore:   now.Add(-time.Hour),
+		NotAfter:    now.Add(kubernetesEngineCertValidity),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: extKeyUsage,
+		DNSNames:    req.DNSNames,
+		IPAddresses: req.IPAddresses,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		return "", "", err
+	}
+
+	dir := kubernetesEngineClusterPkiDir(pkiDir, name)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", "", err
+	}
+	if err := writePemFile(certPath, "CERTIFICATE", leafDER, 0o644); err != nil {
+		return "", "", err
+	}
+	if err := writePemFile(keyPath, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(leafKey), 0o600); err != nil {
+		_ = os.Remove(certPath)
+		return "", "", err
+	}
+	return certPath, keyPath, nil
+}
+
+func newCertificateSerialNumber() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	return rand.Int(rand.Reader, limit)
+}
+
+func writePemFile(path, blockType string, der []byte, mode os.FileMode) error {
+	block := &pem.Block{Type: blockType, Bytes: der}
+	return os.WriteFile(path, pem.EncodeToMemory(block), mode)
+}
+
+func loadKubernetesEngineCA(certPath, keyPath string) (*x509.Certificate, *rsa.PrivateKey, error) {
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return nil, nil, fmt.Errorf("failed to decode CA certificate PEM: %s", certPath)
+	}
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, nil, fmt.Errorf("failed to decode CA private key PEM: %s", keyPath)
+	}
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cert, key, nil
+}
+
+func certFileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/pkg/controller/kubernetes-engine-pki.go
+++ b/pkg/controller/kubernetes-engine-pki.go
@@ -220,7 +220,30 @@ func newCertificateSerialNumber() (*big.Int, error) {
 
 func writePemFile(path, blockType string, der []byte, mode os.FileMode) error {
 	block := &pem.Block{Type: blockType, Bytes: der}
-	return os.WriteFile(path, pem.EncodeToMemory(block), mode)
+	dir := filepath.Dir(path)
+
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(pem.EncodeToMemory(block)); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	return nil
 }
 
 func loadKubernetesEngineCA(certPath, keyPath string) (*x509.Certificate, *rsa.PrivateKey, error) {

--- a/pkg/controller/kubernetes-engine-pki.go
+++ b/pkg/controller/kubernetes-engine-pki.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -87,45 +88,49 @@ func EnsureKubernetesEngineCA(pkiDir, clusterName string) (certPath, keyPath str
 		return "", "", err
 	}
 	certPath, keyPath = KubernetesEngineCAPaths(pkiDir, name)
-	if certFileExists(certPath) && certFileExists(keyPath) {
-		return certPath, keyPath, nil
-	}
-
 	dir := kubernetesEngineClusterPkiDir(pkiDir, name)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", "", fmt.Errorf("failed to create pki dir: %w", err)
 	}
+	if err := withKubernetesEnginePkiLock(filepath.Join(dir, ".ca.lock"), func() error {
+		if certFileExists(certPath) && certFileExists(keyPath) {
+			return nil
+		}
 
-	caKey, err := rsa.GenerateKey(rand.Reader, kubernetesEngineCAKeyBits)
-	if err != nil {
-		return "", "", err
-	}
-	serial, err := newCertificateSerialNumber()
-	if err != nil {
-		return "", "", err
-	}
-	now := time.Now()
-	caTemplate := &x509.Certificate{
-		SerialNumber: serial,
-		Subject: pkix.Name{
-			CommonName:   fmt.Sprintf("mke-%s-ca", name),
-			Organization: []string{"marmot"},
-		},
-		NotBefore:             now.Add(-time.Hour),
-		NotAfter:              now.Add(kubernetesEngineCAValidity),
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
-	if err != nil {
-		return "", "", err
-	}
-	if err := writePemFile(certPath, "CERTIFICATE", caDER, 0o644); err != nil {
-		return "", "", err
-	}
-	if err := writePemFile(keyPath, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(caKey), 0o600); err != nil {
-		_ = os.Remove(certPath)
+		caKey, err := rsa.GenerateKey(rand.Reader, kubernetesEngineCAKeyBits)
+		if err != nil {
+			return err
+		}
+		serial, err := newCertificateSerialNumber()
+		if err != nil {
+			return err
+		}
+		now := time.Now()
+		caTemplate := &x509.Certificate{
+			SerialNumber: serial,
+			Subject: pkix.Name{
+				CommonName:   fmt.Sprintf("mke-%s-ca", name),
+				Organization: []string{"marmot"},
+			},
+			NotBefore:             now.Add(-time.Hour),
+			NotAfter:              now.Add(kubernetesEngineCAValidity),
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+		}
+		caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+		if err != nil {
+			return err
+		}
+		if err := writePemFile(certPath, "CERTIFICATE", caDER, 0o644); err != nil {
+			return err
+		}
+		if err := writePemFile(keyPath, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(caKey), 0o600); err != nil {
+			_ = os.Remove(certPath)
+			return err
+		}
+		return nil
+	}); err != nil {
 		return "", "", err
 	}
 	return certPath, keyPath, nil
@@ -152,62 +157,67 @@ func IssueKubernetesEngineCertificate(pkiDir, clusterName string, req Kubernetes
 		return "", "", fmt.Errorf("certificate request name contains invalid character %q", r)
 	}
 	certPath, keyPath = KubernetesEngineCertPaths(pkiDir, name, reqName)
-	if certFileExists(certPath) && certFileExists(keyPath) {
-		return certPath, keyPath, nil
-	}
-
-	caCertPath, caKeyPath := KubernetesEngineCAPaths(pkiDir, name)
-	caCert, caKey, err := loadKubernetesEngineCA(caCertPath, caKeyPath)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to load cluster CA: %w", err)
-	}
-
-	var extKeyUsage []x509.ExtKeyUsage
-	switch req.Usage {
-	case KubernetesEngineCertUsageServer:
-		extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
-	case KubernetesEngineCertUsageClient:
-		extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
-	default:
-		return "", "", fmt.Errorf("unknown certificate usage: %v", req.Usage)
-	}
-
-	leafKey, err := rsa.GenerateKey(rand.Reader, kubernetesEngineCertKeyBits)
-	if err != nil {
-		return "", "", err
-	}
-	serial, err := newCertificateSerialNumber()
-	if err != nil {
-		return "", "", err
-	}
-	now := time.Now()
-	leafTemplate := &x509.Certificate{
-		SerialNumber: serial,
-		Subject: pkix.Name{
-			CommonName:   req.CommonName,
-			Organization: []string{"marmot"},
-		},
-		NotBefore:   now.Add(-time.Hour),
-		NotAfter:    now.Add(kubernetesEngineCertValidity),
-		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage: extKeyUsage,
-		DNSNames:    req.DNSNames,
-		IPAddresses: req.IPAddresses,
-	}
-	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
-	if err != nil {
-		return "", "", err
-	}
-
 	dir := kubernetesEngineClusterPkiDir(pkiDir, name)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", "", err
 	}
-	if err := writePemFile(certPath, "CERTIFICATE", leafDER, 0o644); err != nil {
-		return "", "", err
-	}
-	if err := writePemFile(keyPath, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(leafKey), 0o600); err != nil {
-		_ = os.Remove(certPath)
+	if err := withKubernetesEnginePkiLock(filepath.Join(dir, "."+reqName+".lock"), func() error {
+		if certFileExists(certPath) && certFileExists(keyPath) {
+			return nil
+		}
+
+		caCertPath, caKeyPath := KubernetesEngineCAPaths(pkiDir, name)
+		caCert, caKey, err := loadKubernetesEngineCA(caCertPath, caKeyPath)
+		if err != nil {
+			return fmt.Errorf("failed to load cluster CA: %w", err)
+		}
+
+		var extKeyUsage []x509.ExtKeyUsage
+		switch req.Usage {
+		case KubernetesEngineCertUsageServer:
+			extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		case KubernetesEngineCertUsageClient:
+			extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+		default:
+			return fmt.Errorf("unknown certificate usage: %v", req.Usage)
+		}
+
+		leafKey, err := rsa.GenerateKey(rand.Reader, kubernetesEngineCertKeyBits)
+		if err != nil {
+			return err
+		}
+		serial, err := newCertificateSerialNumber()
+		if err != nil {
+			return err
+		}
+		now := time.Now()
+		leafTemplate := &x509.Certificate{
+			SerialNumber: serial,
+			Subject: pkix.Name{
+				CommonName:   req.CommonName,
+				Organization: []string{"marmot"},
+			},
+			NotBefore:   now.Add(-time.Hour),
+			NotAfter:    now.Add(kubernetesEngineCertValidity),
+			KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+			ExtKeyUsage: extKeyUsage,
+			DNSNames:    req.DNSNames,
+			IPAddresses: req.IPAddresses,
+		}
+		leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
+		if err != nil {
+			return err
+		}
+
+		if err := writePemFile(certPath, "CERTIFICATE", leafDER, 0o644); err != nil {
+			return err
+		}
+		if err := writePemFile(keyPath, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(leafKey), 0o600); err != nil {
+			_ = os.Remove(certPath)
+			return err
+		}
+		return nil
+	}); err != nil {
 		return "", "", err
 	}
 	return certPath, keyPath, nil
@@ -216,6 +226,23 @@ func IssueKubernetesEngineCertificate(pkiDir, clusterName string, req Kubernetes
 func newCertificateSerialNumber() (*big.Int, error) {
 	limit := new(big.Int).Lsh(big.NewInt(1), 128)
 	return rand.Int(rand.Reader, limit)
+}
+
+func withKubernetesEnginePkiLock(lockPath string, fn func() error) error {
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	defer lockFile.Close()
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer func() {
+		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	}()
+
+	return fn()
 }
 
 func writePemFile(path, blockType string, der []byte, mode os.FileMode) error {

--- a/pkg/controller/kubernetes-engine-pki_test.go
+++ b/pkg/controller/kubernetes-engine-pki_test.go
@@ -131,6 +131,20 @@ func TestIssueKubernetesEngineCertificateRequiresExistingCA(t *testing.T) {
 	}
 }
 
+func TestIssueKubernetesEngineCertificateRejectsInvalidRequestName(t *testing.T) {
+	pkiDir := t.TempDir()
+	if _, _, err := EnsureKubernetesEngineCA(pkiDir, "demo"); err != nil {
+		t.Fatalf("EnsureKubernetesEngineCA() failed: %v", err)
+	}
+	if _, _, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
+		Name:       "../evil",
+		CommonName: "evil",
+		Usage:      KubernetesEngineCertUsageServer,
+	}); err == nil {
+		t.Fatalf("expected error for invalid certificate request name, got nil")
+	}
+}
+
 func assertCertVerifiesAgainstCA(t *testing.T, caPool *x509.CertPool, certPath string, usage x509.ExtKeyUsage) {
 	t.Helper()
 	certPEM, err := os.ReadFile(certPath)

--- a/pkg/controller/kubernetes-engine-pki_test.go
+++ b/pkg/controller/kubernetes-engine-pki_test.go
@@ -1,0 +1,167 @@
+package controller
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureKubernetesEngineCACreatesAndIsIdempotent(t *testing.T) {
+	pkiDir := t.TempDir()
+
+	certPath, keyPath, err := EnsureKubernetesEngineCA(pkiDir, "demo")
+	if err != nil {
+		t.Fatalf("EnsureKubernetesEngineCA() failed: %v", err)
+	}
+	if !certFileExists(certPath) || !certFileExists(keyPath) {
+		t.Fatalf("CA cert/key were not created: certPath=%s keyPath=%s", certPath, keyPath)
+	}
+
+	firstCert, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("failed to read CA cert: %v", err)
+	}
+
+	// 2回目の呼び出しは再生成せず同じ内容を返す(冪等)こと
+	certPath2, keyPath2, err := EnsureKubernetesEngineCA(pkiDir, "demo")
+	if err != nil {
+		t.Fatalf("EnsureKubernetesEngineCA() second call failed: %v", err)
+	}
+	if certPath2 != certPath || keyPath2 != keyPath {
+		t.Fatalf("paths changed between calls: (%s,%s) vs (%s,%s)", certPath, keyPath, certPath2, keyPath2)
+	}
+	secondCert, err := os.ReadFile(certPath2)
+	if err != nil {
+		t.Fatalf("failed to read CA cert: %v", err)
+	}
+	if string(firstCert) != string(secondCert) {
+		t.Fatalf("CA certificate was regenerated on second call")
+	}
+}
+
+func TestEnsureKubernetesEngineCARejectsInvalidClusterName(t *testing.T) {
+	pkiDir := t.TempDir()
+	if _, _, err := EnsureKubernetesEngineCA(pkiDir, " "); err == nil {
+		t.Fatalf("expected error for empty cluster name, got nil")
+	}
+	if _, _, err := EnsureKubernetesEngineCA(pkiDir, "../etc"); err == nil {
+		t.Fatalf("expected error for invalid cluster name, got nil")
+	}
+}
+
+func TestIssueKubernetesEngineCertificateServerAndClient(t *testing.T) {
+	pkiDir := t.TempDir()
+	caCertPath, _, err := EnsureKubernetesEngineCA(pkiDir, "demo")
+	if err != nil {
+		t.Fatalf("EnsureKubernetesEngineCA() failed: %v", err)
+	}
+	caCertPEM, err := os.ReadFile(caCertPath)
+	if err != nil {
+		t.Fatalf("failed to read CA cert: %v", err)
+	}
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caCertPEM) {
+		t.Fatalf("failed to load CA cert into pool")
+	}
+
+	serverCertPath, serverKeyPath, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
+		Name:        "kube-apiserver",
+		CommonName:  "kube-apiserver",
+		Usage:       KubernetesEngineCertUsageServer,
+		DNSNames:    []string{"localhost"},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+	})
+	if err != nil {
+		t.Fatalf("IssueKubernetesEngineCertificate(server) failed: %v", err)
+	}
+	if !certFileExists(serverCertPath) || !certFileExists(serverKeyPath) {
+		t.Fatalf("server cert/key were not created")
+	}
+	assertCertVerifiesAgainstCA(t, caPool, serverCertPath, x509.ExtKeyUsageServerAuth)
+
+	clientCertPath, clientKeyPath, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
+		Name:       "kubelet-node1",
+		CommonName: "system:node:node1",
+		Usage:      KubernetesEngineCertUsageClient,
+	})
+	if err != nil {
+		t.Fatalf("IssueKubernetesEngineCertificate(client) failed: %v", err)
+	}
+	if !certFileExists(clientCertPath) || !certFileExists(clientKeyPath) {
+		t.Fatalf("client cert/key were not created")
+	}
+	assertCertVerifiesAgainstCA(t, caPool, clientCertPath, x509.ExtKeyUsageClientAuth)
+
+	// 同名での再発行は既存ファイルを再利用する(冪等)こと
+	firstCert, err := os.ReadFile(serverCertPath)
+	if err != nil {
+		t.Fatalf("failed to read server cert: %v", err)
+	}
+	serverCertPath2, serverKeyPath2, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
+		Name:       "kube-apiserver",
+		CommonName: "kube-apiserver",
+		Usage:      KubernetesEngineCertUsageServer,
+	})
+	if err != nil {
+		t.Fatalf("IssueKubernetesEngineCertificate() second call failed: %v", err)
+	}
+	if serverCertPath2 != serverCertPath || serverKeyPath2 != serverKeyPath {
+		t.Fatalf("paths changed between calls")
+	}
+	secondCert, err := os.ReadFile(serverCertPath2)
+	if err != nil {
+		t.Fatalf("failed to read server cert: %v", err)
+	}
+	if string(firstCert) != string(secondCert) {
+		t.Fatalf("server certificate was reissued on second call")
+	}
+}
+
+func TestIssueKubernetesEngineCertificateRequiresExistingCA(t *testing.T) {
+	pkiDir := t.TempDir()
+	if _, _, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
+		Name:       "kube-apiserver",
+		CommonName: "kube-apiserver",
+		Usage:      KubernetesEngineCertUsageServer,
+	}); err == nil {
+		t.Fatalf("expected error when CA does not exist, got nil")
+	}
+}
+
+func assertCertVerifiesAgainstCA(t *testing.T, caPool *x509.CertPool, certPath string, usage x509.ExtKeyUsage) {
+	t.Helper()
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("failed to read cert %s: %v", certPath, err)
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatalf("failed to parse PEM block for %s", certPath)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate %s: %v", certPath, err)
+	}
+	opts := x509.VerifyOptions{
+		Roots:     caPool,
+		KeyUsages: []x509.ExtKeyUsage{usage},
+	}
+	if _, err := cert.Verify(opts); err != nil {
+		t.Fatalf("certificate %s did not verify against CA: %v", certPath, err)
+	}
+}
+
+func TestKubernetesEnginePkiDirLayout(t *testing.T) {
+	pkiDir := t.TempDir()
+	certPath, keyPath, err := EnsureKubernetesEngineCA(pkiDir, "demo")
+	if err != nil {
+		t.Fatalf("EnsureKubernetesEngineCA() failed: %v", err)
+	}
+	wantDir := filepath.Join(pkiDir, "demo")
+	if filepath.Dir(certPath) != wantDir || filepath.Dir(keyPath) != wantDir {
+		t.Fatalf("CA files not under expected dir %s: certPath=%s keyPath=%s", wantDir, certPath, keyPath)
+	}
+}

--- a/pkg/controller/kubernetes-engine-pki_test.go
+++ b/pkg/controller/kubernetes-engine-pki_test.go
@@ -6,7 +6,9 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestEnsureKubernetesEngineCACreatesAndIsIdempotent(t *testing.T) {
@@ -142,6 +144,55 @@ func TestIssueKubernetesEngineCertificateRejectsInvalidRequestName(t *testing.T)
 		Usage:      KubernetesEngineCertUsageServer,
 	}); err == nil {
 		t.Fatalf("expected error for invalid certificate request name, got nil")
+	}
+}
+
+func TestWithKubernetesEnginePkiLockSerializesCallers(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), ".test.lock")
+	started := make(chan struct{})
+	release := make(chan struct{})
+	acquired := make(chan struct{})
+	errCh := make(chan error, 2)
+
+	go func() {
+		errCh <- withKubernetesEnginePkiLock(lockPath, func() error {
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+
+	<-started
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errCh <- withKubernetesEnginePkiLock(lockPath, func() error {
+			close(acquired)
+			return nil
+		})
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatalf("second caller acquired lock before first caller released it")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	wg.Wait()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatalf("second caller did not acquire lock after release")
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("withKubernetesEnginePkiLock() failed: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
### 概要
MEMO-marmot-kubernetes-engine.md のフェーズ5に対応。クラスタ専用CAの生成と、コントロールプレーン/ノード向け証明書の発行ロジックを実装。systemdやkube-apiserver等への組み込みは行わず、単体でテスト可能な形で切り出している。

### 変更内容

**kubernetes-engine-pki.go（新規）**
- `EnsureKubernetesEngineCA(pkiDir, clusterName)`
  - クラスタ専用の自己署名CA（RSA 4096bit、有効期間10年）を `<pkiDir>/<cluster>/ca.crt` / `ca.key` に生成
  - 既に生成済みの場合は再生成せず既存パスを返す（冪等）
- `IssueKubernetesEngineCertificate(pkiDir, clusterName, req)`
  - クラスタ専用CAで署名したリーフ証明書（RSA 2048bit、有効期間1年）を発行
  - `KubernetesEngineCertRequest.Usage` で `ServerAuth`/`ClientAuth` を切り替え、`DNSNames`/`IPAddresses` によるSAN指定に対応
  - 同名の証明書が既に存在する場合は再発行せず既存パスを返す（冪等）
  - CA未生成の場合はエラーを返す
- クラスタ名検証（空文字・`.`/`..`・許可文字（`[A-Za-z0-9._-]`）外を拒否）はフェーズ4のetcd実装と同様のロジックをこのファイル内に独立実装（既存ファイルには手を入れていない）
- 既定の配置先: `DefaultKubernetesEnginePkiDir = "/var/lib/marmot/mke/pki"`

**kubernetes-engine-pki_test.go（新規）**
- CA生成の冪等性、不正クラスタ名の拒否
- サーバー証明書・クライアント証明書の発行と、`x509.Certificate.Verify()` によるCA検証（`ExtKeyUsage` を含む）
- 証明書発行の冪等性、CA未生成時のエラー、ディレクトリ構成（`<pkiDir>/<cluster>/...`）の検証

### スコープ外（後続フェーズ）
- kube-apiserver等への証明書配布・起動連携（フェーズ6）
- ノードVMへの証明書配布（フェーズ7）
- `/marmot/mke/id/client-cert` へのクライアント証明書格納（フェーズ10）
- KubernetesEngineリコンサイルループへの組み込み
- marmot-api-v1.yaml の変更（証明書パスをStatusに記録する要件が明確でないため見送り）

### テスト
```
go build ./...
go vet ./...
gofmt -s -l pkg/controller/kubernetes-engine-pki.go pkg/controller/kubernetes-engine-pki_test.go
go test ./pkg/controller/...
```
いずれも成功（新規追加分は kubernetes-engine-pki.go / `kubernetes-engine-pki_test.go` の2ファイルのみ、既存ファイルへの変更なし）。
