### PR TITLE
MKE実装 フェーズ7: ノードVMプロビジョニング,bumpup guest OS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -318,7 +318,7 @@ jobs:
     - name: mactlコマンドのテスト その１
       run: |
         cd cmd/mactl
-        make mactl-test
+        sudo -E env "PATH=$PATH" make mactl-test
         sudo -E env "PATH=$PATH" make test0
         cd ../..
         sudo -E env "PATH=$PATH" ./tools/cleanup.sh
@@ -343,7 +343,7 @@ jobs:
     - name: mactlコマンドのテスト その１
       run: |
         cd cmd/mactl
-        make mactl-test
+        sudo -E env "PATH=$PATH" make mactl-test
         sudo -E env "PATH=$PATH" make test1
         cd ../..
         sudo -E env "PATH=$PATH" ./tools/cleanup.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -444,11 +444,33 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
+  mke-vm-e2e:
+    runs-on: [ self-hosted, any ]
+    needs:
+      - module-tests-end
+      - system-tests-end
+    if: always()
+    steps:
+    - uses: actions/checkout@v5
+    - name: 仮想ネットワーク作成
+      run: |
+        sudo -E env "PATH=$PATH" ./tools/setup-libvirt-networks.sh
+    - name: MKEノード実VM E2Eテスト
+      run: |
+        cd pkg/marmotd
+        sudo -E env "PATH=$PATH" make test-mke-vm-e2e
+        cd ../..
+    - name: 仮想ネットワーク削除
+      if: always()
+      run: |
+        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+
   final-cleanup:
     runs-on: [ self-hosted, any ]
     needs: 
       - module-tests-end
       - system-tests-end
+      - mke-vm-e2e
     steps:
     - uses: actions/checkout@v5
     - name: 最終クリーンアップ

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
     - name: コンフィグパッケージ
       run: | 
         cd pkg/config
-        sudo -E env "PATH=$PATH" make test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test
         cd ../..
 
   package-etcd-access:
@@ -76,7 +76,7 @@ jobs:
     - name: ETCDのデータアクセス パッケージ
       run: | 
         cd pkg/db
-        sudo -E env "PATH=$PATH" make test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test
         cd ../..
 
   package-qcow2-manipulation:
@@ -92,7 +92,7 @@ jobs:
     - name: QCOW2操作 パッケージ
       run: | 
         cd pkg/qcow
-        sudo -E env "PATH=$PATH" make test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test
         cd ../..
 
   package-util:
@@ -107,15 +107,15 @@ jobs:
     #    go-version: '1.26.2'
     - name: ランナーのセットアップ
       run: |
-        sudo -E env "PATH=$PATH" ./tools/setup.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/setup.sh
     - name: ユーティリティ パッケージ テスト
       run: | 
         cd pkg/util
-        sudo -E env "PATH=$PATH" make test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test
         cd ../..
     - name: ランナーのセットアップ
       run: |
-        sudo -E env "PATH=$PATH" ./tools/cleanup.sh 
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/cleanup.sh 
 
   mactl-command-tests:
     runs-on: [ self-hosted, any ]
@@ -130,7 +130,7 @@ jobs:
     - name: mactl コマンド テスト
       run: |
         cd cmd/mactl
-        sudo -E env "PATH=$PATH" make test-unit
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test-unit
         cd ../..
 
   package-lvm:
@@ -146,7 +146,7 @@ jobs:
     - name: ロジカルボリューム マネージャー 操作パッケージ
       run: | 
         cd pkg/lvm
-        sudo -E env "PATH=$PATH" make test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test
         cd ../..
       
   package-ceph:
@@ -164,7 +164,7 @@ jobs:
     - name: Cephブロックストレージ操作パッケージ
       run: | 
         cd pkg/ceph
-        sudo -E env "PATH=$PATH" make test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test
         cd ../..
 
   package-virsh:
@@ -179,19 +179,19 @@ jobs:
     #    go-version: '1.26.2'
     - name: ランナーのセットアップ
       run: |
-        sudo -E env "PATH=$PATH" ./tools/setup.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/setup.sh
     - name: 仮想ネットワーク作成
       run: | 
-        sudo -E env "PATH=$PATH" ./tools/setup-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/setup-libvirt-networks.sh
     - name: 仮想化操作 パッケージ
       run: | 
         cd pkg/virt
-        sudo -E env "PATH=$PATH" make test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test
         cd ../..
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
 
   package-marmotd-volume:
     runs-on: [ self-hosted, any ]
@@ -206,8 +206,8 @@ jobs:
     - name: Test pkg/marmotd ボリューム機能テスト
       run: |
         cd pkg/marmotd
-        sudo -E env "PATH=$PATH" make test-volume
-        sudo -E env "PATH=$PATH" make test-ceph
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test-volume
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test-ceph
         cd ../..
 
   package-marmotd-server:
@@ -222,16 +222,16 @@ jobs:
     #    go-version: '1.26.2'
     - name: 仮想ネットワーク作成
       run: | 
-        sudo -E env "PATH=$PATH" ./tools/setup-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/setup-libvirt-networks.sh
     - name: Test pkg/marmotd サーバー機能テスト
       run: |
         cd pkg/marmotd
-        sudo -E env "PATH=$PATH" make test-server
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test-server
         cd ../..
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
 
   package-marmotd-etc:
     runs-on: [ self-hosted, any ]
@@ -246,7 +246,7 @@ jobs:
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
     - name: Test pkg/marmotd ネットワーク機能テスト
       run: |
         cd pkg/marmotd
@@ -261,7 +261,7 @@ jobs:
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
 
   package-marmotd-images:
     runs-on: [ self-hosted, any ]
@@ -275,7 +275,7 @@ jobs:
     #    go-version: '1.26.2'
     - name: 仮想ネットワーク作成
       run: | 
-        sudo -E env "PATH=$PATH" ./tools/setup-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/setup-libvirt-networks.sh
     - name: Test pkg/marmotd サーバーとイメージ機能テスト
       run: |
         cd pkg/marmotd
@@ -284,7 +284,7 @@ jobs:
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
  
   package-marmotd-osimage:
     runs-on: [ self-hosted, any ]
@@ -314,18 +314,18 @@ jobs:
     #    go-version: '1.26.2'
     - name: 仮想ネットワーク作成
       run: |
-        sudo -E env "PATH=$PATH" ./tools/setup-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/setup-libvirt-networks.sh
     - name: mactlコマンドのテスト その１
       run: |
         cd cmd/mactl
-        sudo -E env "PATH=$PATH" make mactl-test
-        sudo -E env "PATH=$PATH" make test0
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make mactl-test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test0
         cd ../..
-        sudo -E env "PATH=$PATH" ./tools/cleanup.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/cleanup.sh
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
 
   mactl-vm-deploy-1:
     runs-on: [ self-hosted, any ]
@@ -339,18 +339,18 @@ jobs:
     #    go-version: '1.26.2'
     - name: 仮想ネットワーク作成
       run: |
-        sudo -E env "PATH=$PATH" ./tools/setup-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/setup-libvirt-networks.sh
     - name: mactlコマンドのテスト その１
       run: |
         cd cmd/mactl
-        sudo -E env "PATH=$PATH" make mactl-test
-        sudo -E env "PATH=$PATH" make test1
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make mactl-test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test1
         cd ../..
-        sudo -E env "PATH=$PATH" ./tools/cleanup.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/cleanup.sh
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
 
   mactl-vm-deploy-2:
     runs-on: [ self-hosted, any ]
@@ -365,18 +365,18 @@ jobs:
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
     - name: mactlコマンドのテスト その２
       run: |
         cd cmd/mactl
-        sudo -E env "PATH=$PATH" make mactl-test
-        sudo -E env "PATH=$PATH" make test2
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make mactl-test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test2
         cd ../..
-        sudo -E env "PATH=$PATH" ./tools/cleanup.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/cleanup.sh
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
 
   mactl-vm-deploy-3:
     runs-on: [ self-hosted, any ]
@@ -391,18 +391,18 @@ jobs:
     - name: 仮想ネットワーク削除
       if: always()
       run: | 
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
     - name: mactlコマンドのテスト その３
       run: | 
         cd cmd/mactl
-        sudo -E env "PATH=$PATH" make mactl-test
-        sudo -E env "PATH=$PATH" make test3
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make mactl-test
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test3
         cd ../..
-        sudo -E env "PATH=$PATH" ./tools/cleanup.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/cleanup.sh
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
 
 
     #- name: Test cmd/maadm
@@ -411,7 +411,7 @@ jobs:
     #    sudo -s mkdir -p bin
     #    sudo -s chown ubuntu:ubuntu bin
     #    sudo -s chmod 755 bin
-    #    sudo -E env "PATH=$PATH" make test
+    #    sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test
     #    sudo rm -fr bin
     #    cd ../..
  
@@ -454,16 +454,16 @@ jobs:
     - uses: actions/checkout@v5
     - name: 仮想ネットワーク作成
       run: |
-        sudo -E env "PATH=$PATH" ./tools/setup-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/setup-libvirt-networks.sh
     - name: MKEノード実VM E2Eテスト
       run: |
         cd pkg/marmotd
-        sudo -E env "PATH=$PATH" make test-mke-vm-e2e
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make test-mke-vm-e2e
         cd ../..
     - name: 仮想ネットワーク削除
       if: always()
       run: |
-        sudo -E env "PATH=$PATH" ./tools/teardown-libvirt-networks.sh
+        sudo env PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin ./tools/teardown-libvirt-networks.sh
 
   final-cleanup:
     runs-on: [ self-hosted, any ]

--- a/cmd/maadm/testdata/cluster-config1.yaml
+++ b/cmd/maadm/testdata/cluster-config1.yaml
@@ -1,5 +1,5 @@
 domain: labo.local
-os_variant:  ubuntu22.04
+os_variant:  ubuntu24.04
 cluster_name: test
 vm_spec:
   - name: "srv1"

--- a/cmd/maadm/testdata/cluster-config2.yaml
+++ b/cmd/maadm/testdata/cluster-config2.yaml
@@ -1,5 +1,5 @@
 domain: labo.local
-os_variant:  ubuntu22.04
+os_variant:  ubuntu24.04
 cluster_name: test
 vm_spec:
   - name: "srv3"

--- a/cmd/maadm/testdata/hypervisor-config-hvc.yaml
+++ b/cmd/maadm/testdata/hypervisor-config-hvc.yaml
@@ -16,7 +16,7 @@ image_template:
   - name: "ubuntu20.04"
     volumegroup: "vg1"
     logicalvolume: "lv01"
-  - name: "ubuntu22.04"
+  - name: "ubuntu24.04"
     volumegroup: "vg1"
     logicalvolume: "lv02"
 

--- a/cmd/mactl/cmd/image_export_test.go
+++ b/cmd/mactl/cmd/image_export_test.go
@@ -97,10 +97,10 @@ var _ = Describe("pickExportableImageByName", func() {
 var _ = Describe("writeImageArchive / extractFromTGZ round-trip", func() {
 	It("preserves osName and osVersion in the archive", func() {
 		image := api.Image{
-			Metadata: api.Metadata{Name: "ubuntu22.04"},
+			Metadata: api.Metadata{Name: "ubuntu24.04"},
 			Spec: api.ImageSpec{
 				OsName:    util.StringPtr("ubuntu"),
-				OsVersion: util.StringPtr("22.04"),
+				OsVersion: util.StringPtr("24.04"),
 			},
 		}
 		qcow2Data := []byte("fake-qcow2-data")
@@ -141,6 +141,6 @@ var _ = Describe("writeImageArchive / extractFromTGZ round-trip", func() {
 		}
 		Expect(foundMeta).To(BeTrue())
 		Expect(meta.OsName).To(Equal("ubuntu"))
-		Expect(meta.OsVersion).To(Equal("22.04"))
+		Expect(meta.OsVersion).To(Equal("24.04"))
 	})
 })

--- a/cmd/mactl/cmd/manifest_test.go
+++ b/cmd/mactl/cmd/manifest_test.go
@@ -231,14 +231,14 @@ spec:
 		It("keeps spec.mmImage in sync when only spec.osVariant is set", func() {
 			server := &api.Server{
 				Spec: api.ServerSpec{
-					OsVariant: util.StringPtr("ubuntu22.04"),
+					OsVariant: util.StringPtr("ubuntu24.04"),
 				},
 			}
 
 			ApplyServerDefaults(server)
 
 			Expect(server.Spec.MmImage).NotTo(BeNil())
-			Expect(*server.Spec.MmImage).To(Equal("ubuntu22.04"))
+			Expect(*server.Spec.MmImage).To(Equal("ubuntu24.04"))
 		})
 
 		Describe("ManifestToImage", func() {

--- a/cmd/mactl/mactl-ceph-lifecycle_test.go
+++ b/cmd/mactl/mactl-ceph-lifecycle_test.go
@@ -157,7 +157,7 @@ metadata:
 spec:
   cpu: 2
   memory: 2048
-  osVariant: ubuntu22.04
+  osVariant: ubuntu24.04
   bootVolume:
     spec:
       type: qcow2

--- a/cmd/mactl/testdata/test-image-01-ubuntu22.yaml
+++ b/cmd/mactl/testdata/test-image-01-ubuntu22.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Image
 metadata:
-    name: ubuntu22.04
+    name: ubuntu24.04
 spec:
-    sourceUrl: http://hmc/ubuntu-22.04-server-cloudimg-amd64.img
+    sourceUrl: http://hmc/ubuntu-24.04-server-cloudimg-amd64.img
     osName: ubuntu
-    osVersion: "22.04"
+    osVersion: "24.04"

--- a/cmd/mactl/testdata/test-server-04-multi-vol-qcow2.yaml
+++ b/cmd/mactl/testdata/test-server-04-multi-vol-qcow2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 2
     memory: 2048
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     bootVolume:
         spec:
             type: qcow2

--- a/cmd/mactl/testdata/test-server-05-boot-lvm.yaml
+++ b/cmd/mactl/testdata/test-server-05-boot-lvm.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 2
     memory: 2048
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     bootVolume:
         spec:
             type: lvm

--- a/cmd/mactl/testdata/test-server-06-multivol-lvm.yaml
+++ b/cmd/mactl/testdata/test-server-06-multivol-lvm.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 2
     memory: 2048
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     bootVolume:
         spec:
             type: lvm

--- a/cmd/mactl/testdata/test-server-1.yaml
+++ b/cmd/mactl/testdata/test-server-1.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 2
     memory: 2048
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     bootVolume:
         spec:
             type: qcow2

--- a/cmd/mactl/testdata/test-server-2.yaml
+++ b/cmd/mactl/testdata/test-server-2.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 2
     memory: 2048
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     bootVolume:
         spec:
             type: lvm

--- a/cmd/mactl/testdata/test-server-29-multihome.yaml
+++ b/cmd/mactl/testdata/test-server-29-multihome.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 1
     memory: 1024
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     networkInterface:
         - networkname: "test-net-2"
         - networkname: "test-net-1"

--- a/cmd/mactl/testdata/test-server-30-multihome.yaml
+++ b/cmd/mactl/testdata/test-server-30-multihome.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 1
     memory: 1024
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     networkInterface:
         - networkname: "test-net-2"
         - networkname: "test-net-1"

--- a/cmd/mactl/testdata/test-server-30-multivolume.yaml
+++ b/cmd/mactl/testdata/test-server-30-multivolume.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 1
     memory: 1024
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     networkInterface:
         - networkname: "test-net-2"
         - networkname: "test-net-1"

--- a/cmd/mactl/testdata/test-server-31-multihome-host-bridge.yaml
+++ b/cmd/mactl/testdata/test-server-31-multihome-host-bridge.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 1
     memory: 1024
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     networkInterface:
         - networkname: "host-bridge"
           address: "192.168.1.191"

--- a/cmd/mactl/testdata/test-server-32-multihome-host-bridge.yaml
+++ b/cmd/mactl/testdata/test-server-32-multihome-host-bridge.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 1
     memory: 1024
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     networkInterface:
         - networkname: "host-bridge"
           address: "192.168.1.192"

--- a/cmd/mactl/testdata/test-server-33-multihome-host-bridge.yaml
+++ b/cmd/mactl/testdata/test-server-33-multihome-host-bridge.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 4
     memory: 8192
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     networkInterface:
         - networkname: "host-bridge"
           address: "192.168.1.191"

--- a/cmd/mactl/testdata/test-server-34-sshkey.yaml
+++ b/cmd/mactl/testdata/test-server-34-sshkey.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 1
     memory: 1024
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     auth:
         url: https://github.com/takara9.keys
     networkInterface:

--- a/cmd/mactl/testdata/test-server-35-sshkey.yaml
+++ b/cmd/mactl/testdata/test-server-35-sshkey.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 1
     memory: 1024
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     bootVolume:
         spec:
             type: lvm

--- a/cmd/mactl/testdata/test-server-36-existing-volume-id.yaml
+++ b/cmd/mactl/testdata/test-server-36-existing-volume-id.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 1
     memory: 1024
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     bootVolume:
         id: "b7fd113"
         metadata:

--- a/cmd/mactl/testdata/test-server-40-ceph-block.yaml
+++ b/cmd/mactl/testdata/test-server-40-ceph-block.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 1
     memory: 1048
-    mmImage: ubuntu22.04
+    mmImage: ubuntu24.04
     auth:
         url: https://github.com/takara9.keys
     networkInterface:

--- a/cmd/mactl/testdata/test-server-99.yaml
+++ b/cmd/mactl/testdata/test-server-99.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     cpu: 2
     memory: 2048
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04
     bootVolume:
         spec:
             type: qcow2

--- a/cmd/mactl/testdata/test-volume-03-os-qcow2.yaml
+++ b/cmd/mactl/testdata/test-volume-03-os-qcow2.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
     type: qcow2
     kind: os
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04

--- a/cmd/mactl/testdata/test-volume-04-os-lvm.yaml
+++ b/cmd/mactl/testdata/test-volume-04-os-lvm.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
     type: lvm
     kind: os
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04

--- a/cmd/mactl/testdata/test-volume-06-boot-qcow2.yaml
+++ b/cmd/mactl/testdata/test-volume-06-boot-qcow2.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
     type: qcow2
     kind: os
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04

--- a/cmd/mactl/testdata/test-volume-07-os-lvm-success.yaml
+++ b/cmd/mactl/testdata/test-volume-07-os-lvm-success.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
     type: lvm
     kind: os
-    osVariant: ubuntu22.04
+    osVariant: ubuntu24.04

--- a/cmd/marmotd/marmotd-main.go
+++ b/cmd/marmotd/marmotd-main.go
@@ -228,7 +228,7 @@ func main() {
 
 	// Use TLS if both cert and key are configured, otherwise use HTTP.
 	if cfg.TLSCertFile != "" && cfg.TLSKeyFile != "" {
-		slog.Info("Starting API server with TLS", "addr", cfg.APIListenAddr, "cert", cfg.TLSCertFile, "key", cfg.TLSKeyFile)
+		slog.Debug("Starting API server with TLS", "addr", cfg.APIListenAddr, "cert", cfg.TLSCertFile, "key", cfg.TLSKeyFile)
 		if err := e.StartTLS(cfg.APIListenAddr, cfg.TLSCertFile, cfg.TLSKeyFile); err != nil {
 			slog.Error("API server stopped", "err", err)
 			return

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,7 +16,7 @@ var _ = Describe("ReadYamlConfig", func() {
 	It("decodes lowerCamel keys like apiVersion and sourceUrl", func() {
 		tmpDir := GinkgoT().TempDir()
 		configPath := filepath.Join(tmpDir, "image.yaml")
-		content := "apiVersion: v1\nkind: Image\nmetadata:\n  name: ubuntu22.04\nspec:\n  sourceUrl: http://hmc/ubuntu-22.04-server-cloudimg-amd64.img\n  osName: ubuntu\n  osVersion: \"24.04\"\n"
+		content := "apiVersion: v1\nkind: Image\nmetadata:\n  name: ubuntu24.04\nspec:\n  sourceUrl: http://hmc/ubuntu-24.04-server-cloudimg-amd64.img\n  osName: ubuntu\n  osVersion: \"24.04\"\n"
 
 		err := os.WriteFile(configPath, []byte(content), 0o600)
 		Expect(err).NotTo(HaveOccurred())
@@ -26,9 +26,9 @@ var _ = Describe("ReadYamlConfig", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(conf.ApiVersion).To(Equal("v1"))
 		Expect(conf.Kind).To(Equal("Image"))
-		Expect(conf.Metadata.Name).To(Equal("ubuntu22.04"))
+		Expect(conf.Metadata.Name).To(Equal("ubuntu24.04"))
 		Expect(conf.Spec.SourceUrl).NotTo(BeNil())
-		Expect(*conf.Spec.SourceUrl).To(Equal("http://hmc/ubuntu-22.04-server-cloudimg-amd64.img"))
+		Expect(*conf.Spec.SourceUrl).To(Equal("http://hmc/ubuntu-24.04-server-cloudimg-amd64.img"))
 		Expect(conf.Spec.OsName).NotTo(BeNil())
 		Expect(*conf.Spec.OsName).To(Equal("ubuntu"))
 		Expect(conf.Spec.OsVersion).NotTo(BeNil())

--- a/pkg/controller/ansible-playbook-log.go
+++ b/pkg/controller/ansible-playbook-log.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -67,6 +68,31 @@ func sanitizeLogToken(value, fallback string) string {
 	return clean
 }
 
+// ansiblePlaybookLineLogger は ansible-playbook の標準出力/標準エラーを1行ずつ slog.Info へ流し、
+// 長時間実行中もCIログ等でリアルタイムに進捗を確認できるようにする。
+type ansiblePlaybookLineLogger struct {
+	resourceName string
+	resourceID   string
+	pending      []byte
+}
+
+func (l *ansiblePlaybookLineLogger) Write(p []byte) (int, error) {
+	l.pending = append(l.pending, p...)
+	for {
+		idx := bytes.IndexByte(l.pending, '\n')
+		if idx < 0 {
+			break
+		}
+		line := strings.TrimRight(string(l.pending[:idx]), "\r")
+		l.pending = l.pending[idx+1:]
+		if line == "" {
+			continue
+		}
+		slog.Info("ansible-playbook progress", "resource", l.resourceName, "id", l.resourceID, "line", line)
+	}
+	return len(p), nil
+}
+
 func runAnsiblePlaybookWithLogging(args []string, resourceName, resourceID string) error {
 	logPath, err := ansiblePlaybookLogPath(resourceName, resourceID)
 	if err != nil {
@@ -84,9 +110,13 @@ func runAnsiblePlaybookWithLogging(args []string, resourceName, resourceID strin
 	_, _ = fmt.Fprintf(logFile, "\n=== %s ansible-playbook %s ===\n", time.Now().UTC().Format(time.RFC3339), strings.Join(args, " "))
 
 	var buf bytes.Buffer
-	mw := io.MultiWriter(&buf, logFile)
+	lineLogger := &ansiblePlaybookLineLogger{resourceName: resourceName, resourceID: resourceID}
+	mw := io.MultiWriter(&buf, logFile, lineLogger)
 
 	cmd := exec.Command("ansible-playbook", args...)
+	// PYTHONUNBUFFERED を指定しないと、パイプ接続時に ansible-playbook (Python) の出力がブロック単位で
+	// バッファされ、実行完了までラインロガーへ何も流れない。
+	cmd.Env = append(os.Environ(), "PYTHONUNBUFFERED=1")
 	cmd.Stdout = mw
 	cmd.Stderr = mw
 	if err := cmd.Run(); err != nil {

--- a/pkg/controller/ansible-playbook-log.go
+++ b/pkg/controller/ansible-playbook-log.go
@@ -68,7 +68,7 @@ func sanitizeLogToken(value, fallback string) string {
 	return clean
 }
 
-// ansiblePlaybookLineLogger は ansible-playbook の標準出力/標準エラーを1行ずつ slog.Info へ流し、
+// ansiblePlaybookLineLogger は ansible-playbook の標準出力/標準エラーを1行ずつ slog.Debug へ流し、
 // 長時間実行中もCIログ等でリアルタイムに進捗を確認できるようにする。
 type ansiblePlaybookLineLogger struct {
 	resourceName string
@@ -88,7 +88,7 @@ func (l *ansiblePlaybookLineLogger) Write(p []byte) (int, error) {
 		if line == "" {
 			continue
 		}
-		slog.Info("ansible-playbook progress", "resource", l.resourceName, "id", l.resourceID, "line", line)
+		slog.Debug("ansible-playbook progress", "resource", l.resourceName, "id", l.resourceID, "line", line)
 	}
 	return len(p), nil
 }

--- a/pkg/controller/kubernetes-engine-control-plane-assets_test.go
+++ b/pkg/controller/kubernetes-engine-control-plane-assets_test.go
@@ -5,47 +5,35 @@ import (
 	"encoding/pem"
 	"net"
 	"os"
-	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestEnsureKubernetesEngineControlPlaneAssets(t *testing.T) {
-	assets, err := EnsureKubernetesEngineControlPlaneAssets(t.TempDir(), t.TempDir(), "demo", "172.16.90.100", 6443)
-	if err != nil {
-		t.Fatalf("EnsureKubernetesEngineControlPlaneAssets() failed: %v", err)
-	}
-	certPEM, err := os.ReadFile(assets.APIServerCertPath)
-	if err != nil {
-		t.Fatalf("failed to read API server cert: %v", err)
-	}
-	block, _ := pem.Decode(certPEM)
-	if block == nil {
-		t.Fatalf("failed to decode API server cert")
-	}
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		t.Fatalf("failed to parse API server cert: %v", err)
-	}
-	if !containsIP(cert.IPAddresses, "172.16.90.100") || !containsIP(cert.IPAddresses, "127.0.0.1") {
-		t.Fatalf("API server cert IP SANs = %v", cert.IPAddresses)
-	}
-	if !containsString(cert.DNSNames, "kubernetes.default.svc") {
-		t.Fatalf("API server cert DNS SANs = %v", cert.DNSNames)
-	}
+var _ = Describe("EnsureKubernetesEngineControlPlaneAssets", func() {
+	It("issues API server certs and scheduler/controller-manager kubeconfigs", func() {
+		assets, err := EnsureKubernetesEngineControlPlaneAssets(GinkgoT().TempDir(), GinkgoT().TempDir(), "demo", "172.16.90.100", 6443)
+		Expect(err).NotTo(HaveOccurred())
 
-	for _, path := range []string{assets.SchedulerKubeconfigPath, assets.ControllerManagerConfigPath} {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("failed to read kubeconfig %s: %v", path, err)
+		certPEM, err := os.ReadFile(assets.APIServerCertPath)
+		Expect(err).NotTo(HaveOccurred())
+		block, _ := pem.Decode(certPEM)
+		Expect(block).NotTo(BeNil())
+		cert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(containsIP(cert.IPAddresses, "172.16.90.100")).To(BeTrue())
+		Expect(containsIP(cert.IPAddresses, "127.0.0.1")).To(BeTrue())
+		Expect(containsString(cert.DNSNames, "kubernetes.default.svc")).To(BeTrue())
+
+		for _, path := range []string{assets.SchedulerKubeconfigPath, assets.ControllerManagerConfigPath} {
+			data, err := os.ReadFile(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).To(ContainSubstring("https://172.16.90.100:6443"))
 		}
-		if !strings.Contains(string(data), "https://172.16.90.100:6443") {
-			t.Fatalf("kubeconfig %s does not reference API server: %s", path, data)
-		}
-	}
-	if !certFileExists(assets.ServiceAccountPublicKeyPath) || !certFileExists(assets.ServiceAccountPrivateKeyPath) {
-		t.Fatalf("service-account keys were not created")
-	}
-}
+		Expect(certFileExists(assets.ServiceAccountPublicKeyPath)).To(BeTrue())
+		Expect(certFileExists(assets.ServiceAccountPrivateKeyPath)).To(BeTrue())
+	})
+})
 
 func containsIP(values []net.IP, want string) bool {
 	for _, value := range values {

--- a/pkg/controller/kubernetes-engine-control-plane-binary_test.go
+++ b/pkg/controller/kubernetes-engine-control-plane-binary_test.go
@@ -6,90 +6,79 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestResolveKubernetesPatchVersion(t *testing.T) {
-	origDownload := kubernetesDownload
-	t.Cleanup(func() { kubernetesDownload = origDownload })
-	kubernetesDownload = func(rawURL string) ([]byte, error) {
-		if rawURL != kubernetesReleaseBaseURL+"/stable-1.36.txt" {
-			t.Fatalf("unexpected URL: %s", rawURL)
-		}
-		return []byte("v1.36.7\n"), nil
-	}
-
-	for _, input := range []string{"1.36", "v1.36", "v1.36.2"} {
-		resolved, err := ResolveKubernetesPatchVersion(input)
-		if err != nil {
-			t.Fatalf("ResolveKubernetesPatchVersion(%q) failed: %v", input, err)
-		}
-		if resolved != "v1.36.7" {
-			t.Fatalf("resolved = %q, want %q", resolved, "v1.36.7")
-		}
-	}
-}
-
-func TestEnsureKubernetesControlPlaneBinariesDownloadsAndCaches(t *testing.T) {
-	origDownload := kubernetesDownload
-	t.Cleanup(func() { kubernetesDownload = origDownload })
-	binaryDownloads := 0
-	kubernetesDownload = func(rawURL string) ([]byte, error) {
-		if strings.HasSuffix(rawURL, "stable-1.36.txt") {
+var _ = Describe("KubernetesControlPlaneBinaries", func() {
+	It("resolves a Kubernetes minor version to its latest patch version", func() {
+		origDownload := kubernetesDownload
+		DeferCleanup(func() { kubernetesDownload = origDownload })
+		var gotURL string
+		kubernetesDownload = func(rawURL string) ([]byte, error) {
+			gotURL = rawURL
 			return []byte("v1.36.7\n"), nil
 		}
-		for _, binaryName := range kubernetesControlPlaneBinaries {
-			if strings.HasSuffix(rawURL, "/"+binaryName) {
-				binaryDownloads++
-				return []byte("binary-" + binaryName), nil
+
+		for _, input := range []string{"1.36", "v1.36", "v1.36.2"} {
+			resolved, err := ResolveKubernetesPatchVersion(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gotURL).To(Equal(kubernetesReleaseBaseURL + "/stable-1.36.txt"))
+			Expect(resolved).To(Equal("v1.36.7"))
+		}
+	})
+
+	It("downloads control-plane binaries and caches them across calls", func() {
+		origDownload := kubernetesDownload
+		DeferCleanup(func() { kubernetesDownload = origDownload })
+		binaryDownloads := 0
+		kubernetesDownload = func(rawURL string) ([]byte, error) {
+			if strings.HasSuffix(rawURL, "stable-1.36.txt") {
+				return []byte("v1.36.7\n"), nil
 			}
-			if strings.HasSuffix(rawURL, "/"+binaryName+".sha256") {
-				sum := sha256.Sum256([]byte("binary-" + binaryName))
-				return []byte(hex.EncodeToString(sum[:]) + "\n"), nil
+			for _, binaryName := range kubernetesControlPlaneBinaries {
+				if strings.HasSuffix(rawURL, "/"+binaryName) {
+					binaryDownloads++
+					return []byte("binary-" + binaryName), nil
+				}
+				if strings.HasSuffix(rawURL, "/"+binaryName+".sha256") {
+					sum := sha256.Sum256([]byte("binary-" + binaryName))
+					return []byte(hex.EncodeToString(sum[:]) + "\n"), nil
+				}
 			}
+			return nil, fmt.Errorf("unexpected URL %s", rawURL)
 		}
-		return nil, fmt.Errorf("unexpected URL %s", rawURL)
-	}
 
-	cacheDir := t.TempDir()
-	resolved, paths, err := EnsureKubernetesControlPlaneBinaries(cacheDir, "v1.36.2")
-	if err != nil {
-		t.Fatalf("EnsureKubernetesControlPlaneBinaries() failed: %v", err)
-	}
-	if resolved != "v1.36.7" || len(paths) != 3 {
-		t.Fatalf("resolved=%q paths=%v", resolved, paths)
-	}
-	for name, path := range paths {
-		info, err := os.Stat(path)
-		if err != nil {
-			t.Fatalf("binary %s not written: %v", name, err)
+		cacheDir := GinkgoT().TempDir()
+		resolved, paths, err := EnsureKubernetesControlPlaneBinaries(cacheDir, "v1.36.2")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resolved).To(Equal("v1.36.7"))
+		Expect(paths).To(HaveLen(3))
+		for name, path := range paths {
+			info, err := os.Stat(path)
+			Expect(err).NotTo(HaveOccurred(), "binary %s not written", name)
+			Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o755)))
 		}
-		if info.Mode().Perm() != 0o755 {
-			t.Fatalf("binary %s mode = %o, want 755", name, info.Mode().Perm())
-		}
-	}
 
-	if _, _, err := EnsureKubernetesControlPlaneBinaries(cacheDir, "v1.36"); err != nil {
-		t.Fatalf("cached EnsureKubernetesControlPlaneBinaries() failed: %v", err)
-	}
-	if binaryDownloads != 3 {
-		t.Fatalf("binary downloads = %d, want 3", binaryDownloads)
-	}
-}
+		_, _, err = EnsureKubernetesControlPlaneBinaries(cacheDir, "v1.36")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(binaryDownloads).To(Equal(3))
+	})
 
-func TestEnsureKubernetesControlPlaneBinariesRejectsChecksumMismatch(t *testing.T) {
-	origDownload := kubernetesDownload
-	t.Cleanup(func() { kubernetesDownload = origDownload })
-	kubernetesDownload = func(rawURL string) ([]byte, error) {
-		if strings.HasSuffix(rawURL, ".txt") {
-			return []byte("v1.36.7"), nil
+	It("rejects a checksum mismatch", func() {
+		origDownload := kubernetesDownload
+		DeferCleanup(func() { kubernetesDownload = origDownload })
+		kubernetesDownload = func(rawURL string) ([]byte, error) {
+			if strings.HasSuffix(rawURL, ".txt") {
+				return []byte("v1.36.7"), nil
+			}
+			if strings.HasSuffix(rawURL, ".sha256") {
+				return []byte(strings.Repeat("0", 64)), nil
+			}
+			return []byte("binary"), nil
 		}
-		if strings.HasSuffix(rawURL, ".sha256") {
-			return []byte(strings.Repeat("0", 64)), nil
-		}
-		return []byte("binary"), nil
-	}
-	if _, _, err := EnsureKubernetesControlPlaneBinaries(t.TempDir(), "v1.36"); err == nil {
-		t.Fatalf("expected checksum mismatch, got nil")
-	}
-}
+		_, _, err := EnsureKubernetesControlPlaneBinaries(GinkgoT().TempDir(), "v1.36")
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/controller/kubernetes-engine-control-plane-network_linux.go
+++ b/pkg/controller/kubernetes-engine-control-plane-network_linux.go
@@ -34,6 +34,9 @@ var (
 	}
 	controlPlaneCreateNamespace = createControlPlaneNamespace
 	controlPlaneDeleteNamespace = netns.DeleteNamed
+	controlPlaneRunIP           = func(args ...string) ([]byte, error) {
+		return exec.Command("ip", args...).CombinedOutput()
+	}
 	controlPlaneCreateVeth      = createControlPlaneVeth
 	controlPlaneAddOVSPort      = func(bridge, port string) error {
 		output, err := exec.Command("ovs-vsctl", "--may-exist", "add-port", bridge, port).CombinedOutput()
@@ -140,11 +143,11 @@ func TeardownKubernetesEngineControlPlaneNetwork(cfg KubernetesEngineControlPlan
 }
 
 func createControlPlaneNamespace(name string) error {
-	handle, err := netns.NewNamed(name)
+	output, err := controlPlaneRunIP("netns", "add", name)
 	if err != nil {
-		return err
+		return fmt.Errorf("ip netns add failed: %w (output=%s)", err, strings.TrimSpace(string(output)))
 	}
-	return handle.Close()
+	return nil
 }
 
 func createControlPlaneVeth(hostName, peerName string) error {

--- a/pkg/controller/kubernetes-engine-control-plane-network_linux.go
+++ b/pkg/controller/kubernetes-engine-control-plane-network_linux.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"runtime"
 	"strings"
+	"time"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -203,4 +205,74 @@ func configureControlPlanePeer(namespace, peerName, interfaceName, cidr string) 
 		return err
 	}
 	return handle.LinkSetUp(loopback)
+}
+
+var (
+	dialNamespaceGetCurrent = netns.Get
+	dialNamespaceGetByName  = netns.GetFromName
+	dialNamespaceSet        = netns.Set
+	dialNamespaceNetDial    = func(network, address string, timeout time.Duration) (net.Conn, error) {
+		return net.DialTimeout(network, address, timeout)
+	}
+)
+
+type kubernetesEngineNamespaceDialResult struct {
+	conn net.Conn
+	err  error
+}
+
+// DialInKubernetesEngineNetworkNamespace は指定されたネットワーク名前空間の中でTCP接続を確立する。
+// namespaceが空の場合は現在の名前空間からダイヤルする。コントロールプレーン用に作成済みの
+// netns(veth経由でOVSブリッジに接続済み)を再利用し、ノード間通信用ネットワーク上のIPへの
+// 到達性をホスト側プロセスからも得るために使用する。
+func DialInKubernetesEngineNetworkNamespace(namespace, network, address string, timeout time.Duration) (net.Conn, error) {
+	if strings.TrimSpace(namespace) == "" {
+		return dialNamespaceNetDial(network, address, timeout)
+	}
+
+	resultCh := make(chan kubernetesEngineNamespaceDialResult, 1)
+	go func() {
+		// 名前空間の切り替えは呼び出しスレッド全体に影響するため、
+		// 他のgoroutineに影響しないよう専用OSスレッドに固定する。
+		runtime.LockOSThread()
+
+		origNS, err := dialNamespaceGetCurrent()
+		if err != nil {
+			runtime.UnlockOSThread()
+			resultCh <- kubernetesEngineNamespaceDialResult{err: fmt.Errorf("failed to get current network namespace: %w", err)}
+			return
+		}
+		defer func() { _ = origNS.Close() }()
+
+		targetNS, err := dialNamespaceGetByName(namespace)
+		if err != nil {
+			runtime.UnlockOSThread()
+			resultCh <- kubernetesEngineNamespaceDialResult{err: fmt.Errorf("failed to open network namespace %s: %w", namespace, err)}
+			return
+		}
+		defer func() { _ = targetNS.Close() }()
+
+		if err := dialNamespaceSet(targetNS); err != nil {
+			runtime.UnlockOSThread()
+			resultCh <- kubernetesEngineNamespaceDialResult{err: fmt.Errorf("failed to enter network namespace %s: %w", namespace, err)}
+			return
+		}
+
+		conn, dialErr := dialNamespaceNetDial(network, address, timeout)
+
+		if restoreErr := dialNamespaceSet(origNS); restoreErr != nil {
+			// 元の名前空間へ復帰できなかったOSスレッドは再利用させず終了させる(UnlockOSThreadを呼ばない)。
+			if conn != nil {
+				_ = conn.Close()
+			}
+			resultCh <- kubernetesEngineNamespaceDialResult{err: fmt.Errorf("failed to restore original network namespace: %w", restoreErr)}
+			return
+		}
+
+		runtime.UnlockOSThread()
+		resultCh <- kubernetesEngineNamespaceDialResult{conn: conn, err: dialErr}
+	}()
+
+	result := <-resultCh
+	return result.conn, result.err
 }

--- a/pkg/controller/kubernetes-engine-control-plane-network_linux.go
+++ b/pkg/controller/kubernetes-engine-control-plane-network_linux.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/vishvananda/netlink"
@@ -169,26 +168,20 @@ func configureControlPlanePeer(namespace, peerName, interfaceName, cidr string) 
 		return err
 	}
 
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	original, err := netns.Get()
+	handle, err := netlink.NewHandleAt(target)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = original.Close() }()
-	if err := netns.Set(target); err != nil {
-		return err
-	}
-	defer func() { _ = netns.Set(original) }()
+	defer handle.Delete()
 
-	link, err := netlink.LinkByName(peerName)
+	link, err := handle.LinkByName(peerName)
 	if err != nil {
 		return err
 	}
-	if err := netlink.LinkSetName(link, interfaceName); err != nil {
+	if err := handle.LinkSetName(link, interfaceName); err != nil {
 		return err
 	}
-	link, err = netlink.LinkByName(interfaceName)
+	link, err = handle.LinkByName(interfaceName)
 	if err != nil {
 		return err
 	}
@@ -196,15 +189,15 @@ func configureControlPlanePeer(namespace, peerName, interfaceName, cidr string) 
 	if err != nil {
 		return err
 	}
-	if err := netlink.AddrAdd(link, address); err != nil {
+	if err := handle.AddrAdd(link, address); err != nil {
 		return err
 	}
-	if err := netlink.LinkSetUp(link); err != nil {
+	if err := handle.LinkSetUp(link); err != nil {
 		return err
 	}
-	loopback, err := netlink.LinkByName("lo")
+	loopback, err := handle.LinkByName("lo")
 	if err != nil {
 		return err
 	}
-	return netlink.LinkSetUp(loopback)
+	return handle.LinkSetUp(loopback)
 }

--- a/pkg/controller/kubernetes-engine-control-plane-network_linux.go
+++ b/pkg/controller/kubernetes-engine-control-plane-network_linux.go
@@ -172,7 +172,7 @@ func configureControlPlanePeer(namespace, peerName, interfaceName, cidr string) 
 	if err != nil {
 		return err
 	}
-	defer handle.Delete()
+	defer handle.Close()
 
 	link, err := handle.LinkByName(peerName)
 	if err != nil {

--- a/pkg/controller/kubernetes-engine-control-plane-network_linux_test.go
+++ b/pkg/controller/kubernetes-engine-control-plane-network_linux_test.go
@@ -2,106 +2,76 @@ package controller
 
 import (
 	"errors"
-	"reflect"
-	"testing"
 
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestKubernetesEngineControlPlaneNetworkNames(t *testing.T) {
-	namespace, hostVeth, peerVeth, err := KubernetesEngineControlPlaneNetworkNames("demo")
-	if err != nil {
-		t.Fatalf("KubernetesEngineControlPlaneNetworkNames() failed: %v", err)
-	}
-	if namespace != "mke-demo" {
-		t.Fatalf("namespace = %q, want %q", namespace, "mke-demo")
-	}
-	if len(hostVeth) > 15 || len(peerVeth) > 15 || hostVeth == peerVeth {
-		t.Fatalf("invalid veth names: host=%q peer=%q", hostVeth, peerVeth)
-	}
-}
+var _ = Describe("KubernetesEngineControlPlaneNetwork", func() {
+	It("derives namespace and veth names from the cluster name", func() {
+		namespace, hostVeth, peerVeth, err := KubernetesEngineControlPlaneNetworkNames("demo")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(namespace).To(Equal("mke-demo"))
+		Expect(len(hostVeth)).To(BeNumerically("<=", 15))
+		Expect(len(peerVeth)).To(BeNumerically("<=", 15))
+		Expect(hostVeth).NotTo(Equal(peerVeth))
+	})
 
-func TestCreateControlPlaneNamespaceUsesIPSubprocess(t *testing.T) {
-	originalRunIP := controlPlaneRunIP
-	t.Cleanup(func() { controlPlaneRunIP = originalRunIP })
+	It("creates the control-plane namespace via the ip subprocess", func() {
+		originalRunIP := controlPlaneRunIP
+		DeferCleanup(func() { controlPlaneRunIP = originalRunIP })
 
-	var got []string
-	controlPlaneRunIP = func(args ...string) ([]byte, error) {
-		got = append([]string(nil), args...)
-		return nil, nil
-	}
+		var got []string
+		controlPlaneRunIP = func(args ...string) ([]byte, error) {
+			got = append([]string(nil), args...)
+			return nil, nil
+		}
 
-	if err := createControlPlaneNamespace("mke-demo"); err != nil {
-		t.Fatalf("createControlPlaneNamespace() failed: %v", err)
-	}
-	want := []string{"netns", "add", "mke-demo"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("ip args = %v, want %v", got, want)
-	}
-}
+		Expect(createControlPlaneNamespace("mke-demo")).To(Succeed())
+		Expect(got).To(Equal([]string{"netns", "add", "mke-demo"}))
+	})
 
-func TestSetupKubernetesEngineControlPlaneNetworkLifecycle(t *testing.T) {
-	var calls []string
-	installFakeControlPlaneNetworkOps(t, &calls)
-	cfg, err := NewKubernetesEngineControlPlaneNetworkConfig("demo", "br-demo", "172.16.90.100/24")
-	if err != nil {
-		t.Fatalf("NewKubernetesEngineControlPlaneNetworkConfig() failed: %v", err)
-	}
-	if err := SetupKubernetesEngineControlPlaneNetwork(cfg); err != nil {
-		t.Fatalf("SetupKubernetesEngineControlPlaneNetwork() failed: %v", err)
-	}
-	wantSetup := []string{"netns-add:mke-demo", "veth-add", "ovs-add", "host-up", "peer-configure"}
-	if !reflect.DeepEqual(calls, wantSetup) {
-		t.Fatalf("setup calls = %v, want %v", calls, wantSetup)
-	}
+	It("sets up and tears down the control-plane network in order", func() {
+		var calls []string
+		installFakeControlPlaneNetworkOps(&calls)
+		cfg, err := NewKubernetesEngineControlPlaneNetworkConfig("demo", "br-demo", "172.16.90.100/24")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(SetupKubernetesEngineControlPlaneNetwork(cfg)).To(Succeed())
+		Expect(calls).To(Equal([]string{"netns-add:mke-demo", "veth-add", "ovs-add", "host-up", "peer-configure"}))
 
-	calls = nil
-	if err := TeardownKubernetesEngineControlPlaneNetwork(cfg); err != nil {
-		t.Fatalf("TeardownKubernetesEngineControlPlaneNetwork() failed: %v", err)
-	}
-	wantTeardown := []string{"ovs-delete", "netns-delete:mke-demo"}
-	if !reflect.DeepEqual(calls, wantTeardown) {
-		t.Fatalf("teardown calls = %v, want %v", calls, wantTeardown)
-	}
-}
+		calls = nil
+		Expect(TeardownKubernetesEngineControlPlaneNetwork(cfg)).To(Succeed())
+		Expect(calls).To(Equal([]string{"ovs-delete", "netns-delete:mke-demo"}))
+	})
 
-func TestSetupKubernetesEngineControlPlaneNetworkRollsBack(t *testing.T) {
-	var calls []string
-	installFakeControlPlaneNetworkOps(t, &calls)
-	controlPlaneSetHostVethUp = func(string) error {
-		calls = append(calls, "host-up")
-		return errors.New("link failed")
-	}
-	cfg, err := NewKubernetesEngineControlPlaneNetworkConfig("demo", "br-demo", "172.16.90.100/24")
-	if err != nil {
-		t.Fatalf("NewKubernetesEngineControlPlaneNetworkConfig() failed: %v", err)
-	}
-	if err := SetupKubernetesEngineControlPlaneNetwork(cfg); err == nil {
-		t.Fatalf("expected setup error, got nil")
-	}
-	want := []string{"netns-add:mke-demo", "veth-add", "ovs-add", "host-up", "ovs-delete", "netns-delete:mke-demo"}
-	if !reflect.DeepEqual(calls, want) {
-		t.Fatalf("calls = %v, want %v", calls, want)
-	}
-}
+	It("rolls back already-created resources when a later setup step fails", func() {
+		var calls []string
+		installFakeControlPlaneNetworkOps(&calls)
+		controlPlaneSetHostVethUp = func(string) error {
+			calls = append(calls, "host-up")
+			return errors.New("link failed")
+		}
+		cfg, err := NewKubernetesEngineControlPlaneNetworkConfig("demo", "br-demo", "172.16.90.100/24")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(SetupKubernetesEngineControlPlaneNetwork(cfg)).To(HaveOccurred())
+		Expect(calls).To(Equal([]string{"netns-add:mke-demo", "veth-add", "ovs-add", "host-up", "ovs-delete", "netns-delete:mke-demo"}))
+	})
 
-func TestAllocateKubernetesEngineAPIServerPort(t *testing.T) {
-	origProbe := kubernetesEnginePortProbe
-	t.Cleanup(func() { kubernetesEnginePortProbe = origProbe })
-	kubernetesEnginePortProbe = func(port int) bool { return port != 26444 }
-	engines := []api.KubernetesEngine{{Status: &api.Status{ApiServerPort: util.IntPtrInt(26443)}}}
-	port, err := AllocateKubernetesEngineAPIServerPort(engines, 26443, 26446)
-	if err != nil {
-		t.Fatalf("AllocateKubernetesEngineAPIServerPort() failed: %v", err)
-	}
-	if port != 26445 {
-		t.Fatalf("port = %d, want 26445", port)
-	}
-}
+	It("allocates the next free API server port outside used ranges", func() {
+		origProbe := kubernetesEnginePortProbe
+		DeferCleanup(func() { kubernetesEnginePortProbe = origProbe })
+		kubernetesEnginePortProbe = func(port int) bool { return port != 26444 }
+		engines := []api.KubernetesEngine{{Status: &api.Status{ApiServerPort: util.IntPtrInt(26443)}}}
+		port, err := AllocateKubernetesEngineAPIServerPort(engines, 26443, 26446)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(port).To(Equal(26445))
+	})
+})
 
-func installFakeControlPlaneNetworkOps(t *testing.T, calls *[]string) {
-	t.Helper()
+func installFakeControlPlaneNetworkOps(calls *[]string) {
 	origNamespaceExists := controlPlaneNamespaceExists
 	origCreateNamespace := controlPlaneCreateNamespace
 	origDeleteNamespace := controlPlaneDeleteNamespace
@@ -141,7 +111,7 @@ func installFakeControlPlaneNetworkOps(t *testing.T, calls *[]string) {
 		return nil
 	}
 
-	t.Cleanup(func() {
+	DeferCleanup(func() {
 		controlPlaneNamespaceExists = origNamespaceExists
 		controlPlaneCreateNamespace = origCreateNamespace
 		controlPlaneDeleteNamespace = origDeleteNamespace

--- a/pkg/controller/kubernetes-engine-control-plane-network_linux_test.go
+++ b/pkg/controller/kubernetes-engine-control-plane-network_linux_test.go
@@ -2,9 +2,12 @@ package controller
 
 import (
 	"errors"
+	"net"
+	"time"
 
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/util"
+	"github.com/vishvananda/netns"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -68,6 +71,95 @@ var _ = Describe("KubernetesEngineControlPlaneNetwork", func() {
 		port, err := AllocateKubernetesEngineAPIServerPort(engines, 26443, 26446)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(port).To(Equal(26445))
+	})
+})
+
+var _ = Describe("DialInKubernetesEngineNetworkNamespace", func() {
+	var (
+		origGetCurrent = dialNamespaceGetCurrent
+		origGetByName  = dialNamespaceGetByName
+		origSet        = dialNamespaceSet
+		origNetDial    = dialNamespaceNetDial
+	)
+
+	AfterEach(func() {
+		dialNamespaceGetCurrent = origGetCurrent
+		dialNamespaceGetByName = origGetByName
+		dialNamespaceSet = origSet
+		dialNamespaceNetDial = origNetDial
+	})
+
+	It("dials directly without touching namespaces when namespace is empty", func() {
+		var gotNetwork, gotAddress string
+		dialNamespaceNetDial = func(network, address string, timeout time.Duration) (net.Conn, error) {
+			gotNetwork, gotAddress = network, address
+			return nil, nil
+		}
+		dialNamespaceGetCurrent = func() (netns.NsHandle, error) {
+			return netns.NsHandle(0), errors.New("must not be called")
+		}
+
+		_, err := DialInKubernetesEngineNetworkNamespace("", "tcp", "172.16.1.10:22", time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gotNetwork).To(Equal("tcp"))
+		Expect(gotAddress).To(Equal("172.16.1.10:22"))
+	})
+
+	It("switches into the target namespace, dials, and restores the original namespace", func() {
+		origHandle := netns.NsHandle(-2)
+		targetHandle := netns.NsHandle(-3)
+		var setCalls []netns.NsHandle
+
+		dialNamespaceGetCurrent = func() (netns.NsHandle, error) { return origHandle, nil }
+		dialNamespaceGetByName = func(name string) (netns.NsHandle, error) {
+			Expect(name).To(Equal("mke-demo"))
+			return targetHandle, nil
+		}
+		dialNamespaceSet = func(ns netns.NsHandle) error {
+			setCalls = append(setCalls, ns)
+			return nil
+		}
+		dialNamespaceNetDial = func(network, address string, timeout time.Duration) (net.Conn, error) {
+			// namespaceの切り替え後にダイヤルされることを保証する。
+			Expect(setCalls).To(Equal([]netns.NsHandle{targetHandle}))
+			return nil, nil
+		}
+
+		_, err := DialInKubernetesEngineNetworkNamespace("mke-demo", "tcp", "172.16.1.10:22", time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(setCalls).To(Equal([]netns.NsHandle{targetHandle, origHandle}))
+	})
+
+	It("returns an error when the target namespace cannot be opened", func() {
+		dialNamespaceGetCurrent = func() (netns.NsHandle, error) { return netns.NsHandle(-2), nil }
+		dialNamespaceGetByName = func(name string) (netns.NsHandle, error) {
+			return netns.NsHandle(0), errors.New("no such namespace")
+		}
+
+		_, err := DialInKubernetesEngineNetworkNamespace("missing", "tcp", "172.16.1.10:22", time.Second)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to open network namespace missing"))
+	})
+
+	It("propagates the dial error and still restores the original namespace", func() {
+		origHandle := netns.NsHandle(-2)
+		targetHandle := netns.NsHandle(-3)
+		var setCalls []netns.NsHandle
+
+		dialNamespaceGetCurrent = func() (netns.NsHandle, error) { return origHandle, nil }
+		dialNamespaceGetByName = func(name string) (netns.NsHandle, error) { return targetHandle, nil }
+		dialNamespaceSet = func(ns netns.NsHandle) error {
+			setCalls = append(setCalls, ns)
+			return nil
+		}
+		dialNamespaceNetDial = func(network, address string, timeout time.Duration) (net.Conn, error) {
+			return nil, errors.New("connect: no route to host")
+		}
+
+		_, err := DialInKubernetesEngineNetworkNamespace("mke-demo", "tcp", "172.16.1.10:22", time.Second)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no route to host"))
+		Expect(setCalls).To(Equal([]netns.NsHandle{targetHandle, origHandle}))
 	})
 })
 

--- a/pkg/controller/kubernetes-engine-control-plane-network_linux_test.go
+++ b/pkg/controller/kubernetes-engine-control-plane-network_linux_test.go
@@ -22,6 +22,25 @@ func TestKubernetesEngineControlPlaneNetworkNames(t *testing.T) {
 	}
 }
 
+func TestCreateControlPlaneNamespaceUsesIPSubprocess(t *testing.T) {
+	originalRunIP := controlPlaneRunIP
+	t.Cleanup(func() { controlPlaneRunIP = originalRunIP })
+
+	var got []string
+	controlPlaneRunIP = func(args ...string) ([]byte, error) {
+		got = append([]string(nil), args...)
+		return nil, nil
+	}
+
+	if err := createControlPlaneNamespace("mke-demo"); err != nil {
+		t.Fatalf("createControlPlaneNamespace() failed: %v", err)
+	}
+	want := []string{"netns", "add", "mke-demo"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ip args = %v, want %v", got, want)
+	}
+}
+
 func TestSetupKubernetesEngineControlPlaneNetworkLifecycle(t *testing.T) {
 	var calls []string
 	installFakeControlPlaneNetworkOps(t, &calls)

--- a/pkg/controller/kubernetes-engine-control-plane-systemd_test.go
+++ b/pkg/controller/kubernetes-engine-control-plane-systemd_test.go
@@ -4,64 +4,59 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestKubernetesEngineControlPlaneUnitLifecycle(t *testing.T) {
-	recorder := installFakeSystemd(t)
-	origUnitDir := controlPlaneSystemdUnitDir
-	controlPlaneSystemdUnitDir = t.TempDir()
-	t.Cleanup(func() { controlPlaneSystemdUnitDir = origUnitDir })
+var _ = Describe("KubernetesEngineControlPlaneUnits", func() {
+	It("creates and deletes the control-plane systemd units", func() {
+		recorder := installFakeSystemd()
+		origUnitDir := controlPlaneSystemdUnitDir
+		controlPlaneSystemdUnitDir = GinkgoT().TempDir()
+		DeferCleanup(func() { controlPlaneSystemdUnitDir = origUnitDir })
 
-	cfg := testControlPlaneUnitConfig()
-	if err := CreateKubernetesEngineControlPlaneUnits(cfg); err != nil {
-		t.Fatalf("CreateKubernetesEngineControlPlaneUnits() failed: %v", err)
-	}
-	wantCreate := []string{
-		"daemon-reload",
-		"enable:mke-kube-apiserver-demo.service", "start:mke-kube-apiserver-demo.service",
-		"enable:mke-kube-scheduler-demo.service", "start:mke-kube-scheduler-demo.service",
-		"enable:mke-kube-controller-manager-demo.service", "start:mke-kube-controller-manager-demo.service",
-	}
-	assertCallsEqual(t, recorder.calls, wantCreate)
-
-	apiServerUnit, err := os.ReadFile(filepath.Join(controlPlaneSystemdUnitDir, "mke-kube-apiserver-demo.service"))
-	if err != nil {
-		t.Fatalf("failed to read API server unit: %v", err)
-	}
-	for _, want := range []string{"NetworkNamespacePath=/run/netns/mke-demo", "--etcd-servers=http://127.0.0.1:23790", "--secure-port=6443", "--advertise-address=172.16.90.100"} {
-		if !strings.Contains(string(apiServerUnit), want) {
-			t.Fatalf("API server unit does not contain %q: %s", want, apiServerUnit)
+		cfg := testControlPlaneUnitConfig()
+		Expect(CreateKubernetesEngineControlPlaneUnits(cfg)).To(Succeed())
+		wantCreate := []string{
+			"daemon-reload",
+			"enable:mke-kube-apiserver-demo.service", "start:mke-kube-apiserver-demo.service",
+			"enable:mke-kube-scheduler-demo.service", "start:mke-kube-scheduler-demo.service",
+			"enable:mke-kube-controller-manager-demo.service", "start:mke-kube-controller-manager-demo.service",
 		}
-	}
+		Expect(recorder.calls).To(Equal(wantCreate))
 
-	recorder.calls = nil
-	if err := DeleteKubernetesEngineControlPlaneUnits("demo"); err != nil {
-		t.Fatalf("DeleteKubernetesEngineControlPlaneUnits() failed: %v", err)
-	}
-	wantDelete := []string{
-		"stop:mke-kube-controller-manager-demo.service", "disable:mke-kube-controller-manager-demo.service",
-		"stop:mke-kube-scheduler-demo.service", "disable:mke-kube-scheduler-demo.service",
-		"stop:mke-kube-apiserver-demo.service", "disable:mke-kube-apiserver-demo.service",
-		"daemon-reload",
-	}
-	assertCallsEqual(t, recorder.calls, wantDelete)
-}
-
-func TestCheckKubernetesEngineControlPlaneHealth(t *testing.T) {
-	origCommand := controlPlaneHealthCommand
-	t.Cleanup(func() { controlPlaneHealthCommand = origCommand })
-	controlPlaneHealthCommand = func(_ context.Context, namespace, caPath, endpoint string) error {
-		if namespace != "mke-demo" || caPath != "/pki/ca.crt" || endpoint != "https://172.16.90.100:6443/healthz" {
-			t.Fatalf("unexpected health check args: %q %q %q", namespace, caPath, endpoint)
+		apiServerUnit, err := os.ReadFile(filepath.Join(controlPlaneSystemdUnitDir, "mke-kube-apiserver-demo.service"))
+		Expect(err).NotTo(HaveOccurred())
+		for _, want := range []string{"NetworkNamespacePath=/run/netns/mke-demo", "--etcd-servers=http://127.0.0.1:23790", "--secure-port=6443", "--advertise-address=172.16.90.100"} {
+			Expect(string(apiServerUnit)).To(ContainSubstring(want))
 		}
-		return nil
-	}
-	if err := CheckKubernetesEngineControlPlaneHealth("mke-demo", "/pki/ca.crt", "172.16.90.100", 6443); err != nil {
-		t.Fatalf("CheckKubernetesEngineControlPlaneHealth() failed: %v", err)
-	}
-}
+
+		recorder.calls = nil
+		Expect(DeleteKubernetesEngineControlPlaneUnits("demo")).To(Succeed())
+		wantDelete := []string{
+			"stop:mke-kube-controller-manager-demo.service", "disable:mke-kube-controller-manager-demo.service",
+			"stop:mke-kube-scheduler-demo.service", "disable:mke-kube-scheduler-demo.service",
+			"stop:mke-kube-apiserver-demo.service", "disable:mke-kube-apiserver-demo.service",
+			"daemon-reload",
+		}
+		Expect(recorder.calls).To(Equal(wantDelete))
+	})
+
+	It("checks control-plane health using the configured namespace and endpoint", func() {
+		origCommand := controlPlaneHealthCommand
+		DeferCleanup(func() { controlPlaneHealthCommand = origCommand })
+		var gotNamespace, gotCAPath, gotEndpoint string
+		controlPlaneHealthCommand = func(_ context.Context, namespace, caPath, endpoint string) error {
+			gotNamespace, gotCAPath, gotEndpoint = namespace, caPath, endpoint
+			return nil
+		}
+		Expect(CheckKubernetesEngineControlPlaneHealth("mke-demo", "/pki/ca.crt", "172.16.90.100", 6443)).To(Succeed())
+		Expect(gotNamespace).To(Equal("mke-demo"))
+		Expect(gotCAPath).To(Equal("/pki/ca.crt"))
+		Expect(gotEndpoint).To(Equal("https://172.16.90.100:6443/healthz"))
+	})
+})
 
 func testControlPlaneUnitConfig() KubernetesEngineControlPlaneUnitConfig {
 	return KubernetesEngineControlPlaneUnitConfig{

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -22,12 +22,18 @@ const (
 	kubernetesEngineNetworkNamePrefix = "mke-"
 )
 
+var (
+	provisionKubernetesEngineControlPlane = ProvisionKubernetesEngineControlPlane
+	provisionKubernetesEngineNodes        = ProvisionKubernetesEngineNodes
+)
+
 // kubernetesEngineController は MKE (Marmot Kubernetes Engine) コントローラーです。
 // mke.json の読み込みに加えて、/marmot/kubernetes-engine 配下を定期的にポーリングし、
 // KubernetesEngine リソースのライフサイクル状態（Pending→Provisioning→Running→Deleting）を
 // etcd に書き込みます。実際のクラスタ構築（VM作成・kubeadm等）は今後実装します。
 type kubernetesEngineController struct {
 	node     string
+	etcdURL  string
 	mkeConf  *marmotd.MKEConfig
 	marmot   *marmotd.Marmot
 	db       *db.Database
@@ -42,6 +48,7 @@ func StartKubernetesEngineController(node string, etcdUrl string, mkeConfigPath 
 	var c kubernetesEngineController
 	var err error
 	c.node = node
+	c.etcdURL = etcdUrl
 
 	if mkeConfigPath == "" {
 		mkeConfigPath = marmotd.DefaultMKEConfigPath
@@ -182,11 +189,50 @@ func (c *kubernetesEngineController) reconcileKubernetesEnginePending(ke api.Kub
 	}
 }
 
-// reconcileKubernetesEngineProvisioning はノード起動状況を確認して RUNNING に進める処理の差し込み口。
-// TODO: 次フェーズでノード(Server)の起動完了を確認し、全ノード Running になった時点で RUNNING に遷移させる。
+// reconcileKubernetesEngineProvisioning はコントロールプレーンとノードを冪等に構成し、
+// 全ノードがKubernetes API上でReadyになった時点でRUNNINGに進める。
 func (c *kubernetesEngineController) reconcileKubernetesEngineProvisioning(ke api.KubernetesEngine) {
 	id := api.KubernetesEngineID(ke)
-	slog.Debug("KubernetesEngineはPROVISIONING状態です（ノード起動確認は未実装）", "id", id, "name", ke.Metadata.Name)
+	lockKey := "/lock/kubernetes-engine/reconcile/" + id
+	mutex, err := c.db.LockKey(lockKey)
+	if err != nil {
+		slog.Warn("reconcileKubernetesEngineProvisioning: failed to acquire lock", "id", id, "err", err)
+		return
+	}
+	defer c.db.UnlockKey(mutex)
+
+	current, err := c.db.GetKubernetesEngineById(id)
+	if err != nil {
+		slog.Warn("reconcileKubernetesEngineProvisioning: GetKubernetesEngineById() failed", "id", id, "err", err)
+		return
+	}
+	if current.Status == nil || current.Status.StatusCode != db.KUBERNETES_ENGINE_PROVISIONING {
+		return
+	}
+	if err := provisionKubernetesEngineControlPlane(c.db, c.mkeConf, c.etcdURL, current); err != nil {
+		message := fmt.Sprintf("control plane provisioning failed: %v", err)
+		_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_PROVISIONING, message)
+		return
+	}
+
+	current, err = c.db.GetKubernetesEngineById(id)
+	if err != nil {
+		slog.Warn("reconcileKubernetesEngineProvisioning: failed to reload control plane status", "id", id, "err", err)
+		return
+	}
+	ready, err := provisionKubernetesEngineNodes(c.db, c.mkeConf, current)
+	if err != nil {
+		message := fmt.Sprintf("node provisioning failed: %v", err)
+		_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_PROVISIONING, message)
+		return
+	}
+	if !ready {
+		_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_PROVISIONING, "waiting for Kubernetes nodes to become Ready")
+		return
+	}
+	if err := c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_RUNNING, ""); err != nil {
+		slog.Warn("UpdateKubernetesEngineStatusWithMessage() failed", "id", id, "err", err)
+	}
 }
 
 // reconcileKubernetesEngineRunning はRUNNING状態のヘルスチェック用の差し込み口。

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -60,7 +60,7 @@ func StartKubernetesEngineController(node string, etcdUrl string, mkeConfigPath 
 		return nil, err
 	}
 	c.mkeConf = cfg
-	slog.Info("MKE設定を読み込みました", "path", mkeConfigPath, "kubernetesVersion", cfg.KubernetesVersion)
+	slog.Debug("MKE設定を読み込みました", "path", mkeConfigPath, "kubernetesVersion", cfg.KubernetesVersion)
 
 	c.marmot, err = marmotd.NewMarmot(node, etcdUrl)
 	if err != nil {

--- a/pkg/controller/kubernetes-engine-controller_test.go
+++ b/pkg/controller/kubernetes-engine-controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/marmotd"
 )
 
 func TestIsKubernetesEngineInGracePeriod(t *testing.T) {
@@ -56,5 +57,53 @@ func TestIsKubernetesEngineInGracePeriod(t *testing.T) {
 				t.Fatalf("isKubernetesEngineInGracePeriod() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReconcileKubernetesEngineProvisioningTransitionsWhenNodesReady(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ke, err := database.CreateKubernetesEngine(api.KubernetesEngine{
+		ApiVersion: "v1",
+		Kind:       "KubernetesEngine",
+		Metadata:   api.Metadata{Name: "demo-ready"},
+		Spec:       api.KubernetesEngineSpec{Version: "1.36", Nodes: 1},
+	})
+	if err != nil {
+		t.Fatalf("CreateKubernetesEngine() failed: %v", err)
+	}
+	id := api.KubernetesEngineID(ke)
+	if err := database.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_PROVISIONING, ""); err != nil {
+		t.Fatalf("failed to set PROVISIONING: %v", err)
+	}
+	ke, err = database.GetKubernetesEngineById(id)
+	if err != nil {
+		t.Fatalf("GetKubernetesEngineById() failed: %v", err)
+	}
+
+	oldControlPlane := provisionKubernetesEngineControlPlane
+	oldNodes := provisionKubernetesEngineNodes
+	t.Cleanup(func() {
+		provisionKubernetesEngineControlPlane = oldControlPlane
+		provisionKubernetesEngineNodes = oldNodes
+	})
+	provisionKubernetesEngineControlPlane = func(database *db.Database, _ *marmotd.MKEConfig, _ string, current api.KubernetesEngine) error {
+		return database.UpdateKubernetesEngineControlPlaneStatus(api.KubernetesEngineID(current), "172.16.1.2", 26443, "v1.36.2")
+	}
+	provisionKubernetesEngineNodes = func(_ *db.Database, _ *marmotd.MKEConfig, current api.KubernetesEngine) (bool, error) {
+		if current.Status == nil || current.Status.ControlPlaneIpAddress == nil {
+			t.Fatalf("node provisioning received stale control plane status: %+v", current.Status)
+		}
+		return true, nil
+	}
+
+	ctrl := &kubernetesEngineController{db: database, mkeConf: &marmotd.MKEConfig{}, etcdURL: "http://127.0.0.1:2379"}
+	ctrl.reconcileKubernetesEngineProvisioning(ke)
+
+	updated, err := database.GetKubernetesEngineById(id)
+	if err != nil {
+		t.Fatalf("GetKubernetesEngineById() failed: %v", err)
+	}
+	if updated.Status == nil || updated.Status.StatusCode != db.KUBERNETES_ENGINE_RUNNING {
+		t.Fatalf("status = %+v, want RUNNING", updated.Status)
 	}
 }

--- a/pkg/controller/kubernetes-engine-etcd-binary_test.go
+++ b/pkg/controller/kubernetes-engine-etcd-binary_test.go
@@ -10,12 +10,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // buildFakeEtcdArchive は "<tagLinuxArch>/etcd" というエントリのみを含むtar.gzを生成する。
-func buildFakeEtcdArchive(t *testing.T, tag, arch, binaryContent string) []byte {
-	t.Helper()
+func buildFakeEtcdArchive(tag, arch, binaryContent string) []byte {
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gz)
@@ -26,123 +27,97 @@ func buildFakeEtcdArchive(t *testing.T, tag, arch, binaryContent string) []byte 
 		Mode: 0o755,
 		Size: int64(len(binaryContent)),
 	}
-	if err := tw.WriteHeader(hdr); err != nil {
-		t.Fatalf("tar WriteHeader() failed: %v", err)
-	}
-	if _, err := tw.Write([]byte(binaryContent)); err != nil {
-		t.Fatalf("tar Write() failed: %v", err)
-	}
-	if err := tw.Close(); err != nil {
-		t.Fatalf("tar Close() failed: %v", err)
-	}
-	if err := gz.Close(); err != nil {
-		t.Fatalf("gzip Close() failed: %v", err)
-	}
+	Expect(tw.WriteHeader(hdr)).To(Succeed())
+	_, err := tw.Write([]byte(binaryContent))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(tw.Close()).To(Succeed())
+	Expect(gz.Close()).To(Succeed())
 	return buf.Bytes()
 }
 
-func TestEtcdBinaryPath(t *testing.T) {
-	path, err := EtcdBinaryPath("/var/lib/marmot/mke/etcd", "3.6.8")
-	if err != nil {
-		t.Fatalf("EtcdBinaryPath() failed: %v", err)
-	}
-	want := filepath.Join("/var/lib/marmot/mke/etcd", "v3.6.8-linux-"+runtime.GOARCH, "etcd")
-	if path != want {
-		t.Fatalf("EtcdBinaryPath() = %q, want %q", path, want)
-	}
-}
+var _ = Describe("EtcdBinary", func() {
+	It("builds the etcd binary path from the version and host arch", func() {
+		path, err := EtcdBinaryPath("/var/lib/marmot/mke/etcd", "3.6.8")
+		Expect(err).NotTo(HaveOccurred())
+		want := filepath.Join("/var/lib/marmot/mke/etcd", "v3.6.8-linux-"+runtime.GOARCH, "etcd")
+		Expect(path).To(Equal(want))
+	})
 
-func TestEtcdArchFromGOARCHUnsupported(t *testing.T) {
-	if _, err := etcdArchFromGOARCH("riscv64"); err == nil {
-		t.Fatalf("expected error for unsupported arch")
-	}
-}
+	It("rejects unsupported GOARCH values", func() {
+		_, err := etcdArchFromGOARCH("riscv64")
+		Expect(err).To(HaveOccurred())
+	})
 
-func TestEnsureEtcdBinaryDownloadsVerifiesAndCaches(t *testing.T) {
-	arch, err := etcdArchFromGOARCH(runtime.GOARCH)
-	if err != nil {
-		t.Skipf("unsupported test host arch: %v", err)
-	}
-
-	const version = "3.6.8"
-	const tag = "v3.6.8"
-	const binaryContent = "#!/bin/sh\necho fake-etcd\n"
-	assetName := fmt.Sprintf("etcd-%s-linux-%s.tar.gz", tag, arch)
-	archive := buildFakeEtcdArchive(t, tag, arch, binaryContent)
-	sum := sha256.Sum256(archive)
-	sumsContent := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), assetName)
-
-	origDownload := etcdDownload
-	downloadCount := 0
-	t.Cleanup(func() { etcdDownload = origDownload })
-	etcdDownload = func(url string) ([]byte, error) {
-		downloadCount++
-		switch {
-		case url == fmt.Sprintf("%s/%s/%s", etcdReleaseBaseURL, tag, assetName):
-			return archive, nil
-		case url == fmt.Sprintf("%s/%s/SHA256SUMS", etcdReleaseBaseURL, tag):
-			return []byte(sumsContent), nil
-		default:
-			return nil, fmt.Errorf("unexpected download URL: %s", url)
+	It("downloads, verifies and caches the etcd binary", func() {
+		arch, err := etcdArchFromGOARCH(runtime.GOARCH)
+		if err != nil {
+			Skip(fmt.Sprintf("unsupported test host arch: %v", err))
 		}
-	}
 
-	cacheDir := t.TempDir()
-	binPath, err := EnsureEtcdBinary(cacheDir, version)
-	if err != nil {
-		t.Fatalf("EnsureEtcdBinary() failed: %v", err)
-	}
-	content, err := os.ReadFile(binPath)
-	if err != nil {
-		t.Fatalf("os.ReadFile(%q) failed: %v", binPath, err)
-	}
-	if string(content) != binaryContent {
-		t.Fatalf("etcd binary content = %q, want %q", content, binaryContent)
-	}
-	info, err := os.Stat(binPath)
-	if err != nil {
-		t.Fatalf("os.Stat(%q) failed: %v", binPath, err)
-	}
-	if info.Mode().Perm()&0o100 == 0 {
-		t.Fatalf("etcd binary is not executable: mode=%v", info.Mode())
-	}
-	if downloadCount != 2 {
-		t.Fatalf("etcdDownload call count = %d, want 2", downloadCount)
-	}
+		const version = "3.6.8"
+		const tag = "v3.6.8"
+		const binaryContent = "#!/bin/sh\necho fake-etcd\n"
+		assetName := fmt.Sprintf("etcd-%s-linux-%s.tar.gz", tag, arch)
+		archive := buildFakeEtcdArchive(tag, arch, binaryContent)
+		sum := sha256.Sum256(archive)
+		sumsContent := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), assetName)
 
-	// 2回目はキャッシュ済みのためダウンロードを行わないこと(冪等性)
-	if _, err := EnsureEtcdBinary(cacheDir, version); err != nil {
-		t.Fatalf("EnsureEtcdBinary() second call failed: %v", err)
-	}
-	if downloadCount != 2 {
-		t.Fatalf("etcdDownload was called again on cached binary: count=%d", downloadCount)
-	}
-}
-
-func TestEnsureEtcdBinaryChecksumMismatch(t *testing.T) {
-	arch, err := etcdArchFromGOARCH(runtime.GOARCH)
-	if err != nil {
-		t.Skipf("unsupported test host arch: %v", err)
-	}
-	const version = "3.6.8"
-	const tag = "v3.6.8"
-	assetName := fmt.Sprintf("etcd-%s-linux-%s.tar.gz", tag, arch)
-	archive := buildFakeEtcdArchive(t, tag, arch, "content")
-
-	origDownload := etcdDownload
-	t.Cleanup(func() { etcdDownload = origDownload })
-	etcdDownload = func(url string) ([]byte, error) {
-		switch {
-		case url == fmt.Sprintf("%s/%s/%s", etcdReleaseBaseURL, tag, assetName):
-			return archive, nil
-		case url == fmt.Sprintf("%s/%s/SHA256SUMS", etcdReleaseBaseURL, tag):
-			return []byte(fmt.Sprintf("%s  %s\n", "0000000000000000000000000000000000000000000000000000000000000000", assetName)), nil
-		default:
-			return nil, fmt.Errorf("unexpected download URL: %s", url)
+		origDownload := etcdDownload
+		downloadCount := 0
+		DeferCleanup(func() { etcdDownload = origDownload })
+		etcdDownload = func(url string) ([]byte, error) {
+			downloadCount++
+			switch {
+			case url == fmt.Sprintf("%s/%s/%s", etcdReleaseBaseURL, tag, assetName):
+				return archive, nil
+			case url == fmt.Sprintf("%s/%s/SHA256SUMS", etcdReleaseBaseURL, tag):
+				return []byte(sumsContent), nil
+			default:
+				return nil, fmt.Errorf("unexpected download URL: %s", url)
+			}
 		}
-	}
 
-	if _, err := EnsureEtcdBinary(t.TempDir(), version); err == nil {
-		t.Fatalf("expected checksum mismatch error")
-	}
-}
+		cacheDir := GinkgoT().TempDir()
+		binPath, err := EnsureEtcdBinary(cacheDir, version)
+		Expect(err).NotTo(HaveOccurred())
+		content, err := os.ReadFile(binPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(Equal(binaryContent))
+		info, err := os.Stat(binPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm() & 0o100).NotTo(BeZero())
+		Expect(downloadCount).To(Equal(2))
+
+		// 2回目はキャッシュ済みのためダウンロードを行わないこと(冪等性)
+		_, err = EnsureEtcdBinary(cacheDir, version)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(downloadCount).To(Equal(2))
+	})
+
+	It("rejects a checksum mismatch", func() {
+		arch, err := etcdArchFromGOARCH(runtime.GOARCH)
+		if err != nil {
+			Skip(fmt.Sprintf("unsupported test host arch: %v", err))
+		}
+		const version = "3.6.8"
+		const tag = "v3.6.8"
+		assetName := fmt.Sprintf("etcd-%s-linux-%s.tar.gz", tag, arch)
+		archive := buildFakeEtcdArchive(tag, arch, "content")
+
+		origDownload := etcdDownload
+		DeferCleanup(func() { etcdDownload = origDownload })
+		etcdDownload = func(url string) ([]byte, error) {
+			switch {
+			case url == fmt.Sprintf("%s/%s/%s", etcdReleaseBaseURL, tag, assetName):
+				return archive, nil
+			case url == fmt.Sprintf("%s/%s/SHA256SUMS", etcdReleaseBaseURL, tag):
+				return []byte(fmt.Sprintf("%s  %s\n", "0000000000000000000000000000000000000000000000000000000000000000", assetName)), nil
+			default:
+				return nil, fmt.Errorf("unexpected download URL: %s", url)
+			}
+		}
+
+		_, err = EnsureEtcdBinary(GinkgoT().TempDir(), version)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/controller/kubernetes-engine-etcd-ports_test.go
+++ b/pkg/controller/kubernetes-engine-etcd-ports_test.go
@@ -1,81 +1,69 @@
 package controller
 
 import (
-	"testing"
-
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestParsePortFromEndpoint(t *testing.T) {
-	cases := []struct {
-		name     string
-		endpoint string
-		wantPort int
-		wantOk   bool
-	}{
-		{"http url", "http://127.0.0.1:2379", 2379, true},
-		{"host port", "127.0.0.1:2380", 2380, true},
-		{"empty", "", 0, false},
-		{"no port", "127.0.0.1", 0, false},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			port, ok := parsePortFromEndpoint(c.endpoint)
-			if ok != c.wantOk || port != c.wantPort {
-				t.Fatalf("parsePortFromEndpoint(%q) = (%d, %v), want (%d, %v)", c.endpoint, port, ok, c.wantPort, c.wantOk)
-			}
-		})
-	}
-}
-
-func TestAllocateKubernetesEngineEtcdPortsAvoidsOwnEtcdAndOtherClusters(t *testing.T) {
-	rangeStart, rangeEnd := 40000, 40010
-
-	existing := api.KubernetesEngine{
-		Status: &api.Status{
-			EtcdClientPort: util.IntPtrInt(40000),
-			EtcdPeerPort:   util.IntPtrInt(40001),
+var _ = Describe("parsePortFromEndpoint", func() {
+	DescribeTable("parses the port from an endpoint string",
+		func(endpoint string, wantPort int, wantOk bool) {
+			port, ok := parsePortFromEndpoint(endpoint)
+			Expect(ok).To(Equal(wantOk))
+			Expect(port).To(Equal(wantPort))
 		},
-	}
+		Entry("http url", "http://127.0.0.1:2379", 2379, true),
+		Entry("host port", "127.0.0.1:2380", 2380, true),
+		Entry("empty", "", 0, false),
+		Entry("no port", "127.0.0.1", 0, false),
+	)
+})
 
-	clientPort, peerPort, err := AllocateKubernetesEngineEtcdPorts([]api.KubernetesEngine{existing}, "http://127.0.0.1:40002", rangeStart, rangeEnd)
-	if err != nil {
-		t.Fatalf("AllocateKubernetesEngineEtcdPorts() failed: %v", err)
-	}
-	if clientPort == 40000 || clientPort == 40001 || clientPort == 40002 || peerPort == 40002 {
-		t.Fatalf("allocated ports (%d, %d) collide with reserved ports", clientPort, peerPort)
-	}
-	if peerPort != clientPort+1 {
-		t.Fatalf("peerPort = %d, want clientPort+1 (%d)", peerPort, clientPort+1)
-	}
-}
+var _ = Describe("AllocateKubernetesEngineEtcdPorts", func() {
+	It("avoids its own etcd ports and other clusters' allocated ports", func() {
+		rangeStart, rangeEnd := 40000, 40010
 
-func TestAllocateKubernetesEngineEtcdPortsSkipsPortsNotLocallyFree(t *testing.T) {
-	rangeStart, rangeEnd := 41000, 41010
+		existing := api.KubernetesEngine{
+			Status: &api.Status{
+				EtcdClientPort: util.IntPtrInt(40000),
+				EtcdPeerPort:   util.IntPtrInt(40001),
+			},
+		}
 
-	origProbe := kubernetesEnginePortProbe
-	t.Cleanup(func() { kubernetesEnginePortProbe = origProbe })
-	kubernetesEnginePortProbe = func(port int) bool {
-		// 最初の候補ペアだけ使用中(bind不可)を模擬する。
-		return port != 41000 && port != 41001
-	}
+		clientPort, peerPort, err := AllocateKubernetesEngineEtcdPorts([]api.KubernetesEngine{existing}, "http://127.0.0.1:40002", rangeStart, rangeEnd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clientPort).NotTo(Equal(40000))
+		Expect(clientPort).NotTo(Equal(40001))
+		Expect(clientPort).NotTo(Equal(40002))
+		Expect(peerPort).NotTo(Equal(40002))
+		Expect(peerPort).To(Equal(clientPort + 1))
+	})
 
-	clientPort, peerPort, err := AllocateKubernetesEngineEtcdPorts(nil, "", rangeStart, rangeEnd)
-	if err != nil {
-		t.Fatalf("AllocateKubernetesEngineEtcdPorts() failed: %v", err)
-	}
-	if clientPort != 41002 || peerPort != 41003 {
-		t.Fatalf("allocated ports = (%d, %d), want (41002, 41003)", clientPort, peerPort)
-	}
-}
+	It("skips ports that are not locally free", func() {
+		rangeStart, rangeEnd := 41000, 41010
 
-func TestAllocateKubernetesEngineEtcdPortsExhausted(t *testing.T) {
-	origProbe := kubernetesEnginePortProbe
-	t.Cleanup(func() { kubernetesEnginePortProbe = origProbe })
-	kubernetesEnginePortProbe = func(int) bool { return false }
+		origProbe := kubernetesEnginePortProbe
+		DeferCleanup(func() { kubernetesEnginePortProbe = origProbe })
+		kubernetesEnginePortProbe = func(port int) bool {
+			// 最初の候補ペアだけ使用中(bind不可)を模擬する。
+			return port != 41000 && port != 41001
+		}
 
-	if _, _, err := AllocateKubernetesEngineEtcdPorts(nil, "", 42000, 42004); err == nil {
-		t.Fatalf("expected error when no free port pair is available")
-	}
-}
+		clientPort, peerPort, err := AllocateKubernetesEngineEtcdPorts(nil, "", rangeStart, rangeEnd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clientPort).To(Equal(41002))
+		Expect(peerPort).To(Equal(41003))
+	})
+
+	It("returns an error when no free port pair is available", func() {
+		origProbe := kubernetesEnginePortProbe
+		DeferCleanup(func() { kubernetesEnginePortProbe = origProbe })
+		kubernetesEnginePortProbe = func(int) bool { return false }
+
+		_, _, err := AllocateKubernetesEngineEtcdPorts(nil, "", 42000, 42004)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/controller/kubernetes-engine-etcd-systemd_test.go
+++ b/pkg/controller/kubernetes-engine-etcd-systemd_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // fakeSystemdRecorder は systemctl 呼び出しの記録用ヘルパー。
@@ -18,8 +19,7 @@ func (f *fakeSystemdRecorder) record(action string) error {
 	return nil
 }
 
-func installFakeSystemd(t *testing.T) *fakeSystemdRecorder {
-	t.Helper()
+func installFakeSystemd() *fakeSystemdRecorder {
 	rec := &fakeSystemdRecorder{}
 
 	origReload := systemdDaemonReload
@@ -34,9 +34,9 @@ func installFakeSystemd(t *testing.T) *fakeSystemdRecorder {
 	systemdDisableUnit = func(unit string) error { return rec.record("disable:" + unit) }
 	systemdStartUnit = func(unit string) error { return rec.record("start:" + unit) }
 	systemdStopUnit = func(unit string) error { return rec.record("stop:" + unit) }
-	etcdSystemdUnitDir = t.TempDir()
+	etcdSystemdUnitDir = GinkgoT().TempDir()
 
-	t.Cleanup(func() {
+	DeferCleanup(func() {
 		systemdDaemonReload = origReload
 		systemdEnableUnit = origEnable
 		systemdDisableUnit = origDisable
@@ -47,157 +47,113 @@ func installFakeSystemd(t *testing.T) *fakeSystemdRecorder {
 	return rec
 }
 
-func TestKubernetesEngineEtcdUnitName(t *testing.T) {
-	if got, want := KubernetesEngineEtcdUnitName("demo"), "mke-etcd-demo.service"; got != want {
-		t.Fatalf("KubernetesEngineEtcdUnitName() = %q, want %q", got, want)
-	}
-}
-
-func TestRenderKubernetesEngineEtcdUnitWithNetworkNamespace(t *testing.T) {
-	content := renderKubernetesEngineEtcdUnit(KubernetesEngineEtcdUnitConfig{
-		ClusterName:      "demo",
-		EtcdBinaryPath:   "/bin/etcd",
-		DataDir:          "/var/lib/etcd",
-		NetworkNamespace: "mke-demo",
-		ClientPort:       23790,
-		PeerPort:         23791,
+var _ = Describe("KubernetesEngineEtcdUnit", func() {
+	It("derives the systemd unit name from the cluster name", func() {
+		Expect(KubernetesEngineEtcdUnitName("demo")).To(Equal("mke-etcd-demo.service"))
 	})
-	if !strings.Contains(content, "NetworkNamespacePath=/run/netns/mke-demo") {
-		t.Fatalf("unit does not contain network namespace: %s", content)
-	}
-}
 
-// クラスタ専用etcdユニットの「作成→起動→停止→削除」の一連のライフサイクルを検証する。
-func TestKubernetesEngineEtcdUnitLifecycle(t *testing.T) {
-	rec := installFakeSystemd(t)
-	dataDir := filepath.Join(t.TempDir(), "data")
-
-	cfg := KubernetesEngineEtcdUnitConfig{
-		ClusterName:    "demo",
-		EtcdBinaryPath: "/var/lib/marmot/mke/etcd/v3.6.8-linux-amd64/etcd",
-		DataDir:        dataDir,
-		ClientPort:     23790,
-		PeerPort:       23791,
-	}
-
-	// 作成→起動
-	if err := CreateKubernetesEngineEtcdUnit(cfg); err != nil {
-		t.Fatalf("CreateKubernetesEngineEtcdUnit() failed: %v", err)
-	}
-	if _, err := os.Stat(dataDir); err != nil {
-		t.Fatalf("data dir was not created: %v", err)
-	}
-	unitPath := kubernetesEngineEtcdUnitPath("demo")
-	content, err := os.ReadFile(unitPath)
-	if err != nil {
-		t.Fatalf("unit file was not written: %v", err)
-	}
-	if !strings.Contains(string(content), cfg.EtcdBinaryPath) {
-		t.Fatalf("unit file does not reference etcd binary path: %s", content)
-	}
-	if !strings.Contains(string(content), "23790") || !strings.Contains(string(content), "23791") {
-		t.Fatalf("unit file does not reference allocated ports: %s", content)
-	}
-
-	wantAfterCreate := []string{"daemon-reload", "enable:mke-etcd-demo.service", "start:mke-etcd-demo.service"}
-	assertCallsEqual(t, rec.calls, wantAfterCreate)
-
-	// 停止
-	rec.calls = nil
-	if err := StopKubernetesEngineEtcdUnit("demo"); err != nil {
-		t.Fatalf("StopKubernetesEngineEtcdUnit() failed: %v", err)
-	}
-	assertCallsEqual(t, rec.calls, []string{"stop:mke-etcd-demo.service"})
-	if _, err := os.Stat(unitPath); err != nil {
-		t.Fatalf("unit file should remain after stop: %v", err)
-	}
-
-	// 削除
-	rec.calls = nil
-	if err := DeleteKubernetesEngineEtcdUnit("demo"); err != nil {
-		t.Fatalf("DeleteKubernetesEngineEtcdUnit() failed: %v", err)
-	}
-	wantAfterDelete := []string{"stop:mke-etcd-demo.service", "disable:mke-etcd-demo.service", "daemon-reload"}
-	assertCallsEqual(t, rec.calls, wantAfterDelete)
-	if _, err := os.Stat(unitPath); !os.IsNotExist(err) {
-		t.Fatalf("unit file should be removed after delete, stat err = %v", err)
-	}
-
-	// 削除後の再削除は冪等(ユニットファイル不在でもエラーにならない)であること
-	rec.calls = nil
-	if err := DeleteKubernetesEngineEtcdUnit("demo"); err != nil {
-		t.Fatalf("DeleteKubernetesEngineEtcdUnit() second call failed: %v", err)
-	}
-}
-
-// DeleteKubernetesEngineEtcdUnit は「ユニット不在」相当の失敗のみ無視し、
-// それ以外の失敗(権限不足等)はユニットファイルが既に存在しない場合でも
-// 呼び出し元に伝播することを検証する。
-func TestDeleteKubernetesEngineEtcdUnitPropagatesNonMissingErrors(t *testing.T) {
-	installFakeSystemd(t)
-
-	origStop := systemdStopUnit
-	t.Cleanup(func() { systemdStopUnit = origStop })
-	systemdStopUnit = func(unit string) error {
-		return errors.New("permission denied")
-	}
-
-	err := DeleteKubernetesEngineEtcdUnit("demo")
-	if err == nil {
-		t.Fatalf("expected error to propagate, got nil")
-	}
-	if !strings.Contains(err.Error(), "permission denied") {
-		t.Fatalf("error = %v, want it to contain %q", err, "permission denied")
-	}
-}
-
-// systemctlが「ユニット不在」を示すメッセージで失敗した場合は、ユニットファイルが
-// 既に存在しなくても DeleteKubernetesEngineEtcdUnit が成功する(冪等)ことを検証する。
-func TestDeleteKubernetesEngineEtcdUnitIgnoresUnitMissingErrors(t *testing.T) {
-	installFakeSystemd(t)
-
-	origStop := systemdStopUnit
-	origDisable := systemdDisableUnit
-	t.Cleanup(func() {
-		systemdStopUnit = origStop
-		systemdDisableUnit = origDisable
+	It("renders the network namespace into the unit file", func() {
+		content := renderKubernetesEngineEtcdUnit(KubernetesEngineEtcdUnitConfig{
+			ClusterName:      "demo",
+			EtcdBinaryPath:   "/bin/etcd",
+			DataDir:          "/var/lib/etcd",
+			NetworkNamespace: "mke-demo",
+			ClientPort:       23790,
+			PeerPort:         23791,
+		})
+		Expect(content).To(ContainSubstring("NetworkNamespacePath=/run/netns/mke-demo"))
 	})
-	systemdStopUnit = func(unit string) error {
-		return &systemdUnitMissingError{err: errors.New("Unit " + unit + " not loaded.")}
-	}
-	systemdDisableUnit = func(unit string) error {
-		return &systemdUnitMissingError{err: errors.New("Failed to disable unit: No such file or directory")}
-	}
 
-	if err := DeleteKubernetesEngineEtcdUnit("demo"); err != nil {
-		t.Fatalf("DeleteKubernetesEngineEtcdUnit() failed: %v", err)
-	}
-}
+	// クラスタ専用etcdユニットの「作成→起動→停止→削除」の一連のライフサイクルを検証する。
+	It("creates, starts, stops and deletes the etcd unit for a cluster (idempotently)", func() {
+		rec := installFakeSystemd()
+		dataDir := filepath.Join(GinkgoT().TempDir(), "data")
 
-// StopKubernetesEngineEtcdUnit はCreate/Deleteと同様に不正なクラスタ名を拒否し、
-// systemctlを呼び出さないことを検証する。
-func TestStopKubernetesEngineEtcdUnitRejectsInvalidClusterName(t *testing.T) {
-	rec := installFakeSystemd(t)
-
-	if err := StopKubernetesEngineEtcdUnit(" "); err == nil {
-		t.Fatalf("expected error for empty cluster name, got nil")
-	}
-	if err := StopKubernetesEngineEtcdUnit("demo/../etc"); err == nil {
-		t.Fatalf("expected error for invalid cluster name, got nil")
-	}
-	if len(rec.calls) != 0 {
-		t.Fatalf("systemctl should not be called for invalid cluster name, calls = %v", rec.calls)
-	}
-}
-
-func assertCallsEqual(t *testing.T, got, want []string) {
-	t.Helper()
-	if len(got) != len(want) {
-		t.Fatalf("calls = %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("calls = %v, want %v", got, want)
+		cfg := KubernetesEngineEtcdUnitConfig{
+			ClusterName:    "demo",
+			EtcdBinaryPath: "/var/lib/marmot/mke/etcd/v3.6.8-linux-amd64/etcd",
+			DataDir:        dataDir,
+			ClientPort:     23790,
+			PeerPort:       23791,
 		}
-	}
-}
+
+		// 作成→起動
+		Expect(CreateKubernetesEngineEtcdUnit(cfg)).To(Succeed())
+		_, err := os.Stat(dataDir)
+		Expect(err).NotTo(HaveOccurred())
+		unitPath := kubernetesEngineEtcdUnitPath("demo")
+		content, err := os.ReadFile(unitPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(ContainSubstring(cfg.EtcdBinaryPath))
+		Expect(string(content)).To(ContainSubstring("23790"))
+		Expect(string(content)).To(ContainSubstring("23791"))
+
+		Expect(rec.calls).To(Equal([]string{"daemon-reload", "enable:mke-etcd-demo.service", "start:mke-etcd-demo.service"}))
+
+		// 停止
+		rec.calls = nil
+		Expect(StopKubernetesEngineEtcdUnit("demo")).To(Succeed())
+		Expect(rec.calls).To(Equal([]string{"stop:mke-etcd-demo.service"}))
+		_, err = os.Stat(unitPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		// 削除
+		rec.calls = nil
+		Expect(DeleteKubernetesEngineEtcdUnit("demo")).To(Succeed())
+		Expect(rec.calls).To(Equal([]string{"stop:mke-etcd-demo.service", "disable:mke-etcd-demo.service", "daemon-reload"}))
+		_, err = os.Stat(unitPath)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+
+		// 削除後の再削除は冪等(ユニットファイル不在でもエラーにならない)であること
+		rec.calls = nil
+		Expect(DeleteKubernetesEngineEtcdUnit("demo")).To(Succeed())
+	})
+
+	// DeleteKubernetesEngineEtcdUnit は「ユニット不在」相当の失敗のみ無視し、
+	// それ以外の失敗(権限不足等)はユニットファイルが既に存在しない場合でも
+	// 呼び出し元に伝播することを検証する。
+	It("propagates non-missing-unit errors", func() {
+		installFakeSystemd()
+
+		origStop := systemdStopUnit
+		DeferCleanup(func() { systemdStopUnit = origStop })
+		systemdStopUnit = func(unit string) error {
+			return errors.New("permission denied")
+		}
+
+		err := DeleteKubernetesEngineEtcdUnit("demo")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("permission denied"))
+	})
+
+	// systemctlが「ユニット不在」を示すメッセージで失敗した場合は、ユニットファイルが
+	// 既に存在しなくても DeleteKubernetesEngineEtcdUnit が成功する(冪等)ことを検証する。
+	It("ignores unit-missing errors", func() {
+		installFakeSystemd()
+
+		origStop := systemdStopUnit
+		origDisable := systemdDisableUnit
+		DeferCleanup(func() {
+			systemdStopUnit = origStop
+			systemdDisableUnit = origDisable
+		})
+		systemdStopUnit = func(unit string) error {
+			return &systemdUnitMissingError{err: errors.New("Unit " + unit + " not loaded.")}
+		}
+		systemdDisableUnit = func(unit string) error {
+			return &systemdUnitMissingError{err: errors.New("Failed to disable unit: No such file or directory")}
+		}
+
+		Expect(DeleteKubernetesEngineEtcdUnit("demo")).To(Succeed())
+	})
+
+	// StopKubernetesEngineEtcdUnit はCreate/Deleteと同様に不正なクラスタ名を拒否し、
+	// systemctlを呼び出さないことを検証する。
+	It("rejects invalid cluster names without calling systemctl", func() {
+		rec := installFakeSystemd()
+
+		Expect(StopKubernetesEngineEtcdUnit(" ")).To(HaveOccurred())
+		Expect(StopKubernetesEngineEtcdUnit("demo/../etc")).To(HaveOccurred())
+		Expect(rec.calls).To(BeEmpty())
+	})
+})

--- a/pkg/controller/kubernetes-engine-node-ssh.go
+++ b/pkg/controller/kubernetes-engine-node-ssh.go
@@ -1,0 +1,347 @@
+package controller
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var kubernetesEngineNodeSSHPort = 22
+
+var kubernetesEngineNodeSSHDialTimeout = 10 * time.Second
+
+// kubernetesEngineNodeProvisionData holds everything needed to provision a
+// KubernetesEngine worker node over SSH (replacing the former ansible-playbook based flow).
+type kubernetesEngineNodeProvisionData struct {
+	NodeName            string
+	NodeIP              string
+	KubernetesVersion   string
+	ContainerdVersion   string
+	RuncVersion         string
+	CACert              []byte
+	KubeletCert         []byte
+	KubeletKey          []byte
+	KubeProxyCert       []byte
+	KubeProxyKey        []byte
+	KubeletKubeconfig   []byte
+	KubeProxyKubeconfig []byte
+	KubeletConfig       []byte
+	KubeProxyConfig     []byte
+}
+
+// kubernetesEngineNodeCommandRunner executes commands on a KubernetesEngine node,
+// allowing the provisioning steps to be tested without a real SSH connection.
+type kubernetesEngineNodeCommandRunner interface {
+	step(name string, fn func() error) error
+	run(cmd string, stdin io.Reader) error
+	output(cmd string) (string, error)
+	writeFile(path, mode string, content []byte) error
+}
+
+// provisionKubernetesEngineNodeSSH connects to the node via SSH and runs the same setup
+// steps that were previously encoded as an ansible-playbook (install runtime deps, fetch
+// containerd/runc/kubelet/kube-proxy, place credentials, install systemd units).
+func provisionKubernetesEngineNodeSSH(address, privateKeyPath, nodeID string, data kubernetesEngineNodeProvisionData) error {
+	client, err := dialKubernetesEngineNodeSSH(address, privateKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to connect to node %s: %w", data.NodeName, err)
+	}
+	defer func() { _ = client.Close() }()
+
+	runner := &kubernetesEngineNodeSSHRunner{client: client, resourceID: nodeID}
+	return runKubernetesEngineNodeProvisionSteps(runner, data)
+}
+
+func runKubernetesEngineNodeProvisionSteps(runner kubernetesEngineNodeCommandRunner, data kubernetesEngineNodeProvisionData) error {
+
+	if err := runner.step("install runtime dependencies", func() error {
+		return runner.run("DEBIAN_FRONTEND=noninteractive apt-get update && "+
+			"DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates conntrack curl iptables socat", nil)
+	}); err != nil {
+		return err
+	}
+
+	arch, err := detectKubernetesEngineNodeArch(runner)
+	if err != nil {
+		return fmt.Errorf("failed to detect node architecture: %w", err)
+	}
+
+	if err := runner.step("create Kubernetes directories", func() error {
+		return runner.run("mkdir -p /etc/kubernetes /etc/kubernetes/pki /etc/kubernetes/kubelet "+
+			"/etc/kubernetes/kube-proxy /opt/cni/bin", nil)
+	}); err != nil {
+		return err
+	}
+
+	containerdURL := fmt.Sprintf("https://github.com/containerd/containerd/releases/download/v%s/containerd-%s-linux-%s.tar.gz",
+		data.ContainerdVersion, data.ContainerdVersion, arch)
+	if err := runner.step("install containerd", func() error {
+		return runner.run(fmt.Sprintf("test -e /usr/local/bin/containerd || (curl -fsSL %s | tar -xz -C /usr/local)",
+			shellQuote(containerdURL)), nil)
+	}); err != nil {
+		return err
+	}
+
+	runcURL := fmt.Sprintf("https://github.com/opencontainers/runc/releases/download/v%s/runc.%s", data.RuncVersion, arch)
+	if err := runner.step("install runc", func() error {
+		return runner.run(fmt.Sprintf("test -e /usr/local/sbin/runc || (curl -fsSL %s -o /usr/local/sbin/runc && chmod 0755 /usr/local/sbin/runc)",
+			shellQuote(runcURL)), nil)
+	}); err != nil {
+		return err
+	}
+
+	for _, bin := range []string{"kubelet", "kube-proxy"} {
+		binURL := fmt.Sprintf("https://dl.k8s.io/release/%s/bin/linux/%s/%s", data.KubernetesVersion, arch, bin)
+		dest := "/usr/local/bin/" + bin
+		if err := runner.step("install "+bin+" binary", func() error {
+			return runner.run(fmt.Sprintf("test -e %s || (curl -fsSL %s -o %s && chmod 0755 %s)",
+				shellQuote(dest), shellQuote(binURL), shellQuote(dest), shellQuote(dest)), nil)
+		}); err != nil {
+			return err
+		}
+	}
+
+	credentialFiles := []struct {
+		path    string
+		content []byte
+	}{
+		{"/etc/kubernetes/pki/ca.crt", data.CACert},
+		{"/etc/kubernetes/pki/kubelet.crt", data.KubeletCert},
+		{"/etc/kubernetes/pki/kubelet.key", data.KubeletKey},
+		{"/etc/kubernetes/pki/kube-proxy.crt", data.KubeProxyCert},
+		{"/etc/kubernetes/pki/kube-proxy.key", data.KubeProxyKey},
+		{"/etc/kubernetes/kubelet.kubeconfig", data.KubeletKubeconfig},
+		{"/etc/kubernetes/kube-proxy.kubeconfig", data.KubeProxyKubeconfig},
+		{"/etc/kubernetes/kubelet/config.yaml", data.KubeletConfig},
+		{"/etc/kubernetes/kube-proxy/config.yaml", data.KubeProxyConfig},
+	}
+	if err := runner.step("install cluster credentials and configuration", func() error {
+		for _, file := range credentialFiles {
+			if err := runner.writeFile(file.path, "0600", file.content); err != nil {
+				return fmt.Errorf("failed to write %s: %w", file.path, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := runner.step("generate containerd configuration", func() error {
+		return runner.run("mkdir -p /etc/containerd && "+
+			"test -e /etc/containerd/config.toml || "+
+			"(/usr/local/bin/containerd config default > /etc/containerd/config.toml && "+
+			"sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml)", nil)
+	}); err != nil {
+		return err
+	}
+
+	units := []struct {
+		name    string
+		content string
+	}{
+		{"containerd.service", kubernetesEngineNodeContainerdUnit()},
+		{"kubelet.service", kubernetesEngineNodeKubeletUnit(data.NodeName, data.NodeIP)},
+		{"kube-proxy.service", kubernetesEngineNodeKubeProxyUnit()},
+	}
+	if err := runner.step("install systemd units", func() error {
+		for _, unit := range units {
+			path := "/etc/systemd/system/" + unit.name
+			if err := runner.writeFile(path, "0644", []byte(unit.content)); err != nil {
+				return fmt.Errorf("failed to write %s: %w", path, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return runner.step("enable Kubernetes node services", func() error {
+		return runner.run("systemctl daemon-reload && systemctl enable --now containerd kubelet kube-proxy", nil)
+	})
+}
+
+func detectKubernetesEngineNodeArch(runner kubernetesEngineNodeCommandRunner) (string, error) {
+	machine, err := runner.output("uname -m")
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(machine) == "x86_64" {
+		return "amd64", nil
+	}
+	return "arm64", nil
+}
+
+func kubernetesEngineNodeContainerdUnit() string {
+	return `[Unit]
+Description=containerd container runtime
+After=network.target local-fs.target
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/containerd
+Restart=always
+Delegate=yes
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target
+`
+}
+
+func kubernetesEngineNodeKubeletUnit(nodeName, nodeIP string) string {
+	return fmt.Sprintf(`[Unit]
+Description=Kubernetes Kubelet
+Wants=network-online.target containerd.service
+After=network-online.target containerd.service
+
+[Service]
+ExecStart=/usr/local/bin/kubelet --config=/etc/kubernetes/kubelet/config.yaml --kubeconfig=/etc/kubernetes/kubelet.kubeconfig --hostname-override=%s --node-ip=%s
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`, nodeName, nodeIP)
+}
+
+func kubernetesEngineNodeKubeProxyUnit() string {
+	return `[Unit]
+Description=Kubernetes Kube Proxy
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/kube-proxy --config=/etc/kubernetes/kube-proxy/config.yaml
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+`
+}
+
+func dialKubernetesEngineNodeSSH(address, privateKeyPath string) (*ssh.Client, error) {
+	keyData, err := os.ReadFile(privateKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read private key: %w", err)
+	}
+	signer, err := ssh.ParsePrivateKey(keyData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+	config := &ssh.ClientConfig{
+		User: "root",
+		Auth: []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		// ノードは使い捨てのVMであり、事前にホスト鍵を検証する手段がないため無視する
+		// （旧ansible実行時の -o StrictHostKeyChecking=no と同等）。
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         kubernetesEngineNodeSSHDialTimeout,
+	}
+	trimmed := strings.TrimSpace(address)
+	if trimmed == "" {
+		return nil, fmt.Errorf("node address is empty")
+	}
+	return ssh.Dial("tcp", net.JoinHostPort(trimmed, fmt.Sprintf("%d", kubernetesEngineNodeSSHPort)), config)
+}
+
+// kubernetesEngineNodeSSHRunner executes commands on a KubernetesEngine node over SSH,
+// streaming each output line to slog so long-running steps stay visible in CI logs.
+type kubernetesEngineNodeSSHRunner struct {
+	client     *ssh.Client
+	resourceID string
+}
+
+func (r *kubernetesEngineNodeSSHRunner) step(name string, fn func() error) error {
+	slog.Info("kubernetes-engine-node provision step", "id", r.resourceID, "step", name)
+	if err := fn(); err != nil {
+		return fmt.Errorf("%s: %w", name, err)
+	}
+	return nil
+}
+
+func (r *kubernetesEngineNodeSSHRunner) run(cmd string, stdin io.Reader) error {
+	session, err := r.client.NewSession()
+	if err != nil {
+		return fmt.Errorf("failed to open ssh session: %w", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	var buf bytes.Buffer
+	lineLogger := &kubernetesEngineNodeSSHLineLogger{resourceID: r.resourceID}
+	mw := io.MultiWriter(&buf, lineLogger)
+	session.Stdout = mw
+	session.Stderr = mw
+	if stdin != nil {
+		session.Stdin = stdin
+	}
+	if err := session.Run(cmd); err != nil {
+		trimmed := strings.TrimSpace(buf.String())
+		if trimmed == "" {
+			return fmt.Errorf("remote command failed: %w", err)
+		}
+		return fmt.Errorf("remote command failed: %w: %s", err, trimmed)
+	}
+	return nil
+}
+
+func (r *kubernetesEngineNodeSSHRunner) output(cmd string) (string, error) {
+	session, err := r.client.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("failed to open ssh session: %w", err)
+	}
+	defer func() { _ = session.Close() }()
+	out, err := session.CombinedOutput(cmd)
+	if err != nil {
+		return "", fmt.Errorf("remote command failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (r *kubernetesEngineNodeSSHRunner) writeFile(path, mode string, content []byte) error {
+	cmd := fmt.Sprintf("mkdir -p %s && cat > %s && chmod %s %s",
+		shellQuote(parentDir(path)), shellQuote(path), mode, shellQuote(path))
+	return r.run(cmd, bytes.NewReader(content))
+}
+
+func parentDir(path string) string {
+	idx := strings.LastIndex(path, "/")
+	if idx <= 0 {
+		return "/"
+	}
+	return path[:idx]
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// kubernetesEngineNodeSSHLineLogger streams remote command output to slog line-by-line,
+// mirroring the ansible-playbook progress logging it replaces.
+type kubernetesEngineNodeSSHLineLogger struct {
+	resourceID string
+	pending    []byte
+}
+
+func (l *kubernetesEngineNodeSSHLineLogger) Write(p []byte) (int, error) {
+	l.pending = append(l.pending, p...)
+	for {
+		idx := bytes.IndexByte(l.pending, '\n')
+		if idx < 0 {
+			break
+		}
+		line := strings.TrimRight(string(l.pending[:idx]), "\r")
+		l.pending = l.pending[idx+1:]
+		if line == "" {
+			continue
+		}
+		slog.Info("kubernetes-engine-node provision progress", "id", l.resourceID, "line", line)
+	}
+	return len(p), nil
+}

--- a/pkg/controller/kubernetes-engine-node-ssh.go
+++ b/pkg/controller/kubernetes-engine-node-ssh.go
@@ -102,10 +102,19 @@ func runKubernetesEngineNodeProvisionSteps(runner kubernetesEngineNodeCommandRun
 
 	for _, bin := range []string{"kubelet", "kube-proxy"} {
 		binURL := fmt.Sprintf("https://dl.k8s.io/release/%s/bin/linux/%s/%s", data.KubernetesVersion, arch, bin)
+		shaURL := binURL + ".sha256"
 		dest := "/usr/local/bin/" + bin
 		if err := runner.step("install "+bin+" binary", func() error {
-			return runner.run(fmt.Sprintf("test -e %s || (curl -fsSL %s -o %s && chmod 0755 %s)",
-				shellQuote(dest), shellQuote(binURL), shellQuote(dest), shellQuote(dest)), nil)
+			return runner.run(fmt.Sprintf(
+				"test -e %s || ("+
+					"tmp=$(mktemp) && "+
+					"curl -fsSL %s -o \"$tmp\" && "+
+					"sha=$(curl -fsSL %s | awk '{print $1}') && "+
+					"echo \"$sha  $tmp\" | sha256sum -c - && "+
+					"install -m 0755 \"$tmp\" %s"+
+				")",
+				shellQuote(dest), shellQuote(binURL), shellQuote(shaURL), shellQuote(dest),
+			), nil)
 		}); err != nil {
 			return err
 		}

--- a/pkg/controller/kubernetes-engine-node-ssh.go
+++ b/pkg/controller/kubernetes-engine-node-ssh.go
@@ -48,8 +48,11 @@ type kubernetesEngineNodeCommandRunner interface {
 // provisionKubernetesEngineNodeSSH connects to the node via SSH and runs the same setup
 // steps that were previously encoded as an ansible-playbook (install runtime deps, fetch
 // containerd/runc/kubelet/kube-proxy, place credentials, install systemd units).
-func provisionKubernetesEngineNodeSSH(address, privateKeyPath, nodeID string, data kubernetesEngineNodeProvisionData) error {
-	client, err := dialKubernetesEngineNodeSSH(address, privateKeyPath)
+// namespace は、ノードが接続された「ノード間通信用ネットワーク」に到達するために使用する
+// ネットワーク名前空間(コントロールプレーン用に作成済みのnetnsを再利用する)。空文字の場合は
+// 呼び出し元プロセスの名前空間からそのままダイヤルする。
+func provisionKubernetesEngineNodeSSH(address, privateKeyPath, namespace, nodeID string, data kubernetesEngineNodeProvisionData) error {
+	client, err := dialKubernetesEngineNodeSSH(address, privateKeyPath, namespace)
 	if err != nil {
 		return fmt.Errorf("failed to connect to node %s: %w", data.NodeName, err)
 	}
@@ -227,7 +230,13 @@ WantedBy=multi-user.target
 `
 }
 
-func dialKubernetesEngineNodeSSH(address, privateKeyPath string) (*ssh.Client, error) {
+// kubernetesEngineNodeDialTCP は、必要に応じて指定されたネットワーク名前空間からTCP接続を確立する。
+// テストからモック可能にするための注入ポイント。
+var kubernetesEngineNodeDialTCP = func(namespace, network, address string) (net.Conn, error) {
+	return DialInKubernetesEngineNetworkNamespace(namespace, network, address, kubernetesEngineNodeSSHDialTimeout)
+}
+
+func dialKubernetesEngineNodeSSH(address, privateKeyPath, namespace string) (*ssh.Client, error) {
 	keyData, err := os.ReadFile(privateKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read private key: %w", err)
@@ -248,7 +257,18 @@ func dialKubernetesEngineNodeSSH(address, privateKeyPath string) (*ssh.Client, e
 	if trimmed == "" {
 		return nil, fmt.Errorf("node address is empty")
 	}
-	return ssh.Dial("tcp", net.JoinHostPort(trimmed, fmt.Sprintf("%d", kubernetesEngineNodeSSHPort)), config)
+	targetAddr := net.JoinHostPort(trimmed, fmt.Sprintf("%d", kubernetesEngineNodeSSHPort))
+
+	conn, err := kubernetesEngineNodeDialTCP(namespace, "tcp", targetAddr)
+	if err != nil {
+		return nil, err
+	}
+	clientConn, chans, reqs, err := ssh.NewClientConn(conn, targetAddr, config)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return ssh.NewClient(clientConn, chans, reqs), nil
 }
 
 // kubernetesEngineNodeSSHRunner executes commands on a KubernetesEngine node over SSH,
@@ -259,7 +279,7 @@ type kubernetesEngineNodeSSHRunner struct {
 }
 
 func (r *kubernetesEngineNodeSSHRunner) step(name string, fn func() error) error {
-	slog.Info("kubernetes-engine-node provision step", "id", r.resourceID, "step", name)
+	slog.Debug("kubernetes-engine-node provision step", "id", r.resourceID, "step", name)
 	if err := fn(); err != nil {
 		return fmt.Errorf("%s: %w", name, err)
 	}
@@ -341,7 +361,7 @@ func (l *kubernetesEngineNodeSSHLineLogger) Write(p []byte) (int, error) {
 		if line == "" {
 			continue
 		}
-		slog.Info("kubernetes-engine-node provision progress", "id", l.resourceID, "line", line)
+		slog.Debug("kubernetes-engine-node provision progress", "id", l.resourceID, "line", line)
 	}
 	return len(p), nil
 }

--- a/pkg/controller/kubernetes-engine-node-ssh_test.go
+++ b/pkg/controller/kubernetes-engine-node-ssh_test.go
@@ -1,0 +1,147 @@
+package controller
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// fakeKubernetesEngineNodeCommandRunner records every command/file write issued by
+// runKubernetesEngineNodeProvisionSteps so it can be verified without a real SSH connection.
+type fakeKubernetesEngineNodeCommandRunner struct {
+	commands []string
+	files    map[string]string
+	outputs  map[string]string
+	failCmd  string
+}
+
+func (r *fakeKubernetesEngineNodeCommandRunner) step(name string, fn func() error) error {
+	if err := fn(); err != nil {
+		return fmt.Errorf("%s: %w", name, err)
+	}
+	return nil
+}
+
+func (r *fakeKubernetesEngineNodeCommandRunner) run(cmd string, stdin io.Reader) error {
+	r.commands = append(r.commands, cmd)
+	if r.failCmd != "" && strings.Contains(cmd, r.failCmd) {
+		return fmt.Errorf("simulated failure")
+	}
+	return nil
+}
+
+func (r *fakeKubernetesEngineNodeCommandRunner) output(cmd string) (string, error) {
+	r.commands = append(r.commands, cmd)
+	return r.outputs[cmd], nil
+}
+
+func (r *fakeKubernetesEngineNodeCommandRunner) writeFile(path, mode string, content []byte) error {
+	if r.files == nil {
+		r.files = map[string]string{}
+	}
+	r.files[path] = string(content)
+	return nil
+}
+
+func newTestKubernetesEngineNodeProvisionData() kubernetesEngineNodeProvisionData {
+	return kubernetesEngineNodeProvisionData{
+		NodeName:            "mke-demo-node-1",
+		NodeIP:              "172.16.1.10",
+		KubernetesVersion:   "v1.36.2",
+		ContainerdVersion:   "2.3.1",
+		RuncVersion:         "1.4.0",
+		CACert:              []byte("ca"),
+		KubeletCert:         []byte("kubelet-cert"),
+		KubeletKey:          []byte("kubelet-key"),
+		KubeProxyCert:       []byte("kube-proxy-cert"),
+		KubeProxyKey:        []byte("kube-proxy-key"),
+		KubeletKubeconfig:   []byte("kubelet-kubeconfig"),
+		KubeProxyKubeconfig: []byte("kube-proxy-kubeconfig"),
+		KubeletConfig:       []byte("kubelet-config"),
+		KubeProxyConfig:     []byte("kube-proxy-config"),
+	}
+}
+
+func TestRunKubernetesEngineNodeProvisionSteps(t *testing.T) {
+	runner := &fakeKubernetesEngineNodeCommandRunner{outputs: map[string]string{"uname -m": "x86_64"}}
+	data := newTestKubernetesEngineNodeProvisionData()
+
+	if err := runKubernetesEngineNodeProvisionSteps(runner, data); err != nil {
+		t.Fatalf("runKubernetesEngineNodeProvisionSteps() failed: %v", err)
+	}
+
+	joined := strings.Join(runner.commands, "\n")
+	for _, want := range []string{
+		"apt-get install -y ca-certificates conntrack curl iptables socat",
+		"uname -m",
+		"mkdir -p /etc/kubernetes /etc/kubernetes/pki /etc/kubernetes/kubelet /etc/kubernetes/kube-proxy /opt/cni/bin",
+		"containerd-2.3.1-linux-amd64.tar.gz",
+		"runc.amd64",
+		"/usr/local/bin/kubelet",
+		"/usr/local/bin/kube-proxy",
+		"containerd config default > /etc/containerd/config.toml",
+		"systemctl daemon-reload && systemctl enable --now containerd kubelet kube-proxy",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("commands do not contain %q; got: %s", want, joined)
+		}
+	}
+
+	wantFiles := map[string]string{
+		"/etc/kubernetes/pki/ca.crt":             "ca",
+		"/etc/kubernetes/pki/kubelet.crt":        "kubelet-cert",
+		"/etc/kubernetes/pki/kubelet.key":        "kubelet-key",
+		"/etc/kubernetes/pki/kube-proxy.crt":     "kube-proxy-cert",
+		"/etc/kubernetes/pki/kube-proxy.key":     "kube-proxy-key",
+		"/etc/kubernetes/kubelet.kubeconfig":     "kubelet-kubeconfig",
+		"/etc/kubernetes/kube-proxy.kubeconfig":  "kube-proxy-kubeconfig",
+		"/etc/kubernetes/kubelet/config.yaml":    "kubelet-config",
+		"/etc/kubernetes/kube-proxy/config.yaml": "kube-proxy-config",
+		"/etc/systemd/system/containerd.service": "",
+		"/etc/systemd/system/kubelet.service":    "",
+		"/etc/systemd/system/kube-proxy.service": "",
+	}
+	for path, want := range wantFiles {
+		got, ok := runner.files[path]
+		if !ok {
+			t.Fatalf("file %s was not written", path)
+		}
+		if want != "" && got != want {
+			t.Fatalf("file %s content = %q, want %q", path, got, want)
+		}
+	}
+	if !strings.Contains(runner.files["/etc/systemd/system/kubelet.service"], "--hostname-override=mke-demo-node-1 --node-ip=172.16.1.10") {
+		t.Fatalf("kubelet.service does not reference node name/ip: %s", runner.files["/etc/systemd/system/kubelet.service"])
+	}
+}
+
+func TestRunKubernetesEngineNodeProvisionSteps_ArmArch(t *testing.T) {
+	runner := &fakeKubernetesEngineNodeCommandRunner{outputs: map[string]string{"uname -m": "aarch64"}}
+	data := newTestKubernetesEngineNodeProvisionData()
+
+	if err := runKubernetesEngineNodeProvisionSteps(runner, data); err != nil {
+		t.Fatalf("runKubernetesEngineNodeProvisionSteps() failed: %v", err)
+	}
+
+	joined := strings.Join(runner.commands, "\n")
+	if !strings.Contains(joined, "containerd-2.3.1-linux-arm64.tar.gz") || !strings.Contains(joined, "runc.arm64") {
+		t.Fatalf("commands do not reflect arm64 architecture: %s", joined)
+	}
+}
+
+func TestRunKubernetesEngineNodeProvisionSteps_StepFailureIsWrapped(t *testing.T) {
+	runner := &fakeKubernetesEngineNodeCommandRunner{
+		outputs: map[string]string{"uname -m": "x86_64"},
+		failCmd: "apt-get install",
+	}
+	data := newTestKubernetesEngineNodeProvisionData()
+
+	err := runKubernetesEngineNodeProvisionSteps(runner, data)
+	if err == nil {
+		t.Fatalf("runKubernetesEngineNodeProvisionSteps() succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "install runtime dependencies") {
+		t.Fatalf("error = %v, want it to mention the failed step name", err)
+	}
+}

--- a/pkg/controller/kubernetes-engine-node-ssh_test.go
+++ b/pkg/controller/kubernetes-engine-node-ssh_test.go
@@ -1,13 +1,31 @@
 package controller
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// writeTestSSHPrivateKey writes a freshly generated RSA private key (PKCS#1 PEM, the
+// format ssh.ParsePrivateKey accepts) to dir and returns its path.
+func writeTestSSHPrivateKey(dir string) string {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).NotTo(HaveOccurred())
+	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+	path := filepath.Join(dir, "id_rsa")
+	Expect(os.WriteFile(path, pem.EncodeToMemory(block), 0o600)).To(Succeed())
+	return path
+}
 
 // fakeKubernetesEngineNodeCommandRunner records every command/file write issued by
 // runKubernetesEngineNodeProvisionSteps so it can be verified without a real SSH connection.
@@ -45,6 +63,53 @@ func (r *fakeKubernetesEngineNodeCommandRunner) writeFile(path, mode string, con
 	r.files[path] = string(content)
 	return nil
 }
+
+var _ = Describe("dialKubernetesEngineNodeSSH", func() {
+	It("routes the TCP dial through the requested network namespace", func() {
+		origDial := kubernetesEngineNodeDialTCP
+		DeferCleanup(func() { kubernetesEngineNodeDialTCP = origDial })
+
+		clientConn, serverConn := net.Pipe()
+		// サーバー側を即座に閉じることで、本物のSSHサーバーが応答しない状態でも
+		// ハンドシェイクが無限に待たされず速やかに失敗するようにする。
+		Expect(serverConn.Close()).To(Succeed())
+
+		var gotNamespace, gotNetwork, gotAddress string
+		kubernetesEngineNodeDialTCP = func(namespace, network, address string) (net.Conn, error) {
+			gotNamespace, gotNetwork, gotAddress = namespace, network, address
+			return clientConn, nil
+		}
+
+		keyPath := writeTestSSHPrivateKey(GinkgoT().TempDir())
+
+		// 相手側に本物のSSHサーバーが無いためハンドシェイクは失敗するが、
+		// namespace/network/addressがダイヤル層へ正しく伝わることは検証できる。
+		_, err := dialKubernetesEngineNodeSSH("172.16.1.10", keyPath, "mke-demo")
+		Expect(err).To(HaveOccurred())
+		Expect(gotNamespace).To(Equal("mke-demo"))
+		Expect(gotNetwork).To(Equal("tcp"))
+		Expect(gotAddress).To(Equal("172.16.1.10:22"))
+	})
+
+	It("dials directly when no namespace is given", func() {
+		origDial := kubernetesEngineNodeDialTCP
+		DeferCleanup(func() { kubernetesEngineNodeDialTCP = origDial })
+
+		var gotNamespace string
+		called := false
+		kubernetesEngineNodeDialTCP = func(namespace, network, address string) (net.Conn, error) {
+			called = true
+			gotNamespace = namespace
+			return nil, fmt.Errorf("simulated dial failure")
+		}
+
+		keyPath := writeTestSSHPrivateKey(GinkgoT().TempDir())
+		_, err := dialKubernetesEngineNodeSSH("172.16.1.10", keyPath, "")
+		Expect(err).To(HaveOccurred())
+		Expect(called).To(BeTrue())
+		Expect(gotNamespace).To(BeEmpty())
+	})
+})
 
 func newTestKubernetesEngineNodeProvisionData() kubernetesEngineNodeProvisionData {
 	return kubernetesEngineNodeProvisionData{

--- a/pkg/controller/kubernetes-engine-node-ssh_test.go
+++ b/pkg/controller/kubernetes-engine-node-ssh_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // fakeKubernetesEngineNodeCommandRunner records every command/file write issued by
@@ -63,85 +65,71 @@ func newTestKubernetesEngineNodeProvisionData() kubernetesEngineNodeProvisionDat
 	}
 }
 
-func TestRunKubernetesEngineNodeProvisionSteps(t *testing.T) {
-	runner := &fakeKubernetesEngineNodeCommandRunner{outputs: map[string]string{"uname -m": "x86_64"}}
-	data := newTestKubernetesEngineNodeProvisionData()
+var _ = Describe("runKubernetesEngineNodeProvisionSteps", func() {
+	It("installs, configures and enables containerd/kubelet/kube-proxy on x86_64", func() {
+		runner := &fakeKubernetesEngineNodeCommandRunner{outputs: map[string]string{"uname -m": "x86_64"}}
+		data := newTestKubernetesEngineNodeProvisionData()
 
-	if err := runKubernetesEngineNodeProvisionSteps(runner, data); err != nil {
-		t.Fatalf("runKubernetesEngineNodeProvisionSteps() failed: %v", err)
-	}
+		Expect(runKubernetesEngineNodeProvisionSteps(runner, data)).To(Succeed())
 
-	joined := strings.Join(runner.commands, "\n")
-	for _, want := range []string{
-		"apt-get install -y ca-certificates conntrack curl iptables socat",
-		"uname -m",
-		"mkdir -p /etc/kubernetes /etc/kubernetes/pki /etc/kubernetes/kubelet /etc/kubernetes/kube-proxy /opt/cni/bin",
-		"containerd-2.3.1-linux-amd64.tar.gz",
-		"runc.amd64",
-		"/usr/local/bin/kubelet",
-		"/usr/local/bin/kube-proxy",
-		"containerd config default > /etc/containerd/config.toml",
-		"systemctl daemon-reload && systemctl enable --now containerd kubelet kube-proxy",
-	} {
-		if !strings.Contains(joined, want) {
-			t.Fatalf("commands do not contain %q; got: %s", want, joined)
+		joined := strings.Join(runner.commands, "\n")
+		for _, want := range []string{
+			"apt-get install -y ca-certificates conntrack curl iptables socat",
+			"uname -m",
+			"mkdir -p /etc/kubernetes /etc/kubernetes/pki /etc/kubernetes/kubelet /etc/kubernetes/kube-proxy /opt/cni/bin",
+			"containerd-2.3.1-linux-amd64.tar.gz",
+			"runc.amd64",
+			"/usr/local/bin/kubelet",
+			"/usr/local/bin/kube-proxy",
+			"containerd config default > /etc/containerd/config.toml",
+			"systemctl daemon-reload && systemctl enable --now containerd kubelet kube-proxy",
+		} {
+			Expect(joined).To(ContainSubstring(want))
 		}
-	}
 
-	wantFiles := map[string]string{
-		"/etc/kubernetes/pki/ca.crt":             "ca",
-		"/etc/kubernetes/pki/kubelet.crt":        "kubelet-cert",
-		"/etc/kubernetes/pki/kubelet.key":        "kubelet-key",
-		"/etc/kubernetes/pki/kube-proxy.crt":     "kube-proxy-cert",
-		"/etc/kubernetes/pki/kube-proxy.key":     "kube-proxy-key",
-		"/etc/kubernetes/kubelet.kubeconfig":     "kubelet-kubeconfig",
-		"/etc/kubernetes/kube-proxy.kubeconfig":  "kube-proxy-kubeconfig",
-		"/etc/kubernetes/kubelet/config.yaml":    "kubelet-config",
-		"/etc/kubernetes/kube-proxy/config.yaml": "kube-proxy-config",
-		"/etc/systemd/system/containerd.service": "",
-		"/etc/systemd/system/kubelet.service":    "",
-		"/etc/systemd/system/kube-proxy.service": "",
-	}
-	for path, want := range wantFiles {
-		got, ok := runner.files[path]
-		if !ok {
-			t.Fatalf("file %s was not written", path)
+		wantFiles := map[string]string{
+			"/etc/kubernetes/pki/ca.crt":             "ca",
+			"/etc/kubernetes/pki/kubelet.crt":        "kubelet-cert",
+			"/etc/kubernetes/pki/kubelet.key":        "kubelet-key",
+			"/etc/kubernetes/pki/kube-proxy.crt":     "kube-proxy-cert",
+			"/etc/kubernetes/pki/kube-proxy.key":     "kube-proxy-key",
+			"/etc/kubernetes/kubelet.kubeconfig":     "kubelet-kubeconfig",
+			"/etc/kubernetes/kube-proxy.kubeconfig":  "kube-proxy-kubeconfig",
+			"/etc/kubernetes/kubelet/config.yaml":    "kubelet-config",
+			"/etc/kubernetes/kube-proxy/config.yaml": "kube-proxy-config",
+			"/etc/systemd/system/containerd.service": "",
+			"/etc/systemd/system/kubelet.service":    "",
+			"/etc/systemd/system/kube-proxy.service": "",
 		}
-		if want != "" && got != want {
-			t.Fatalf("file %s content = %q, want %q", path, got, want)
+		for path, want := range wantFiles {
+			Expect(runner.files).To(HaveKey(path))
+			if want != "" {
+				Expect(runner.files[path]).To(Equal(want))
+			}
 		}
-	}
-	if !strings.Contains(runner.files["/etc/systemd/system/kubelet.service"], "--hostname-override=mke-demo-node-1 --node-ip=172.16.1.10") {
-		t.Fatalf("kubelet.service does not reference node name/ip: %s", runner.files["/etc/systemd/system/kubelet.service"])
-	}
-}
+		Expect(runner.files["/etc/systemd/system/kubelet.service"]).To(ContainSubstring("--hostname-override=mke-demo-node-1 --node-ip=172.16.1.10"))
+	})
 
-func TestRunKubernetesEngineNodeProvisionSteps_ArmArch(t *testing.T) {
-	runner := &fakeKubernetesEngineNodeCommandRunner{outputs: map[string]string{"uname -m": "aarch64"}}
-	data := newTestKubernetesEngineNodeProvisionData()
+	It("selects arm64 assets when the node reports an aarch64 architecture", func() {
+		runner := &fakeKubernetesEngineNodeCommandRunner{outputs: map[string]string{"uname -m": "aarch64"}}
+		data := newTestKubernetesEngineNodeProvisionData()
 
-	if err := runKubernetesEngineNodeProvisionSteps(runner, data); err != nil {
-		t.Fatalf("runKubernetesEngineNodeProvisionSteps() failed: %v", err)
-	}
+		Expect(runKubernetesEngineNodeProvisionSteps(runner, data)).To(Succeed())
 
-	joined := strings.Join(runner.commands, "\n")
-	if !strings.Contains(joined, "containerd-2.3.1-linux-arm64.tar.gz") || !strings.Contains(joined, "runc.arm64") {
-		t.Fatalf("commands do not reflect arm64 architecture: %s", joined)
-	}
-}
+		joined := strings.Join(runner.commands, "\n")
+		Expect(joined).To(ContainSubstring("containerd-2.3.1-linux-arm64.tar.gz"))
+		Expect(joined).To(ContainSubstring("runc.arm64"))
+	})
 
-func TestRunKubernetesEngineNodeProvisionSteps_StepFailureIsWrapped(t *testing.T) {
-	runner := &fakeKubernetesEngineNodeCommandRunner{
-		outputs: map[string]string{"uname -m": "x86_64"},
-		failCmd: "apt-get install",
-	}
-	data := newTestKubernetesEngineNodeProvisionData()
+	It("wraps a failed step with its step name", func() {
+		runner := &fakeKubernetesEngineNodeCommandRunner{
+			outputs: map[string]string{"uname -m": "x86_64"},
+			failCmd: "apt-get install",
+		}
+		data := newTestKubernetesEngineNodeProvisionData()
 
-	err := runKubernetesEngineNodeProvisionSteps(runner, data)
-	if err == nil {
-		t.Fatalf("runKubernetesEngineNodeProvisionSteps() succeeded, want error")
-	}
-	if !strings.Contains(err.Error(), "install runtime dependencies") {
-		t.Fatalf("error = %v, want it to mention the failed step name", err)
-	}
-}
+		err := runKubernetesEngineNodeProvisionSteps(runner, data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("install runtime dependencies"))
+	})
+})

--- a/pkg/controller/kubernetes-engine-node.go
+++ b/pkg/controller/kubernetes-engine-node.go
@@ -17,12 +17,13 @@ import (
 )
 
 const (
-	kubernetesEngineNodeLabelOwner    = "kubernetesEngineId"
-	kubernetesEngineNodeLabelRole     = "kubernetesEngineRole"
-	kubernetesEngineNodeRoleValue     = "node"
-	kubernetesEngineNodeLabelIndex    = "kubernetesEngineNodeIndex"
-	defaultKubernetesEngineNodeCPU    = 2
-	defaultKubernetesEngineNodeMemory = 2048
+	kubernetesEngineNodeLabelOwner       = "kubernetesEngineId"
+	kubernetesEngineNodeLabelRole        = "kubernetesEngineRole"
+	kubernetesEngineNodeRoleValue        = "node"
+	kubernetesEngineNodeLabelIndex       = "kubernetesEngineNodeIndex"
+	kubernetesEngineNodeLabelProvisioned = "kubernetesEngineNodeProvisioned"
+	defaultKubernetesEngineNodeCPU       = 2
+	defaultKubernetesEngineNodeMemory    = 2048
 )
 
 var (
@@ -92,8 +93,18 @@ func ProvisionKubernetesEngineNodes(database *db.Database, mkeConf *marmotd.MKEC
 		if err != nil {
 			return false, err
 		}
-		if err := configureKubernetesEngineNode(mkeConf, ke, server.Metadata.Name, nodeIP); err != nil {
-			return false, err
+		labels := make(map[string]interface{})
+		if server.Metadata.Labels != nil {
+			labels = *server.Metadata.Labels
+		}
+		if labels[kubernetesEngineNodeLabelProvisioned] != "true" {
+			if err := configureKubernetesEngineNode(mkeConf, ke, server.Metadata.Name, nodeIP); err != nil {
+				return false, err
+			}
+			labels[kubernetesEngineNodeLabelProvisioned] = "true"
+			if err := database.UpdateServer(server.Metadata.Id, api.Server{Metadata: api.Metadata{Labels: &labels}}); err != nil {
+				return false, fmt.Errorf("failed to mark node %s as provisioned: %w", server.Metadata.Name, err)
+			}
 		}
 		expectedNames = append(expectedNames, server.Metadata.Name)
 	}

--- a/pkg/controller/kubernetes-engine-node.go
+++ b/pkg/controller/kubernetes-engine-node.go
@@ -1,0 +1,612 @@
+package controller
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+const (
+	kubernetesEngineNodeLabelOwner    = "kubernetesEngineId"
+	kubernetesEngineNodeLabelRole     = "kubernetesEngineRole"
+	kubernetesEngineNodeRoleValue     = "node"
+	kubernetesEngineNodeLabelIndex    = "kubernetesEngineNodeIndex"
+	defaultKubernetesEngineNodeCPU    = 2
+	defaultKubernetesEngineNodeMemory = 2048
+	kubernetesEngineNodePlaybookDir   = "/var/lib/marmot/ansible-playbooks"
+)
+
+var (
+	kubernetesEngineNodePrivateKeyPath  = marmotd.GatewayPrivateKeyPath()
+	kubernetesEngineNodePublicKeyPath   = marmotd.GatewayPublicKeyPath()
+	ensureKubernetesEngineNodeSSHAssets = marmotd.EnsureGatewayRuntimeAssets
+	runKubernetesEngineNodePlaybook     = runKubernetesEngineNodePlaybookCommand
+	queryKubernetesEngineNodes          = queryKubernetesEngineNodesCommand
+)
+
+type kubernetesEngineNodePlaybookData struct {
+	NodeName            string
+	NodeIP              string
+	APIServerEndpoint   string
+	KubernetesVersion   string
+	ContainerdVersion   string
+	RuncVersion         string
+	CACertBase64        string
+	KubeletCertBase64   string
+	KubeletKeyBase64    string
+	KubeProxyCertBase64 string
+	KubeProxyKeyBase64  string
+}
+
+type kubernetesNodeList struct {
+	Items []struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		Status struct {
+			Conditions []struct {
+				Type   string `json:"type"`
+				Status string `json:"status"`
+			} `json:"conditions"`
+		} `json:"status"`
+	} `json:"items"`
+}
+
+const kubernetesEngineNodePlaybookTemplate = `---
+- name: Configure Marmot Kubernetes node
+  hosts: all
+  become: true
+  gather_facts: true
+  vars:
+    kubernetes_version: {{ printf "%q" .KubernetesVersion }}
+    containerd_version: {{ printf "%q" .ContainerdVersion }}
+    runc_version: {{ printf "%q" .RuncVersion }}
+  tasks:
+    - name: Install runtime dependencies
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - conntrack
+          - curl
+          - iptables
+          - socat
+        state: present
+        update_cache: true
+
+    - name: Select release architecture
+      ansible.builtin.set_fact:
+        release_arch: {{ "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}" }}
+
+    - name: Create Kubernetes directories
+      ansible.builtin.file:
+        path: {{ "{{ item }}" }}
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      loop:
+        - /etc/kubernetes
+        - /etc/kubernetes/pki
+        - /etc/kubernetes/kubelet
+        - /etc/kubernetes/kube-proxy
+        - /opt/cni/bin
+
+    - name: Install containerd
+      ansible.builtin.unarchive:
+        src: {{ "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ release_arch }}.tar.gz" }}
+        dest: /usr/local
+        remote_src: true
+        creates: /usr/local/bin/containerd
+
+    - name: Install runc
+      ansible.builtin.get_url:
+        url: {{ "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.{{ release_arch }}" }}
+        dest: /usr/local/sbin/runc
+        mode: "0755"
+
+    - name: Install Kubernetes node binaries
+      ansible.builtin.get_url:
+        url: {{ "https://dl.k8s.io/release/{{ kubernetes_version }}/bin/linux/{{ release_arch }}/{{ item }}" }}
+        dest: {{ "'/usr/local/bin/' + item" }}
+        mode: "0755"
+      loop:
+        - kubelet
+        - kube-proxy
+
+    - name: Install cluster credentials and configuration
+      ansible.builtin.copy:
+        content: {{ "{{ item.content | b64decode }}" }}
+        dest: {{ "{{ item.path }}" }}
+        owner: root
+        group: root
+        mode: "0600"
+      no_log: true
+      loop:
+        - path: /etc/kubernetes/pki/ca.crt
+          content: {{ printf "%q" .CACertBase64 }}
+        - path: /etc/kubernetes/pki/kubelet.crt
+          content: {{ printf "%q" .KubeletCertBase64 }}
+        - path: /etc/kubernetes/pki/kubelet.key
+          content: {{ printf "%q" .KubeletKeyBase64 }}
+        - path: /etc/kubernetes/pki/kube-proxy.crt
+          content: {{ printf "%q" .KubeProxyCertBase64 }}
+        - path: /etc/kubernetes/pki/kube-proxy.key
+          content: {{ printf "%q" .KubeProxyKeyBase64 }}
+        - path: /etc/kubernetes/kubelet.kubeconfig
+          content: {{ printf "%q" (kubeconfigBase64 .APIServerEndpoint "system:node" "/etc/kubernetes/pki/kubelet.crt" "/etc/kubernetes/pki/kubelet.key") }}
+        - path: /etc/kubernetes/kube-proxy.kubeconfig
+          content: {{ printf "%q" (kubeconfigBase64 .APIServerEndpoint "system:kube-proxy" "/etc/kubernetes/pki/kube-proxy.crt" "/etc/kubernetes/pki/kube-proxy.key") }}
+        - path: /etc/kubernetes/kubelet/config.yaml
+          content: {{ printf "%q" (kubeletConfigBase64) }}
+        - path: /etc/kubernetes/kube-proxy/config.yaml
+          content: {{ printf "%q" (kubeProxyConfigBase64) }}
+
+    - name: Create containerd configuration directory
+      ansible.builtin.file:
+        path: /etc/containerd
+        state: directory
+        mode: "0755"
+
+    - name: Generate containerd configuration
+      ansible.builtin.shell: |
+        set -eu
+        /usr/local/bin/containerd config default > /etc/containerd/config.toml
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+      args:
+        creates: /etc/containerd/config.toml
+
+    - name: Install containerd systemd unit
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/containerd.service
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=containerd container runtime
+          After=network.target local-fs.target
+
+          [Service]
+          ExecStartPre=-/sbin/modprobe overlay
+          ExecStart=/usr/local/bin/containerd
+          Restart=always
+          Delegate=yes
+          KillMode=process
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Install kubelet systemd unit
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/kubelet.service
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Kubernetes Kubelet
+          Wants=network-online.target containerd.service
+          After=network-online.target containerd.service
+
+          [Service]
+          ExecStart=/usr/local/bin/kubelet --config=/etc/kubernetes/kubelet/config.yaml --kubeconfig=/etc/kubernetes/kubelet.kubeconfig --hostname-override={{ .NodeName }} --node-ip={{ .NodeIP }}
+          Restart=always
+          RestartSec=5
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Install kube-proxy systemd unit
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/kube-proxy.service
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Kubernetes Kube Proxy
+          Wants=network-online.target
+          After=network-online.target
+
+          [Service]
+          ExecStart=/usr/local/bin/kube-proxy --config=/etc/kubernetes/kube-proxy/config.yaml
+          Restart=always
+          RestartSec=5
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Enable Kubernetes node services
+      ansible.builtin.systemd:
+        name: {{ "{{ item }}" }}
+        enabled: true
+				state: started
+        daemon_reload: true
+      loop:
+        - containerd
+        - kubelet
+        - kube-proxy
+`
+
+func ProvisionKubernetesEngineNodes(database *db.Database, mkeConf *marmotd.MKEConfig, ke api.KubernetesEngine) (bool, error) {
+	if ke.Spec.Nodes < 1 {
+		return false, fmt.Errorf("spec.nodes must be greater than zero")
+	}
+	if ke.Status == nil || ke.Status.ControlPlaneIpAddress == nil || ke.Status.ApiServerPort == nil || ke.Status.ResolvedKubernetesVersion == nil {
+		return false, fmt.Errorf("KubernetesEngine control plane status is incomplete")
+	}
+	if err := ensureKubernetesEngineNodeSSHAssets(); err != nil {
+		return false, fmt.Errorf("failed to prepare KubernetesEngine node SSH assets: %w", err)
+	}
+
+	servers, err := findKubernetesEngineNodeServers(database, ke)
+	if err != nil {
+		return false, err
+	}
+	if len(servers) > ke.Spec.Nodes {
+		return false, fmt.Errorf("KubernetesEngine has %d nodes, expected %d; scale-in is handled in phase 12", len(servers), ke.Spec.Nodes)
+	}
+	if len(servers) < ke.Spec.Nodes {
+		if err := createMissingKubernetesEngineNodeServers(database, ke, servers); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	expectedNames := make([]string, 0, len(servers))
+	for _, server := range servers {
+		if server.Status == nil {
+			return false, nil
+		}
+		switch server.Status.StatusCode {
+		case db.SERVER_RUNNING:
+		case db.SERVER_ERROR:
+			message := "node server entered error state"
+			if server.Status.Message != nil && strings.TrimSpace(*server.Status.Message) != "" {
+				message = strings.TrimSpace(*server.Status.Message)
+			}
+			return false, fmt.Errorf("node %s: %s", server.Metadata.Name, message)
+		default:
+			return false, nil
+		}
+		nodeIP, err := kubernetesEngineNodeInternalIP(server, kubernetesEngineNetworkName(ke))
+		if err != nil {
+			return false, err
+		}
+		if err := configureKubernetesEngineNode(mkeConf, ke, server.Metadata.Name, nodeIP); err != nil {
+			return false, err
+		}
+		expectedNames = append(expectedNames, server.Metadata.Name)
+	}
+
+	ready, err := queryKubernetesEngineNodes(ke, expectedNames)
+	if err != nil {
+		return false, err
+	}
+	return ready, nil
+}
+
+func findKubernetesEngineNodeServers(database *db.Database, ke api.KubernetesEngine) ([]api.Server, error) {
+	servers, err := database.GetServers()
+	if err != nil {
+		return nil, err
+	}
+	owner := api.KubernetesEngineID(ke)
+	owned := make([]api.Server, 0, ke.Spec.Nodes)
+	for _, server := range servers {
+		if server.Metadata.Labels == nil {
+			continue
+		}
+		labels := *server.Metadata.Labels
+		if labels[kubernetesEngineNodeLabelOwner] == owner && labels[kubernetesEngineNodeLabelRole] == kubernetesEngineNodeRoleValue {
+			owned = append(owned, server)
+		}
+	}
+	sort.Slice(owned, func(i, j int) bool { return owned[i].Metadata.Name < owned[j].Metadata.Name })
+	return owned, nil
+}
+
+func createMissingKubernetesEngineNodeServers(database *db.Database, ke api.KubernetesEngine, existing []api.Server) error {
+	existingNames := make(map[string]bool, len(existing))
+	for _, server := range existing {
+		existingNames[server.Metadata.Name] = true
+	}
+	allServers, err := database.GetServers()
+	if err != nil {
+		return err
+	}
+	serverOwnersByName := make(map[string]string, len(allServers))
+	for _, server := range allServers {
+		owner := ""
+		if server.Metadata.Labels != nil {
+			owner, _ = (*server.Metadata.Labels)[kubernetesEngineNodeLabelOwner].(string)
+		}
+		serverOwnersByName[server.Metadata.Name] = owner
+	}
+	publicKey, err := os.ReadFile(kubernetesEngineNodePublicKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to read KubernetesEngine node public key: %w", err)
+	}
+	for index := 0; index < ke.Spec.Nodes; index++ {
+		name := kubernetesEngineNodeName(ke, index)
+		if existingNames[name] {
+			continue
+		}
+		if owner, found := serverOwnersByName[name]; found {
+			return fmt.Errorf("server name %s is already used by owner %q", name, owner)
+		}
+		spec, err := buildKubernetesEngineNodeServerSpec(ke, index, strings.TrimSpace(string(publicKey)))
+		if err != nil {
+			return err
+		}
+		if _, err := database.MakeServerEntry(spec); err != nil {
+			return fmt.Errorf("failed to create KubernetesEngine node %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func buildKubernetesEngineNodeServerSpec(ke api.KubernetesEngine, index int, publicKey string) (api.Server, error) {
+	externalNetwork := "default"
+	cpu := defaultKubernetesEngineNodeCPU
+	memory := defaultKubernetesEngineNodeMemory
+	if ke.Spec.NodeSpec != nil {
+		if ke.Spec.NodeSpec.Cpu != nil {
+			cpu = *ke.Spec.NodeSpec.Cpu
+		}
+		if ke.Spec.NodeSpec.Memory != nil {
+			memory = *ke.Spec.NodeSpec.Memory
+		}
+		if ke.Spec.NodeSpec.Network != nil && ke.Spec.NodeSpec.Network.External != nil {
+			externalNetwork = strings.TrimSpace(*ke.Spec.NodeSpec.Network.External)
+		}
+	}
+	if cpu < 1 || memory < 1 {
+		return api.Server{}, fmt.Errorf("nodeSpec cpu and memory must be greater than zero")
+	}
+	if externalNetwork != "default" && externalNetwork != "host-bridge" {
+		return api.Server{}, fmt.Errorf("nodeSpec.network.external must be default or host-bridge")
+	}
+	if strings.TrimSpace(publicKey) == "" {
+		return api.Server{}, fmt.Errorf("KubernetesEngine node public key is empty")
+	}
+
+	name := kubernetesEngineNodeName(ke, index)
+	labels := map[string]interface{}{
+		kubernetesEngineNodeLabelOwner: api.KubernetesEngineID(ke),
+		kubernetesEngineNodeLabelRole:  kubernetesEngineNodeRoleValue,
+		kubernetesEngineNodeLabelIndex: index,
+	}
+	metadata := api.Metadata{Name: name, Labels: &labels}
+	if ke.Metadata.NodeName != nil && strings.TrimSpace(*ke.Metadata.NodeName) != "" {
+		metadata.NodeName = util.StringPtr(strings.TrimSpace(*ke.Metadata.NodeName))
+	}
+	nics := []api.NetworkInterface{
+		{Networkname: externalNetwork},
+		{Networkname: kubernetesEngineNetworkName(ke)},
+	}
+	return api.Server{
+		ApiVersion: "v1",
+		Kind:       "Server",
+		Metadata:   metadata,
+		Spec: api.ServerSpec{
+			Cpu:              util.IntPtrInt(cpu),
+			Memory:           util.IntPtrInt(memory),
+			OsVariant:        util.StringPtr("ubuntu24.04"),
+			NetworkInterface: &nics,
+			Auth:             &api.Auth{PublicKey: util.StringPtr(publicKey), User: util.StringPtr("root")},
+		},
+	}, nil
+}
+
+func kubernetesEngineNodeName(ke api.KubernetesEngine, index int) string {
+	return fmt.Sprintf("mke-%s-node-%d", strings.TrimSpace(ke.Metadata.Name), index+1)
+}
+
+func kubernetesEngineNodeInternalIP(server api.Server, networkName string) (string, error) {
+	if server.Spec.NetworkInterface == nil {
+		return "", fmt.Errorf("node %s has no network interfaces", server.Metadata.Name)
+	}
+	for _, nic := range *server.Spec.NetworkInterface {
+		if nic.Networkname == networkName && nic.Address != nil && strings.TrimSpace(*nic.Address) != "" {
+			return strings.TrimSpace(*nic.Address), nil
+		}
+	}
+	return "", fmt.Errorf("node %s has no address on network %s", server.Metadata.Name, networkName)
+}
+
+func configureKubernetesEngineNode(mkeConf *marmotd.MKEConfig, ke api.KubernetesEngine, nodeName, nodeIP string) error {
+	clusterName := strings.TrimSpace(ke.Metadata.Name)
+	caPath, _ := KubernetesEngineCAPaths(DefaultKubernetesEnginePkiDir, clusterName)
+	kubeletCertPath, kubeletKeyPath, err := IssueKubernetesEngineCertificate(DefaultKubernetesEnginePkiDir, clusterName, KubernetesEngineCertRequest{
+		Name:          "kubelet-" + nodeName,
+		CommonName:    "system:node:" + nodeName,
+		Organizations: []string{"system:nodes"},
+		Usage:         KubernetesEngineCertUsageClient,
+	})
+	if err != nil {
+		return err
+	}
+	kubeProxyCertPath, kubeProxyKeyPath, err := IssueKubernetesEngineCertificate(DefaultKubernetesEnginePkiDir, clusterName, KubernetesEngineCertRequest{
+		Name:       "kube-proxy-" + nodeName,
+		CommonName: "system:kube-proxy",
+		Usage:      KubernetesEngineCertUsageClient,
+	})
+	if err != nil {
+		return err
+	}
+	paths := []string{caPath, kubeletCertPath, kubeletKeyPath, kubeProxyCertPath, kubeProxyKeyPath}
+	encoded := make([]string, len(paths))
+	for index, path := range paths {
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		encoded[index] = base64.StdEncoding.EncodeToString(data)
+	}
+	endpoint := fmt.Sprintf("https://%s:%d", *ke.Status.ControlPlaneIpAddress, *ke.Status.ApiServerPort)
+	playbookPath := filepath.Join(kubernetesEngineNodePlaybookDir, fmt.Sprintf("mke-node-%s-%s.yaml", api.KubernetesEngineID(ke), nodeName))
+	data := kubernetesEngineNodePlaybookData{
+		NodeName:            nodeName,
+		NodeIP:              nodeIP,
+		APIServerEndpoint:   endpoint,
+		KubernetesVersion:   strings.TrimSpace(*ke.Status.ResolvedKubernetesVersion),
+		ContainerdVersion:   strings.TrimPrefix(strings.TrimSpace(mkeConf.ContainerdVersion), "v"),
+		RuncVersion:         strings.TrimPrefix(strings.TrimSpace(mkeConf.RuncVersion), "v"),
+		CACertBase64:        encoded[0],
+		KubeletCertBase64:   encoded[1],
+		KubeletKeyBase64:    encoded[2],
+		KubeProxyCertBase64: encoded[3],
+		KubeProxyKeyBase64:  encoded[4],
+	}
+	if err := renderKubernetesEngineNodePlaybook(playbookPath, data); err != nil {
+		return err
+	}
+	return runKubernetesEngineNodePlaybook(playbookPath, nodeIP, kubernetesEngineNodePrivateKeyPath)
+}
+
+func renderKubernetesEngineNodePlaybook(path string, data kubernetesEngineNodePlaybookData) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	functions := template.FuncMap{
+		"kubeconfigBase64": func(endpoint, user, certPath, keyPath string) string {
+			return base64.StdEncoding.EncodeToString([]byte(renderKubernetesEngineNodeKubeconfig(endpoint, user, certPath, keyPath)))
+		},
+		"kubeletConfigBase64": func() string {
+			return base64.StdEncoding.EncodeToString([]byte(renderKubernetesEngineKubeletConfig()))
+		},
+		"kubeProxyConfigBase64": func() string {
+			return base64.StdEncoding.EncodeToString([]byte(renderKubernetesEngineKubeProxyConfig()))
+		},
+	}
+	tmpl, err := template.New("kubernetes-engine-node").Funcs(functions).Parse(kubernetesEngineNodePlaybookTemplate)
+	if err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	return tmpl.Execute(file, data)
+}
+
+func renderKubernetesEngineNodeKubeconfig(endpoint, user, certPath, keyPath string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+  - name: mke
+    cluster:
+      server: %s
+      certificate-authority: /etc/kubernetes/pki/ca.crt
+users:
+  - name: %s
+    user:
+      client-certificate: %s
+      client-key: %s
+contexts:
+  - name: %s@mke
+    context:
+      cluster: mke
+      user: %s
+current-context: %s@mke
+`, endpoint, user, certPath, keyPath, user, user, user)
+}
+
+func renderKubernetesEngineKubeletConfig() string {
+	return `apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  x509:
+    clientCAFile: /etc/kubernetes/pki/ca.crt
+authorization:
+  mode: Webhook
+cgroupDriver: systemd
+clusterDNS:
+  - 10.96.0.10
+clusterDomain: cluster.local
+containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
+failSwapOn: false
+`
+}
+
+func renderKubernetesEngineKubeProxyConfig() string {
+	return `apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+clientConnection:
+  kubeconfig: /etc/kubernetes/kube-proxy.kubeconfig
+mode: iptables
+`
+}
+
+func runKubernetesEngineNodePlaybookCommand(playbookPath, address, privateKeyPath string) error {
+	if strings.TrimSpace(address) == "" {
+		return fmt.Errorf("node address is empty")
+	}
+	if _, err := os.Stat(privateKeyPath); err != nil {
+		return fmt.Errorf("private key is not available: %w", err)
+	}
+	args := []string{
+		"-i", strings.TrimSpace(address) + ",",
+		playbookPath,
+		"--private-key", privateKeyPath,
+		"-u", "root",
+		"--ssh-common-args", "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
+	}
+	return runAnsiblePlaybookWithLogging(args, "kubernetes-engine-node", filepath.Base(playbookPath))
+}
+
+func queryKubernetesEngineNodesCommand(ke api.KubernetesEngine, expectedNames []string) (bool, error) {
+	clusterName := strings.TrimSpace(ke.Metadata.Name)
+	adminCertPath, adminKeyPath, err := IssueKubernetesEngineCertificate(DefaultKubernetesEnginePkiDir, clusterName, KubernetesEngineCertRequest{
+		Name:          "controller-admin",
+		CommonName:    "mke-controller-admin",
+		Organizations: []string{"system:masters"},
+		Usage:         KubernetesEngineCertUsageClient,
+	})
+	if err != nil {
+		return false, err
+	}
+	caPath, _ := KubernetesEngineCAPaths(DefaultKubernetesEnginePkiDir, clusterName)
+	namespace, _, _, err := KubernetesEngineControlPlaneNetworkNames(clusterName)
+	if err != nil {
+		return false, err
+	}
+	endpoint := fmt.Sprintf("https://%s:%d/api/v1/nodes", *ke.Status.ControlPlaneIpAddress, *ke.Status.ApiServerPort)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, "ip", "netns", "exec", namespace, "curl", "--fail", "--silent", "--show-error", "--cacert", caPath, "--cert", adminCertPath, "--key", adminKeyPath, endpoint).CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("failed to list Kubernetes nodes: %w (output=%s)", err, strings.TrimSpace(string(output)))
+	}
+	return kubernetesEngineNodesReady(output, expectedNames)
+}
+
+func kubernetesEngineNodesReady(data []byte, expectedNames []string) (bool, error) {
+	var nodeList kubernetesNodeList
+	if err := json.Unmarshal(data, &nodeList); err != nil {
+		return false, fmt.Errorf("failed to decode Kubernetes node list: %w", err)
+	}
+	ready := make(map[string]bool, len(nodeList.Items))
+	for _, item := range nodeList.Items {
+		for _, condition := range item.Status.Conditions {
+			if condition.Type == "Ready" && condition.Status == "True" {
+				ready[item.Metadata.Name] = true
+			}
+		}
+	}
+	for _, name := range expectedNames {
+		if !ready[name] {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/pkg/controller/kubernetes-engine-node.go
+++ b/pkg/controller/kubernetes-engine-node.go
@@ -2,15 +2,12 @@ package controller
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/takara9/marmot/api"
@@ -26,30 +23,15 @@ const (
 	kubernetesEngineNodeLabelIndex    = "kubernetesEngineNodeIndex"
 	defaultKubernetesEngineNodeCPU    = 2
 	defaultKubernetesEngineNodeMemory = 2048
-	kubernetesEngineNodePlaybookDir   = "/var/lib/marmot/ansible-playbooks"
 )
 
 var (
 	kubernetesEngineNodePrivateKeyPath  = marmotd.GatewayPrivateKeyPath()
 	kubernetesEngineNodePublicKeyPath   = marmotd.GatewayPublicKeyPath()
 	ensureKubernetesEngineNodeSSHAssets = marmotd.EnsureGatewayRuntimeAssets
-	runKubernetesEngineNodePlaybook     = runKubernetesEngineNodePlaybookCommand
+	runKubernetesEngineNodeProvision    = provisionKubernetesEngineNodeSSH
 	queryKubernetesEngineNodes          = queryKubernetesEngineNodesCommand
 )
-
-type kubernetesEngineNodePlaybookData struct {
-	NodeName            string
-	NodeIP              string
-	APIServerEndpoint   string
-	KubernetesVersion   string
-	ContainerdVersion   string
-	RuncVersion         string
-	CACertBase64        string
-	KubeletCertBase64   string
-	KubeletKeyBase64    string
-	KubeProxyCertBase64 string
-	KubeProxyKeyBase64  string
-}
 
 type kubernetesNodeList struct {
 	Items []struct {
@@ -64,176 +46,6 @@ type kubernetesNodeList struct {
 		} `json:"status"`
 	} `json:"items"`
 }
-
-const kubernetesEngineNodePlaybookTemplate = `---
-- name: Configure Marmot Kubernetes node
-  hosts: all
-  become: true
-  gather_facts: true
-  vars:
-    kubernetes_version: {{ printf "%q" .KubernetesVersion }}
-    containerd_version: {{ printf "%q" .ContainerdVersion }}
-    runc_version: {{ printf "%q" .RuncVersion }}
-  tasks:
-    - name: Install runtime dependencies
-      ansible.builtin.apt:
-        name:
-          - ca-certificates
-          - conntrack
-          - curl
-          - iptables
-          - socat
-        state: present
-        update_cache: true
-
-    - name: Select release architecture
-      ansible.builtin.set_fact:
-        release_arch: {{ "\"{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}\"" }}
-
-    - name: Create Kubernetes directories
-      ansible.builtin.file:
-        path: {{ "{{ item }}" }}
-        state: directory
-        owner: root
-        group: root
-        mode: "0755"
-      loop:
-        - /etc/kubernetes
-        - /etc/kubernetes/pki
-        - /etc/kubernetes/kubelet
-        - /etc/kubernetes/kube-proxy
-        - /opt/cni/bin
-
-    - name: Install containerd
-      ansible.builtin.unarchive:
-        src: {{ "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ release_arch }}.tar.gz" }}
-        dest: /usr/local
-        remote_src: true
-        creates: /usr/local/bin/containerd
-
-    - name: Install runc
-      ansible.builtin.get_url:
-        url: {{ "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.{{ release_arch }}" }}
-        dest: /usr/local/sbin/runc
-        mode: "0755"
-
-    - name: Install Kubernetes node binaries
-      ansible.builtin.get_url:
-        url: {{ "https://dl.k8s.io/release/{{ kubernetes_version }}/bin/linux/{{ release_arch }}/{{ item }}" }}
-        dest: {{ "\"{{ '/usr/local/bin/' + item }}\"" }}
-        mode: "0755"
-      loop:
-        - kubelet
-        - kube-proxy
-
-    - name: Install cluster credentials and configuration
-      ansible.builtin.copy:
-        content: {{ "{{ item.content | b64decode }}" }}
-        dest: {{ "{{ item.path }}" }}
-        owner: root
-        group: root
-        mode: "0600"
-      no_log: true
-      loop:
-        - path: /etc/kubernetes/pki/ca.crt
-          content: {{ printf "%q" .CACertBase64 }}
-        - path: /etc/kubernetes/pki/kubelet.crt
-          content: {{ printf "%q" .KubeletCertBase64 }}
-        - path: /etc/kubernetes/pki/kubelet.key
-          content: {{ printf "%q" .KubeletKeyBase64 }}
-        - path: /etc/kubernetes/pki/kube-proxy.crt
-          content: {{ printf "%q" .KubeProxyCertBase64 }}
-        - path: /etc/kubernetes/pki/kube-proxy.key
-          content: {{ printf "%q" .KubeProxyKeyBase64 }}
-        - path: /etc/kubernetes/kubelet.kubeconfig
-          content: {{ printf "%q" (kubeconfigBase64 .APIServerEndpoint "system:node" "/etc/kubernetes/pki/kubelet.crt" "/etc/kubernetes/pki/kubelet.key") }}
-        - path: /etc/kubernetes/kube-proxy.kubeconfig
-          content: {{ printf "%q" (kubeconfigBase64 .APIServerEndpoint "system:kube-proxy" "/etc/kubernetes/pki/kube-proxy.crt" "/etc/kubernetes/pki/kube-proxy.key") }}
-        - path: /etc/kubernetes/kubelet/config.yaml
-          content: {{ printf "%q" (kubeletConfigBase64) }}
-        - path: /etc/kubernetes/kube-proxy/config.yaml
-          content: {{ printf "%q" (kubeProxyConfigBase64) }}
-
-    - name: Create containerd configuration directory
-      ansible.builtin.file:
-        path: /etc/containerd
-        state: directory
-        mode: "0755"
-
-    - name: Generate containerd configuration
-      ansible.builtin.shell: |
-        set -eu
-        /usr/local/bin/containerd config default > /etc/containerd/config.toml
-        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
-      args:
-        creates: /etc/containerd/config.toml
-
-    - name: Install containerd systemd unit
-      ansible.builtin.copy:
-        dest: /etc/systemd/system/containerd.service
-        mode: "0644"
-        content: |
-          [Unit]
-          Description=containerd container runtime
-          After=network.target local-fs.target
-
-          [Service]
-          ExecStartPre=-/sbin/modprobe overlay
-          ExecStart=/usr/local/bin/containerd
-          Restart=always
-          Delegate=yes
-          KillMode=process
-
-          [Install]
-          WantedBy=multi-user.target
-
-    - name: Install kubelet systemd unit
-      ansible.builtin.copy:
-        dest: /etc/systemd/system/kubelet.service
-        mode: "0644"
-        content: |
-          [Unit]
-          Description=Kubernetes Kubelet
-          Wants=network-online.target containerd.service
-          After=network-online.target containerd.service
-
-          [Service]
-          ExecStart=/usr/local/bin/kubelet --config=/etc/kubernetes/kubelet/config.yaml --kubeconfig=/etc/kubernetes/kubelet.kubeconfig --hostname-override={{ .NodeName }} --node-ip={{ .NodeIP }}
-          Restart=always
-          RestartSec=5
-
-          [Install]
-          WantedBy=multi-user.target
-
-    - name: Install kube-proxy systemd unit
-      ansible.builtin.copy:
-        dest: /etc/systemd/system/kube-proxy.service
-        mode: "0644"
-        content: |
-          [Unit]
-          Description=Kubernetes Kube Proxy
-          Wants=network-online.target
-          After=network-online.target
-
-          [Service]
-          ExecStart=/usr/local/bin/kube-proxy --config=/etc/kubernetes/kube-proxy/config.yaml
-          Restart=always
-          RestartSec=5
-
-          [Install]
-          WantedBy=multi-user.target
-
-    - name: Enable Kubernetes node services
-      ansible.builtin.systemd:
-        name: {{ "{{ item }}" }}
-        enabled: true
-        state: started
-        daemon_reload: true
-      loop:
-        - containerd
-        - kubelet
-        - kube-proxy
-`
 
 func ProvisionKubernetesEngineNodes(database *db.Database, mkeConf *marmotd.MKEConfig, ke api.KubernetesEngine) (bool, error) {
 	if ke.Spec.Nodes < 1 {
@@ -443,60 +255,33 @@ func configureKubernetesEngineNode(mkeConf *marmotd.MKEConfig, ke api.Kubernetes
 		return err
 	}
 	paths := []string{caPath, kubeletCertPath, kubeletKeyPath, kubeProxyCertPath, kubeProxyKeyPath}
-	encoded := make([]string, len(paths))
+	contents := make([][]byte, len(paths))
 	for index, path := range paths {
-		data, readErr := os.ReadFile(path)
+		content, readErr := os.ReadFile(path)
 		if readErr != nil {
 			return readErr
 		}
-		encoded[index] = base64.StdEncoding.EncodeToString(data)
+		contents[index] = content
 	}
 	endpoint := fmt.Sprintf("https://%s:%d", *ke.Status.ControlPlaneIpAddress, *ke.Status.ApiServerPort)
-	playbookPath := filepath.Join(kubernetesEngineNodePlaybookDir, fmt.Sprintf("mke-node-%s-%s.yaml", api.KubernetesEngineID(ke), nodeName))
-	data := kubernetesEngineNodePlaybookData{
+	data := kubernetesEngineNodeProvisionData{
 		NodeName:            nodeName,
 		NodeIP:              nodeIP,
-		APIServerEndpoint:   endpoint,
 		KubernetesVersion:   strings.TrimSpace(*ke.Status.ResolvedKubernetesVersion),
 		ContainerdVersion:   strings.TrimPrefix(strings.TrimSpace(mkeConf.ContainerdVersion), "v"),
 		RuncVersion:         strings.TrimPrefix(strings.TrimSpace(mkeConf.RuncVersion), "v"),
-		CACertBase64:        encoded[0],
-		KubeletCertBase64:   encoded[1],
-		KubeletKeyBase64:    encoded[2],
-		KubeProxyCertBase64: encoded[3],
-		KubeProxyKeyBase64:  encoded[4],
+		CACert:              contents[0],
+		KubeletCert:         contents[1],
+		KubeletKey:          contents[2],
+		KubeProxyCert:       contents[3],
+		KubeProxyKey:        contents[4],
+		KubeletKubeconfig:   []byte(renderKubernetesEngineNodeKubeconfig(endpoint, "system:node", "/etc/kubernetes/pki/kubelet.crt", "/etc/kubernetes/pki/kubelet.key")),
+		KubeProxyKubeconfig: []byte(renderKubernetesEngineNodeKubeconfig(endpoint, "system:kube-proxy", "/etc/kubernetes/pki/kube-proxy.crt", "/etc/kubernetes/pki/kube-proxy.key")),
+		KubeletConfig:       []byte(renderKubernetesEngineKubeletConfig()),
+		KubeProxyConfig:     []byte(renderKubernetesEngineKubeProxyConfig()),
 	}
-	if err := renderKubernetesEngineNodePlaybook(playbookPath, data); err != nil {
-		return err
-	}
-	return runKubernetesEngineNodePlaybook(playbookPath, nodeIP, kubernetesEngineNodePrivateKeyPath)
-}
-
-func renderKubernetesEngineNodePlaybook(path string, data kubernetesEngineNodePlaybookData) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	functions := template.FuncMap{
-		"kubeconfigBase64": func(endpoint, user, certPath, keyPath string) string {
-			return base64.StdEncoding.EncodeToString([]byte(renderKubernetesEngineNodeKubeconfig(endpoint, user, certPath, keyPath)))
-		},
-		"kubeletConfigBase64": func() string {
-			return base64.StdEncoding.EncodeToString([]byte(renderKubernetesEngineKubeletConfig()))
-		},
-		"kubeProxyConfigBase64": func() string {
-			return base64.StdEncoding.EncodeToString([]byte(renderKubernetesEngineKubeProxyConfig()))
-		},
-	}
-	tmpl, err := template.New("kubernetes-engine-node").Funcs(functions).Parse(kubernetesEngineNodePlaybookTemplate)
-	if err != nil {
-		return err
-	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = file.Close() }()
-	return tmpl.Execute(file, data)
+	nodeID := fmt.Sprintf("%s-%s", api.KubernetesEngineID(ke), nodeName)
+	return runKubernetesEngineNodeProvision(nodeIP, kubernetesEngineNodePrivateKeyPath, nodeID, data)
 }
 
 func renderKubernetesEngineNodeKubeconfig(endpoint, user, certPath, keyPath string) string {
@@ -545,23 +330,6 @@ clientConnection:
   kubeconfig: /etc/kubernetes/kube-proxy.kubeconfig
 mode: iptables
 `
-}
-
-func runKubernetesEngineNodePlaybookCommand(playbookPath, address, privateKeyPath string) error {
-	if strings.TrimSpace(address) == "" {
-		return fmt.Errorf("node address is empty")
-	}
-	if _, err := os.Stat(privateKeyPath); err != nil {
-		return fmt.Errorf("private key is not available: %w", err)
-	}
-	args := []string{
-		"-i", strings.TrimSpace(address) + ",",
-		playbookPath,
-		"--private-key", privateKeyPath,
-		"-u", "root",
-		"--ssh-common-args", "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
-	}
-	return runAnsiblePlaybookWithLogging(args, "kubernetes-engine-node", filepath.Base(playbookPath))
 }
 
 func queryKubernetesEngineNodesCommand(ke api.KubernetesEngine, expectedNames []string) (bool, error) {

--- a/pkg/controller/kubernetes-engine-node.go
+++ b/pkg/controller/kubernetes-engine-node.go
@@ -281,7 +281,14 @@ func configureKubernetesEngineNode(mkeConf *marmotd.MKEConfig, ke api.Kubernetes
 		KubeProxyConfig:     []byte(renderKubernetesEngineKubeProxyConfig()),
 	}
 	nodeID := fmt.Sprintf("%s-%s", api.KubernetesEngineID(ke), nodeName)
-	return runKubernetesEngineNodeProvision(nodeIP, kubernetesEngineNodePrivateKeyPath, nodeID, data)
+	// ノードのIPは「ノード間通信用ネットワーク」上のアドレスであり、ホストのroot netnsからは
+	// 到達できないため、コントロールプレーン用に作成済みのnetns(veth経由でOVSブリッジに接続済み)
+	// を経由してSSH接続する。
+	namespace, _, _, err := KubernetesEngineControlPlaneNetworkNames(clusterName)
+	if err != nil {
+		return err
+	}
+	return runKubernetesEngineNodeProvision(nodeIP, kubernetesEngineNodePrivateKeyPath, namespace, nodeID, data)
 }
 
 func renderKubernetesEngineNodeKubeconfig(endpoint, user, certPath, keyPath string) string {

--- a/pkg/controller/kubernetes-engine-node.go
+++ b/pkg/controller/kubernetes-engine-node.go
@@ -88,7 +88,7 @@ const kubernetesEngineNodePlaybookTemplate = `---
 
     - name: Select release architecture
       ansible.builtin.set_fact:
-        release_arch: {{ "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}" }}
+        release_arch: {{ "\"{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}\"" }}
 
     - name: Create Kubernetes directories
       ansible.builtin.file:
@@ -120,7 +120,7 @@ const kubernetesEngineNodePlaybookTemplate = `---
     - name: Install Kubernetes node binaries
       ansible.builtin.get_url:
         url: {{ "https://dl.k8s.io/release/{{ kubernetes_version }}/bin/linux/{{ release_arch }}/{{ item }}" }}
-        dest: {{ "'/usr/local/bin/' + item" }}
+        dest: {{ "\"{{ '/usr/local/bin/' + item }}\"" }}
         mode: "0755"
       loop:
         - kubelet
@@ -227,7 +227,7 @@ const kubernetesEngineNodePlaybookTemplate = `---
       ansible.builtin.systemd:
         name: {{ "{{ item }}" }}
         enabled: true
-				state: started
+        state: started
         daemon_reload: true
       loop:
         - containerd

--- a/pkg/controller/kubernetes-engine-node_test.go
+++ b/pkg/controller/kubernetes-engine-node_test.go
@@ -1,0 +1,142 @@
+package controller
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestBuildKubernetesEngineNodeServerSpec(t *testing.T) {
+	external := "host-bridge"
+	cpu := 4
+	memory := 8192
+	ke := api.KubernetesEngine{
+		Metadata: api.Metadata{Name: "demo"},
+		Spec: api.KubernetesEngineSpec{
+			Nodes: 2,
+			NodeSpec: &api.KubernetesEngineNodeSpec{
+				Cpu:     &cpu,
+				Memory:  &memory,
+				Network: &api.KubernetesEngineNodeNetwork{External: &external},
+			},
+		},
+	}
+	api.SetKubernetesEngineID(&ke, "ke123")
+
+	server, err := buildKubernetesEngineNodeServerSpec(ke, 1, "ssh-rsa AAAA")
+	if err != nil {
+		t.Fatalf("buildKubernetesEngineNodeServerSpec() failed: %v", err)
+	}
+	if server.Metadata.Name != "mke-demo-node-2" {
+		t.Fatalf("server name = %q, want mke-demo-node-2", server.Metadata.Name)
+	}
+	if server.Spec.Cpu == nil || *server.Spec.Cpu != cpu || server.Spec.Memory == nil || *server.Spec.Memory != memory {
+		t.Fatalf("server resources = cpu:%v memory:%v", server.Spec.Cpu, server.Spec.Memory)
+	}
+	if server.Spec.NetworkInterface == nil || len(*server.Spec.NetworkInterface) != 2 {
+		t.Fatalf("network interfaces = %v, want two", server.Spec.NetworkInterface)
+	}
+	nics := *server.Spec.NetworkInterface
+	if nics[0].Networkname != "host-bridge" || nics[1].Networkname != "mke-demo" {
+		t.Fatalf("network interfaces = %+v", nics)
+	}
+	if server.Metadata.Labels == nil || (*server.Metadata.Labels)[kubernetesEngineNodeLabelOwner] != "ke123" {
+		t.Fatalf("server labels = %v", server.Metadata.Labels)
+	}
+	if server.Spec.Auth == nil || server.Spec.Auth.PublicKey == nil || *server.Spec.Auth.PublicKey != "ssh-rsa AAAA" {
+		t.Fatalf("server auth = %+v", server.Spec.Auth)
+	}
+}
+
+func TestRenderKubernetesEngineNodePlaybook(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "node.yaml")
+	data := kubernetesEngineNodePlaybookData{
+		NodeName:            "mke-demo-node-1",
+		NodeIP:              "172.16.1.10",
+		APIServerEndpoint:   "https://172.16.1.2:26443",
+		KubernetesVersion:   "v1.36.2",
+		ContainerdVersion:   "2.3.1",
+		RuncVersion:         "1.4.0",
+		CACertBase64:        "Y2E=",
+		KubeletCertBase64:   "a2MtY2VydA==",
+		KubeletKeyBase64:    "a2wta2V5",
+		KubeProxyCertBase64: "a3AtY2VydA==",
+		KubeProxyKeyBase64:  "a3Ata2V5",
+	}
+	if err := renderKubernetesEngineNodePlaybook(path, data); err != nil {
+		t.Fatalf("renderKubernetesEngineNodePlaybook() failed: %v", err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() failed: %v", err)
+	}
+	text := string(content)
+	for _, want := range []string{
+		"containerd-{{ containerd_version }}-linux-{{ release_arch }}.tar.gz",
+		"/usr/local/bin/kubelet",
+		"/usr/local/bin/kube-proxy",
+		"/etc/kubernetes/pki/kubelet.crt",
+		"--hostname-override=mke-demo-node-1",
+		"--node-ip=172.16.1.10",
+		base64.StdEncoding.EncodeToString([]byte(renderKubernetesEngineNodeKubeconfig(
+			"https://172.16.1.2:26443",
+			"system:node",
+			"/etc/kubernetes/pki/kubelet.crt",
+			"/etc/kubernetes/pki/kubelet.key",
+		))),
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("rendered playbook does not contain %q", want)
+		}
+	}
+	if strings.Contains(text, "kc-cert") || strings.Contains(text, "kl-key") {
+		t.Fatalf("rendered playbook contains unencoded credential material")
+	}
+}
+
+func TestKubernetesEngineNodesReady(t *testing.T) {
+	data := []byte(`{"items":[
+		{"metadata":{"name":"node-1"},"status":{"conditions":[{"type":"Ready","status":"True"}]}},
+		{"metadata":{"name":"node-2"},"status":{"conditions":[{"type":"Ready","status":"False"}]}}
+	]}`)
+	ready, err := kubernetesEngineNodesReady(data, []string{"node-1", "node-2"})
+	if err != nil {
+		t.Fatalf("kubernetesEngineNodesReady() failed: %v", err)
+	}
+	if ready {
+		t.Fatalf("kubernetesEngineNodesReady() = true while node-2 is not Ready")
+	}
+
+	readyData := []byte(`{"items":[
+		{"metadata":{"name":"node-1"},"status":{"conditions":[{"type":"Ready","status":"True"}]}},
+		{"metadata":{"name":"node-2"},"status":{"conditions":[{"type":"Ready","status":"True"}]}}
+	]}`)
+	ready, err = kubernetesEngineNodesReady(readyData, []string{"node-1", "node-2"})
+	if err != nil {
+		t.Fatalf("kubernetesEngineNodesReady() failed: %v", err)
+	}
+	if !ready {
+		t.Fatalf("kubernetesEngineNodesReady() = false, want true")
+	}
+}
+
+func TestKubernetesEngineNodeInternalIP(t *testing.T) {
+	server := api.Server{Metadata: api.Metadata{Name: "node-1"}, Spec: api.ServerSpec{
+		NetworkInterface: &[]api.NetworkInterface{
+			{Networkname: "default"},
+			{Networkname: "mke-demo", Address: util.StringPtr("172.16.1.10")},
+		},
+	}}
+	address, err := kubernetesEngineNodeInternalIP(server, "mke-demo")
+	if err != nil {
+		t.Fatalf("kubernetesEngineNodeInternalIP() failed: %v", err)
+	}
+	if address != "172.16.1.10" {
+		t.Fatalf("address = %q, want 172.16.1.10", address)
+	}
+}

--- a/pkg/controller/kubernetes-engine-node_test.go
+++ b/pkg/controller/kubernetes-engine-node_test.go
@@ -1,10 +1,6 @@
 package controller
 
 import (
-	"encoding/base64"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/takara9/marmot/api"
@@ -50,52 +46,6 @@ func TestBuildKubernetesEngineNodeServerSpec(t *testing.T) {
 	}
 	if server.Spec.Auth == nil || server.Spec.Auth.PublicKey == nil || *server.Spec.Auth.PublicKey != "ssh-rsa AAAA" {
 		t.Fatalf("server auth = %+v", server.Spec.Auth)
-	}
-}
-
-func TestRenderKubernetesEngineNodePlaybook(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "node.yaml")
-	data := kubernetesEngineNodePlaybookData{
-		NodeName:            "mke-demo-node-1",
-		NodeIP:              "172.16.1.10",
-		APIServerEndpoint:   "https://172.16.1.2:26443",
-		KubernetesVersion:   "v1.36.2",
-		ContainerdVersion:   "2.3.1",
-		RuncVersion:         "1.4.0",
-		CACertBase64:        "Y2E=",
-		KubeletCertBase64:   "a2MtY2VydA==",
-		KubeletKeyBase64:    "a2wta2V5",
-		KubeProxyCertBase64: "a3AtY2VydA==",
-		KubeProxyKeyBase64:  "a3Ata2V5",
-	}
-	if err := renderKubernetesEngineNodePlaybook(path, data); err != nil {
-		t.Fatalf("renderKubernetesEngineNodePlaybook() failed: %v", err)
-	}
-	content, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile() failed: %v", err)
-	}
-	text := string(content)
-	for _, want := range []string{
-		"containerd-{{ containerd_version }}-linux-{{ release_arch }}.tar.gz",
-		"/usr/local/bin/kubelet",
-		"/usr/local/bin/kube-proxy",
-		"/etc/kubernetes/pki/kubelet.crt",
-		"--hostname-override=mke-demo-node-1",
-		"--node-ip=172.16.1.10",
-		base64.StdEncoding.EncodeToString([]byte(renderKubernetesEngineNodeKubeconfig(
-			"https://172.16.1.2:26443",
-			"system:node",
-			"/etc/kubernetes/pki/kubelet.crt",
-			"/etc/kubernetes/pki/kubelet.key",
-		))),
-	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("rendered playbook does not contain %q", want)
-		}
-	}
-	if strings.Contains(text, "kc-cert") || strings.Contains(text, "kl-key") {
-		t.Fatalf("rendered playbook contains unencoded credential material")
 	}
 }
 

--- a/pkg/controller/kubernetes-engine-node_test.go
+++ b/pkg/controller/kubernetes-engine-node_test.go
@@ -1,92 +1,73 @@
 package controller
 
 import (
-	"testing"
-
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestBuildKubernetesEngineNodeServerSpec(t *testing.T) {
-	external := "host-bridge"
-	cpu := 4
-	memory := 8192
-	ke := api.KubernetesEngine{
-		Metadata: api.Metadata{Name: "demo"},
-		Spec: api.KubernetesEngineSpec{
-			Nodes: 2,
-			NodeSpec: &api.KubernetesEngineNodeSpec{
-				Cpu:     &cpu,
-				Memory:  &memory,
-				Network: &api.KubernetesEngineNodeNetwork{External: &external},
+var _ = Describe("KubernetesEngineNode", func() {
+	It("builds a node server spec with resources, networks and labels", func() {
+		external := "host-bridge"
+		cpu := 4
+		memory := 8192
+		ke := api.KubernetesEngine{
+			Metadata: api.Metadata{Name: "demo"},
+			Spec: api.KubernetesEngineSpec{
+				Nodes: 2,
+				NodeSpec: &api.KubernetesEngineNodeSpec{
+					Cpu:     &cpu,
+					Memory:  &memory,
+					Network: &api.KubernetesEngineNodeNetwork{External: &external},
+				},
 			},
-		},
-	}
-	api.SetKubernetesEngineID(&ke, "ke123")
+		}
+		api.SetKubernetesEngineID(&ke, "ke123")
 
-	server, err := buildKubernetesEngineNodeServerSpec(ke, 1, "ssh-rsa AAAA")
-	if err != nil {
-		t.Fatalf("buildKubernetesEngineNodeServerSpec() failed: %v", err)
-	}
-	if server.Metadata.Name != "mke-demo-node-2" {
-		t.Fatalf("server name = %q, want mke-demo-node-2", server.Metadata.Name)
-	}
-	if server.Spec.Cpu == nil || *server.Spec.Cpu != cpu || server.Spec.Memory == nil || *server.Spec.Memory != memory {
-		t.Fatalf("server resources = cpu:%v memory:%v", server.Spec.Cpu, server.Spec.Memory)
-	}
-	if server.Spec.NetworkInterface == nil || len(*server.Spec.NetworkInterface) != 2 {
-		t.Fatalf("network interfaces = %v, want two", server.Spec.NetworkInterface)
-	}
-	nics := *server.Spec.NetworkInterface
-	if nics[0].Networkname != "host-bridge" || nics[1].Networkname != "mke-demo" {
-		t.Fatalf("network interfaces = %+v", nics)
-	}
-	if server.Metadata.Labels == nil || (*server.Metadata.Labels)[kubernetesEngineNodeLabelOwner] != "ke123" {
-		t.Fatalf("server labels = %v", server.Metadata.Labels)
-	}
-	if server.Spec.Auth == nil || server.Spec.Auth.PublicKey == nil || *server.Spec.Auth.PublicKey != "ssh-rsa AAAA" {
-		t.Fatalf("server auth = %+v", server.Spec.Auth)
-	}
-}
+		server, err := buildKubernetesEngineNodeServerSpec(ke, 1, "ssh-rsa AAAA")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(server.Metadata.Name).To(Equal("mke-demo-node-2"))
+		Expect(server.Spec.Cpu).To(HaveValue(Equal(cpu)))
+		Expect(server.Spec.Memory).To(HaveValue(Equal(memory)))
+		Expect(server.Spec.NetworkInterface).To(HaveValue(HaveLen(2)))
+		nics := *server.Spec.NetworkInterface
+		Expect(nics[0].Networkname).To(Equal("host-bridge"))
+		Expect(nics[1].Networkname).To(Equal("mke-demo"))
+		Expect(server.Metadata.Labels).NotTo(BeNil())
+		Expect((*server.Metadata.Labels)[kubernetesEngineNodeLabelOwner]).To(Equal("ke123"))
+		Expect(server.Spec.Auth).NotTo(BeNil())
+		Expect(server.Spec.Auth.PublicKey).To(HaveValue(Equal("ssh-rsa AAAA")))
+	})
 
-func TestKubernetesEngineNodesReady(t *testing.T) {
-	data := []byte(`{"items":[
-		{"metadata":{"name":"node-1"},"status":{"conditions":[{"type":"Ready","status":"True"}]}},
-		{"metadata":{"name":"node-2"},"status":{"conditions":[{"type":"Ready","status":"False"}]}}
-	]}`)
-	ready, err := kubernetesEngineNodesReady(data, []string{"node-1", "node-2"})
-	if err != nil {
-		t.Fatalf("kubernetesEngineNodesReady() failed: %v", err)
-	}
-	if ready {
-		t.Fatalf("kubernetesEngineNodesReady() = true while node-2 is not Ready")
-	}
+	It("reports nodes ready only when every listed node has a True Ready condition", func() {
+		data := []byte(`{"items":[
+			{"metadata":{"name":"node-1"},"status":{"conditions":[{"type":"Ready","status":"True"}]}},
+			{"metadata":{"name":"node-2"},"status":{"conditions":[{"type":"Ready","status":"False"}]}}
+		]}`)
+		ready, err := kubernetesEngineNodesReady(data, []string{"node-1", "node-2"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeFalse())
 
-	readyData := []byte(`{"items":[
-		{"metadata":{"name":"node-1"},"status":{"conditions":[{"type":"Ready","status":"True"}]}},
-		{"metadata":{"name":"node-2"},"status":{"conditions":[{"type":"Ready","status":"True"}]}}
-	]}`)
-	ready, err = kubernetesEngineNodesReady(readyData, []string{"node-1", "node-2"})
-	if err != nil {
-		t.Fatalf("kubernetesEngineNodesReady() failed: %v", err)
-	}
-	if !ready {
-		t.Fatalf("kubernetesEngineNodesReady() = false, want true")
-	}
-}
+		readyData := []byte(`{"items":[
+			{"metadata":{"name":"node-1"},"status":{"conditions":[{"type":"Ready","status":"True"}]}},
+			{"metadata":{"name":"node-2"},"status":{"conditions":[{"type":"Ready","status":"True"}]}}
+		]}`)
+		ready, err = kubernetesEngineNodesReady(readyData, []string{"node-1", "node-2"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeTrue())
+	})
 
-func TestKubernetesEngineNodeInternalIP(t *testing.T) {
-	server := api.Server{Metadata: api.Metadata{Name: "node-1"}, Spec: api.ServerSpec{
-		NetworkInterface: &[]api.NetworkInterface{
-			{Networkname: "default"},
-			{Networkname: "mke-demo", Address: util.StringPtr("172.16.1.10")},
-		},
-	}}
-	address, err := kubernetesEngineNodeInternalIP(server, "mke-demo")
-	if err != nil {
-		t.Fatalf("kubernetesEngineNodeInternalIP() failed: %v", err)
-	}
-	if address != "172.16.1.10" {
-		t.Fatalf("address = %q, want 172.16.1.10", address)
-	}
-}
+	It("resolves a node's internal IP from its network interfaces", func() {
+		server := api.Server{Metadata: api.Metadata{Name: "node-1"}, Spec: api.ServerSpec{
+			NetworkInterface: &[]api.NetworkInterface{
+				{Networkname: "default"},
+				{Networkname: "mke-demo", Address: util.StringPtr("172.16.1.10")},
+			},
+		}}
+		address, err := kubernetesEngineNodeInternalIP(server, "mke-demo")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(address).To(Equal("172.16.1.10"))
+	})
+})

--- a/pkg/controller/kubernetes-engine-pki_test.go
+++ b/pkg/controller/kubernetes-engine-pki_test.go
@@ -7,226 +7,185 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestEnsureKubernetesEngineCACreatesAndIsIdempotent(t *testing.T) {
-	pkiDir := t.TempDir()
+var _ = Describe("KubernetesEngineCA", func() {
+	It("creates the CA and is idempotent on repeated calls", func() {
+		pkiDir := GinkgoT().TempDir()
 
-	certPath, keyPath, err := EnsureKubernetesEngineCA(pkiDir, "demo")
-	if err != nil {
-		t.Fatalf("EnsureKubernetesEngineCA() failed: %v", err)
-	}
-	if !certFileExists(certPath) || !certFileExists(keyPath) {
-		t.Fatalf("CA cert/key were not created: certPath=%s keyPath=%s", certPath, keyPath)
-	}
+		certPath, keyPath, err := EnsureKubernetesEngineCA(pkiDir, "demo")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(certFileExists(certPath)).To(BeTrue())
+		Expect(certFileExists(keyPath)).To(BeTrue())
 
-	firstCert, err := os.ReadFile(certPath)
-	if err != nil {
-		t.Fatalf("failed to read CA cert: %v", err)
-	}
+		firstCert, err := os.ReadFile(certPath)
+		Expect(err).NotTo(HaveOccurred())
 
-	// 2回目の呼び出しは再生成せず同じ内容を返す(冪等)こと
-	certPath2, keyPath2, err := EnsureKubernetesEngineCA(pkiDir, "demo")
-	if err != nil {
-		t.Fatalf("EnsureKubernetesEngineCA() second call failed: %v", err)
-	}
-	if certPath2 != certPath || keyPath2 != keyPath {
-		t.Fatalf("paths changed between calls: (%s,%s) vs (%s,%s)", certPath, keyPath, certPath2, keyPath2)
-	}
-	secondCert, err := os.ReadFile(certPath2)
-	if err != nil {
-		t.Fatalf("failed to read CA cert: %v", err)
-	}
-	if string(firstCert) != string(secondCert) {
-		t.Fatalf("CA certificate was regenerated on second call")
-	}
-}
-
-func TestEnsureKubernetesEngineCARejectsInvalidClusterName(t *testing.T) {
-	pkiDir := t.TempDir()
-	if _, _, err := EnsureKubernetesEngineCA(pkiDir, " "); err == nil {
-		t.Fatalf("expected error for empty cluster name, got nil")
-	}
-	if _, _, err := EnsureKubernetesEngineCA(pkiDir, "../etc"); err == nil {
-		t.Fatalf("expected error for invalid cluster name, got nil")
-	}
-}
-
-func TestIssueKubernetesEngineCertificateServerAndClient(t *testing.T) {
-	pkiDir := t.TempDir()
-	caCertPath, _, err := EnsureKubernetesEngineCA(pkiDir, "demo")
-	if err != nil {
-		t.Fatalf("EnsureKubernetesEngineCA() failed: %v", err)
-	}
-	caCertPEM, err := os.ReadFile(caCertPath)
-	if err != nil {
-		t.Fatalf("failed to read CA cert: %v", err)
-	}
-	caPool := x509.NewCertPool()
-	if !caPool.AppendCertsFromPEM(caCertPEM) {
-		t.Fatalf("failed to load CA cert into pool")
-	}
-
-	serverCertPath, serverKeyPath, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
-		Name:        "kube-apiserver",
-		CommonName:  "kube-apiserver",
-		Usage:       KubernetesEngineCertUsageServer,
-		DNSNames:    []string{"localhost"},
-		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		// 2回目の呼び出しは再生成せず同じ内容を返す(冪等)こと
+		certPath2, keyPath2, err := EnsureKubernetesEngineCA(pkiDir, "demo")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(certPath2).To(Equal(certPath))
+		Expect(keyPath2).To(Equal(keyPath))
+		secondCert, err := os.ReadFile(certPath2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(secondCert)).To(Equal(string(firstCert)))
 	})
-	if err != nil {
-		t.Fatalf("IssueKubernetesEngineCertificate(server) failed: %v", err)
-	}
-	if !certFileExists(serverCertPath) || !certFileExists(serverKeyPath) {
-		t.Fatalf("server cert/key were not created")
-	}
-	assertCertVerifiesAgainstCA(t, caPool, serverCertPath, x509.ExtKeyUsageServerAuth)
 
-	clientCertPath, clientKeyPath, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
-		Name:       "kubelet-node1",
-		CommonName: "system:node:node1",
-		Usage:      KubernetesEngineCertUsageClient,
+	It("rejects invalid cluster names", func() {
+		pkiDir := GinkgoT().TempDir()
+		_, _, err := EnsureKubernetesEngineCA(pkiDir, " ")
+		Expect(err).To(HaveOccurred())
+		_, _, err = EnsureKubernetesEngineCA(pkiDir, "../etc")
+		Expect(err).To(HaveOccurred())
 	})
-	if err != nil {
-		t.Fatalf("IssueKubernetesEngineCertificate(client) failed: %v", err)
-	}
-	if !certFileExists(clientCertPath) || !certFileExists(clientKeyPath) {
-		t.Fatalf("client cert/key were not created")
-	}
-	assertCertVerifiesAgainstCA(t, caPool, clientCertPath, x509.ExtKeyUsageClientAuth)
+})
 
-	// 同名での再発行は既存ファイルを再利用する(冪等)こと
-	firstCert, err := os.ReadFile(serverCertPath)
-	if err != nil {
-		t.Fatalf("failed to read server cert: %v", err)
-	}
-	serverCertPath2, serverKeyPath2, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
-		Name:       "kube-apiserver",
-		CommonName: "kube-apiserver",
-		Usage:      KubernetesEngineCertUsageServer,
-	})
-	if err != nil {
-		t.Fatalf("IssueKubernetesEngineCertificate() second call failed: %v", err)
-	}
-	if serverCertPath2 != serverCertPath || serverKeyPath2 != serverKeyPath {
-		t.Fatalf("paths changed between calls")
-	}
-	secondCert, err := os.ReadFile(serverCertPath2)
-	if err != nil {
-		t.Fatalf("failed to read server cert: %v", err)
-	}
-	if string(firstCert) != string(secondCert) {
-		t.Fatalf("server certificate was reissued on second call")
-	}
-}
+var _ = Describe("IssueKubernetesEngineCertificate", func() {
+	It("issues server and client certificates that verify against the CA and are cached", func() {
+		pkiDir := GinkgoT().TempDir()
+		caCertPath, _, err := EnsureKubernetesEngineCA(pkiDir, "demo")
+		Expect(err).NotTo(HaveOccurred())
+		caCertPEM, err := os.ReadFile(caCertPath)
+		Expect(err).NotTo(HaveOccurred())
+		caPool := x509.NewCertPool()
+		Expect(caPool.AppendCertsFromPEM(caCertPEM)).To(BeTrue())
 
-func TestIssueKubernetesEngineCertificateRequiresExistingCA(t *testing.T) {
-	pkiDir := t.TempDir()
-	if _, _, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
-		Name:       "kube-apiserver",
-		CommonName: "kube-apiserver",
-		Usage:      KubernetesEngineCertUsageServer,
-	}); err == nil {
-		t.Fatalf("expected error when CA does not exist, got nil")
-	}
-}
-
-func TestIssueKubernetesEngineCertificateRejectsInvalidRequestName(t *testing.T) {
-	pkiDir := t.TempDir()
-	if _, _, err := EnsureKubernetesEngineCA(pkiDir, "demo"); err != nil {
-		t.Fatalf("EnsureKubernetesEngineCA() failed: %v", err)
-	}
-	if _, _, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
-		Name:       "../evil",
-		CommonName: "evil",
-		Usage:      KubernetesEngineCertUsageServer,
-	}); err == nil {
-		t.Fatalf("expected error for invalid certificate request name, got nil")
-	}
-}
-
-func TestWithKubernetesEnginePkiLockSerializesCallers(t *testing.T) {
-	lockPath := filepath.Join(t.TempDir(), ".test.lock")
-	started := make(chan struct{})
-	release := make(chan struct{})
-	acquired := make(chan struct{})
-	errCh := make(chan error, 2)
-
-	go func() {
-		errCh <- withKubernetesEnginePkiLock(lockPath, func() error {
-			close(started)
-			<-release
-			return nil
+		serverCertPath, serverKeyPath, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
+			Name:        "kube-apiserver",
+			CommonName:  "kube-apiserver",
+			Usage:       KubernetesEngineCertUsageServer,
+			DNSNames:    []string{"localhost"},
+			IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
 		})
-	}()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(certFileExists(serverCertPath)).To(BeTrue())
+		Expect(certFileExists(serverKeyPath)).To(BeTrue())
+		assertCertVerifiesAgainstCA(caPool, serverCertPath, x509.ExtKeyUsageServerAuth)
 
-	<-started
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		errCh <- withKubernetesEnginePkiLock(lockPath, func() error {
-			close(acquired)
-			return nil
+		clientCertPath, clientKeyPath, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
+			Name:       "kubelet-node1",
+			CommonName: "system:node:node1",
+			Usage:      KubernetesEngineCertUsageClient,
 		})
-	}()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(certFileExists(clientCertPath)).To(BeTrue())
+		Expect(certFileExists(clientKeyPath)).To(BeTrue())
+		assertCertVerifiesAgainstCA(caPool, clientCertPath, x509.ExtKeyUsageClientAuth)
 
-	select {
-	case <-acquired:
-		t.Fatalf("second caller acquired lock before first caller released it")
-	case <-time.After(100 * time.Millisecond):
-	}
+		// 同名での再発行は既存ファイルを再利用する(冪等)こと
+		firstCert, err := os.ReadFile(serverCertPath)
+		Expect(err).NotTo(HaveOccurred())
+		serverCertPath2, serverKeyPath2, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
+			Name:       "kube-apiserver",
+			CommonName: "kube-apiserver",
+			Usage:      KubernetesEngineCertUsageServer,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serverCertPath2).To(Equal(serverCertPath))
+		Expect(serverKeyPath2).To(Equal(serverKeyPath))
+		secondCert, err := os.ReadFile(serverCertPath2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(secondCert)).To(Equal(string(firstCert)))
+	})
 
-	close(release)
-	wg.Wait()
+	It("requires an existing CA", func() {
+		pkiDir := GinkgoT().TempDir()
+		_, _, err := IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
+			Name:       "kube-apiserver",
+			CommonName: "kube-apiserver",
+			Usage:      KubernetesEngineCertUsageServer,
+		})
+		Expect(err).To(HaveOccurred())
+	})
 
-	select {
-	case <-acquired:
-	case <-time.After(time.Second):
-		t.Fatalf("second caller did not acquire lock after release")
-	}
+	It("rejects an invalid certificate request name", func() {
+		pkiDir := GinkgoT().TempDir()
+		_, _, err := EnsureKubernetesEngineCA(pkiDir, "demo")
+		Expect(err).NotTo(HaveOccurred())
+		_, _, err = IssueKubernetesEngineCertificate(pkiDir, "demo", KubernetesEngineCertRequest{
+			Name:       "../evil",
+			CommonName: "evil",
+			Usage:      KubernetesEngineCertUsageServer,
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})
 
-	for i := 0; i < 2; i++ {
-		if err := <-errCh; err != nil {
-			t.Fatalf("withKubernetesEnginePkiLock() failed: %v", err)
+var _ = Describe("withKubernetesEnginePkiLock", func() {
+	It("serializes concurrent callers", func() {
+		lockPath := filepath.Join(GinkgoT().TempDir(), ".test.lock")
+		started := make(chan struct{})
+		release := make(chan struct{})
+		acquired := make(chan struct{})
+		errCh := make(chan error, 2)
+
+		go func() {
+			errCh <- withKubernetesEnginePkiLock(lockPath, func() error {
+				close(started)
+				<-release
+				return nil
+			})
+		}()
+
+		<-started
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- withKubernetesEnginePkiLock(lockPath, func() error {
+				close(acquired)
+				return nil
+			})
+		}()
+
+		select {
+		case <-acquired:
+			Fail("second caller acquired lock before first caller released it")
+		case <-time.After(100 * time.Millisecond):
 		}
-	}
-}
 
-func assertCertVerifiesAgainstCA(t *testing.T, caPool *x509.CertPool, certPath string, usage x509.ExtKeyUsage) {
-	t.Helper()
+		close(release)
+		wg.Wait()
+
+		select {
+		case <-acquired:
+		case <-time.After(time.Second):
+			Fail("second caller did not acquire lock after release")
+		}
+
+		for i := 0; i < 2; i++ {
+			Expect(<-errCh).NotTo(HaveOccurred())
+		}
+	})
+})
+
+func assertCertVerifiesAgainstCA(caPool *x509.CertPool, certPath string, usage x509.ExtKeyUsage) {
 	certPEM, err := os.ReadFile(certPath)
-	if err != nil {
-		t.Fatalf("failed to read cert %s: %v", certPath, err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	block, _ := pem.Decode(certPEM)
-	if block == nil {
-		t.Fatalf("failed to parse PEM block for %s", certPath)
-	}
+	Expect(block).NotTo(BeNil())
 	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		t.Fatalf("failed to parse certificate %s: %v", certPath, err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	opts := x509.VerifyOptions{
 		Roots:     caPool,
 		KeyUsages: []x509.ExtKeyUsage{usage},
 	}
-	if _, err := cert.Verify(opts); err != nil {
-		t.Fatalf("certificate %s did not verify against CA: %v", certPath, err)
-	}
+	_, err = cert.Verify(opts)
+	Expect(err).NotTo(HaveOccurred())
 }
 
-func TestKubernetesEnginePkiDirLayout(t *testing.T) {
-	pkiDir := t.TempDir()
-	certPath, keyPath, err := EnsureKubernetesEngineCA(pkiDir, "demo")
-	if err != nil {
-		t.Fatalf("EnsureKubernetesEngineCA() failed: %v", err)
-	}
-	wantDir := filepath.Join(pkiDir, "demo")
-	if filepath.Dir(certPath) != wantDir || filepath.Dir(keyPath) != wantDir {
-		t.Fatalf("CA files not under expected dir %s: certPath=%s keyPath=%s", wantDir, certPath, keyPath)
-	}
-}
+var _ = Describe("KubernetesEnginePkiDirLayout", func() {
+	It("places CA files under the expected pki directory", func() {
+		pkiDir := GinkgoT().TempDir()
+		certPath, keyPath, err := EnsureKubernetesEngineCA(pkiDir, "demo")
+		Expect(err).NotTo(HaveOccurred())
+		wantDir := filepath.Join(pkiDir, "demo")
+		Expect(filepath.Dir(certPath)).To(Equal(wantDir))
+		Expect(filepath.Dir(keyPath)).To(Equal(wantDir))
+	})
+})

--- a/pkg/controller/kubernetes-engine-vm-e2e_test.go
+++ b/pkg/controller/kubernetes-engine-vm-e2e_test.go
@@ -5,57 +5,29 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"strings"
-	"testing"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/db"
 	"github.com/takara9/marmot/pkg/marmotd"
 	"github.com/takara9/marmot/pkg/util"
 )
 
-func TestKubernetesEngineVMEndToEnd(t *testing.T) {
-	if os.Getenv("MARMOT_RUN_MKE_VM_E2E") != "1" {
-		t.Skip("set MARMOT_RUN_MKE_VM_E2E=1 to run the KubernetesEngine VM E2E test")
-	}
-
-	for _, command := range []string{"ansible-playbook", "curl", "docker", "ip", "systemctl", "virsh"} {
-		if _, err := exec.LookPath(command); err != nil {
-			t.Fatalf("required command %q is unavailable: %v", command, err)
-		}
-	}
-	if output, err := exec.Command("docker", "info").CombinedOutput(); err != nil {
-		t.Fatalf("docker daemon is unavailable: %v (output=%s)", err, strings.TrimSpace(string(output)))
-	}
-
-	nodeName := fmt.Sprintf("mke-e2e-%d", time.Now().Unix())
-	clusterName := fmt.Sprintf("ci-%d", time.Now().Unix())
-	endpoint := strings.TrimSpace(os.Getenv("MARMOT_TEST_ETCD_ENDPOINT"))
-	if endpoint == "" {
-		endpoint = startGatewayTestEtcdContainer(t)
-	}
-
-	ma, err := marmotd.NewMarmot(nodeName, endpoint)
-	if err != nil {
-		t.Fatalf("NewMarmot() failed: %v", err)
-	}
-	t.Cleanup(func() { _ = ma.Db.Close() })
-	if err := ma.CollectAndUpdateHostStatus(); err != nil {
-		t.Fatalf("CollectAndUpdateHostStatus() failed: %v", err)
-	}
-
-	imageID, err := prepareKubernetesEngineE2EImage(ma, nodeName)
-	if err != nil {
-		if imageID != "" {
-			_ = ma.DeleteImageManage(imageID)
-		}
-		t.Fatalf("failed to prepare Ubuntu 24.04 image: %v", err)
-	}
-
+// フェーズごとにItを分割し、Ordered経由で失敗箇所以降のItを自動スキップさせることで問題箇所を特定しやすくする。
+var _ = Describe("KubernetesEngine VM E2E", Ordered, func() {
 	var (
+		nodeName          string
+		clusterName       string
+		endpoint          string
+		expectedNodeName  string
+		ma                *marmotd.Marmot
+		imageID           string
 		engine            api.KubernetesEngine
 		networkController *controller
 		volumeController  *controller
@@ -64,7 +36,32 @@ func TestKubernetesEngineVMEndToEnd(t *testing.T) {
 		stopHostStatus    context.CancelFunc
 		hostStatusDone    chan struct{}
 	)
-	t.Cleanup(func() {
+
+	BeforeAll(func() {
+		if os.Getenv("MARMOT_RUN_MKE_VM_E2E") != "1" {
+			Skip("set MARMOT_RUN_MKE_VM_E2E=1 to run the KubernetesEngine VM E2E test")
+		}
+
+		for _, command := range []string{"ansible-playbook", "curl", "docker", "ip", "systemctl", "virsh"} {
+			_, err := exec.LookPath(command)
+			Expect(err).NotTo(HaveOccurred(), "required command %q is unavailable", command)
+		}
+		output, err := exec.Command("docker", "info").CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), "docker daemon is unavailable (output=%s)", strings.TrimSpace(string(output)))
+
+		nodeName = fmt.Sprintf("mke-e2e-%d", time.Now().Unix())
+		clusterName = fmt.Sprintf("ci-%d", time.Now().Unix())
+		endpoint = strings.TrimSpace(os.Getenv("MARMOT_TEST_ETCD_ENDPOINT"))
+		if endpoint == "" {
+			endpoint = startKubernetesEngineE2EEtcdContainer()
+		}
+
+		ma, err = marmotd.NewMarmot(nodeName, endpoint)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ma.CollectAndUpdateHostStatus()).To(Succeed())
+	})
+
+	AfterAll(func() {
 		if mkeController != nil {
 			mkeController.Stop()
 		}
@@ -72,75 +69,160 @@ func TestKubernetesEngineVMEndToEnd(t *testing.T) {
 			stopHostStatus()
 			<-hostStatusDone
 		}
-		cleanupKubernetesEngineVMEndToEnd(t, ma, vmController, volumeController, networkController, engine, imageID)
+		cleanupKubernetesEngineVMEndToEnd(ma, vmController, volumeController, networkController, engine, imageID)
+		if ma != nil {
+			_ = ma.Db.Close()
+		}
 	})
 
-	networkController, err = StartNetController(nodeName, endpoint, 1)
-	if err != nil {
-		t.Fatalf("StartNetController() failed: %v", err)
-	}
-	volumeController, err = StartVolController(nodeName, endpoint, 1)
-	if err != nil {
-		t.Fatalf("StartVolController() failed: %v", err)
-	}
-	vmController, err = StartVmController(nodeName, endpoint, 1)
-	if err != nil {
-		t.Fatalf("StartVmController() failed: %v", err)
-	}
-	mkeController, err = StartKubernetesEngineController(nodeName, endpoint, "")
-	if err != nil {
-		t.Fatalf("StartKubernetesEngineController() failed: %v", err)
-	}
-
-	hostStatusContext, cancelHostStatus := context.WithCancel(context.Background())
-	stopHostStatus = cancelHostStatus
-	hostStatusDone = make(chan struct{})
-	go refreshKubernetesEngineE2EHostStatus(hostStatusContext, hostStatusDone, ma)
-
-	engine, err = ma.Db.CreateKubernetesEngine(api.KubernetesEngine{
-		ApiVersion: "v1",
-		Kind:       "KubernetesEngine",
-		Metadata: api.Metadata{
-			Name:     clusterName,
-			NodeName: util.StringPtr(nodeName),
-		},
-		Spec: api.KubernetesEngineSpec{
-			Version: "1.36",
-			Nodes:   1,
-		},
+	It("prepares the Ubuntu 24.04 base image", func() {
+		By("preparing the Ubuntu 24.04 base image for node " + nodeName)
+		stopProgress := startKubernetesEngineE2EElapsedProgress("preparing Ubuntu 24.04 base image")
+		defer stopProgress()
+		var err error
+		imageID, err = prepareKubernetesEngineE2EImage(ma, nodeName)
+		Expect(err).NotTo(HaveOccurred())
 	})
-	if err != nil {
-		t.Fatalf("CreateKubernetesEngine() failed: %v", err)
-	}
 
-	deadline := time.Now().Add(40 * time.Minute)
-	expectedNodeName := kubernetesEngineNodeName(engine, 0)
-	for time.Now().Before(deadline) {
-		current, getErr := ma.Db.GetKubernetesEngineById(api.KubernetesEngineID(engine))
-		if getErr != nil {
-			t.Fatalf("GetKubernetesEngineById() failed: %v", getErr)
-		}
-		engine = current
-		if bridgeName, err := failOnKubernetesEngineE2ENetworkError(ma.Db, engine); err != nil {
-			logKubernetesEngineE2EOVSDiagnostics(t, bridgeName)
-			t.Fatal(err)
-		}
-		if err := failOnKubernetesEngineE2EServerError(ma.Db, engine); err != nil {
-			t.Fatal(err)
-		}
-		registered, queryErr := kubernetesEngineE2ENodeRegistered(current, expectedNodeName)
-		if queryErr == nil && registered {
-			t.Logf("Kubernetes node %s registered successfully", expectedNodeName)
-			return
-		}
-		time.Sleep(10 * time.Second)
-	}
+	It("starts the network, volume, VM, and KubernetesEngine controllers", func() {
+		By("starting the network, volume, VM, and KubernetesEngine controllers")
+		var err error
+		networkController, err = StartNetController(nodeName, endpoint, 1)
+		Expect(err).NotTo(HaveOccurred())
+		volumeController, err = StartVolController(nodeName, endpoint, 1)
+		Expect(err).NotTo(HaveOccurred())
+		vmController, err = StartVmController(nodeName, endpoint, 1)
+		Expect(err).NotTo(HaveOccurred())
+		mkeController, err = StartKubernetesEngineController(nodeName, endpoint, "")
+		Expect(err).NotTo(HaveOccurred())
 
-	message := ""
-	if engine.Status != nil && engine.Status.Message != nil {
-		message = *engine.Status.Message
-	}
-	t.Fatalf("timed out waiting for Kubernetes node %s to register; engine status=%+v message=%q", expectedNodeName, engine.Status, message)
+		hostStatusContext, cancelHostStatus := context.WithCancel(context.Background())
+		stopHostStatus = cancelHostStatus
+		hostStatusDone = make(chan struct{})
+		go refreshKubernetesEngineE2EHostStatus(hostStatusContext, hostStatusDone, ma)
+	})
+
+	It("creates the KubernetesEngine cluster resource", func() {
+		By("creating the KubernetesEngine cluster resource " + clusterName)
+		var err error
+		engine, err = ma.Db.CreateKubernetesEngine(api.KubernetesEngine{
+			ApiVersion: "v1",
+			Kind:       "KubernetesEngine",
+			Metadata: api.Metadata{
+				Name:     clusterName,
+				NodeName: util.StringPtr(nodeName),
+			},
+			Spec: api.KubernetesEngineSpec{
+				Version: "1.36",
+				Nodes:   1,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		expectedNodeName = kubernetesEngineNodeName(engine, 0)
+	})
+
+	It("provisions the KubernetesEngine dedicated network", func() {
+		expectedName := kubernetesEngineNetworkName(engine)
+		By("waiting for KubernetesEngine network " + expectedName + " to become active")
+		nextProgressLog := time.Now()
+		Eventually(func(g Gomega) int {
+			networks, err := ma.Db.GetVirtualNetworks()
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, network := range networks {
+				if network.Metadata.Name != expectedName || network.Status == nil {
+					continue
+				}
+				if network.Status.StatusCode == db.NETWORK_ERROR {
+					bridgeName := ""
+					if network.Spec.BridgeName != nil {
+						bridgeName = strings.TrimSpace(*network.Spec.BridgeName)
+					}
+					logKubernetesEngineE2EOVSDiagnostics(bridgeName)
+					message := ""
+					if network.Status.Message != nil {
+						message = strings.TrimSpace(*network.Status.Message)
+					}
+					StopTrying(fmt.Sprintf("KubernetesEngine network %s entered ERROR: %s", expectedName, message)).Now()
+				}
+				logKubernetesEngineE2EProgress(&nextProgressLog, "waiting for network %s; status=%d", expectedName, network.Status.StatusCode)
+				return network.Status.StatusCode
+			}
+			logKubernetesEngineE2EProgress(&nextProgressLog, "network %s not created yet", expectedName)
+			return db.NETWORK_PENDING
+		}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Equal(db.NETWORK_ACTIVE))
+	})
+
+	It("provisions the KubernetesEngine control plane", func() {
+		By("waiting for the KubernetesEngine control plane to become healthy")
+		nextProgressLog := time.Now()
+		Eventually(func(g Gomega) error {
+			current, err := ma.Db.GetKubernetesEngineById(api.KubernetesEngineID(engine))
+			g.Expect(err).NotTo(HaveOccurred())
+			engine = current
+			if err := failOnKubernetesEngineE2EServerError(ma.Db, engine); err != nil {
+				StopTrying(err.Error()).Now()
+			}
+			if engine.Status == nil || engine.Status.ControlPlaneIpAddress == nil || engine.Status.ApiServerPort == nil {
+				logKubernetesEngineE2EProgress(&nextProgressLog, "control plane address not yet allocated; engine message=%q", kubernetesEngineE2EStatusMessage(engine))
+				return fmt.Errorf("control plane address not yet allocated")
+			}
+			trimmedClusterName := strings.TrimSpace(engine.Metadata.Name)
+			caPath, _ := KubernetesEngineCAPaths(DefaultKubernetesEnginePkiDir, trimmedClusterName)
+			namespace, _, _, err := KubernetesEngineControlPlaneNetworkNames(trimmedClusterName)
+			if err != nil {
+				return err
+			}
+			healthErr := CheckKubernetesEngineControlPlaneHealth(namespace, caPath, *engine.Status.ControlPlaneIpAddress, *engine.Status.ApiServerPort)
+			logKubernetesEngineE2EProgress(&nextProgressLog, "waiting for control plane %s:%d health check; last error=%v", *engine.Status.ControlPlaneIpAddress, *engine.Status.ApiServerPort, healthErr)
+			return healthErr
+		}).WithTimeout(10 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
+	})
+
+	It("provisions the node VM and registers it with the Kubernetes API", func() {
+		By("waiting for Kubernetes node " + expectedNodeName + " to register")
+		nextProgressLog := time.Now()
+		Eventually(func(g Gomega) error {
+			current, err := ma.Db.GetKubernetesEngineById(api.KubernetesEngineID(engine))
+			g.Expect(err).NotTo(HaveOccurred())
+			engine = current
+			if err := failOnKubernetesEngineE2EServerError(ma.Db, engine); err != nil {
+				StopTrying(err.Error()).Now()
+			}
+			registered, queryErr := kubernetesEngineE2ENodeRegistered(engine, expectedNodeName)
+			logKubernetesEngineE2EProgress(&nextProgressLog, "waiting for Kubernetes node %s; registered=%v query error=%v engine message=%q", expectedNodeName, registered, queryErr, kubernetesEngineE2EStatusMessage(engine))
+			if queryErr != nil {
+				return queryErr
+			}
+			if !registered {
+				return fmt.Errorf("Kubernetes node %s not yet registered; engine message=%q", expectedNodeName, kubernetesEngineE2EStatusMessage(engine))
+			}
+			return nil
+		}).WithTimeout(25 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+	})
+})
+
+func startKubernetesEngineE2EEtcdContainer() string {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	Expect(err).NotTo(HaveOccurred(), "net.Listen() failed while reserving test port")
+	port := listener.Addr().(*net.TCPAddr).Port
+	Expect(listener.Close()).To(Succeed())
+
+	output, err := exec.Command("docker", "run", "-d", "--rm", "-p", fmt.Sprintf("%d:2379", port), "ghcr.io/takara9/etcd:3.6.5").CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "failed to start etcd test container (output=%s)", strings.TrimSpace(string(output)))
+	containerID := strings.TrimSpace(string(output))
+	DeferCleanup(func() {
+		_, _ = exec.Command("docker", "stop", containerID).CombinedOutput()
+	})
+
+	endpoint := fmt.Sprintf("http://127.0.0.1:%d", port)
+	Eventually(func() error {
+		database, err := db.NewDatabase(endpoint)
+		if err != nil {
+			return err
+		}
+		return database.Close()
+	}).WithTimeout(20 * time.Second).WithPolling(300 * time.Millisecond).Should(Succeed())
+	return endpoint
 }
 
 func prepareKubernetesEngineE2EImage(ma *marmotd.Marmot, nodeName string) (string, error) {
@@ -180,31 +262,45 @@ func refreshKubernetesEngineE2EHostStatus(ctx context.Context, done chan<- struc
 	}
 }
 
-func failOnKubernetesEngineE2ENetworkError(database *db.Database, engine api.KubernetesEngine) (string, error) {
-	networks, err := database.GetVirtualNetworks()
-	if err != nil {
-		return "", err
+// logKubernetesEngineE2EProgress は-ginkgo.vでリアルタイム表示されるGinkgoWriterへ、長時間のEventuallyポーリング中に
+// 経過を1分間隔で出力し、CIログが長時間無出力になるのを防ぐ。
+func logKubernetesEngineE2EProgress(nextLogAt *time.Time, format string, args ...any) {
+	if time.Now().Before(*nextLogAt) {
+		return
 	}
-	expectedName := kubernetesEngineNetworkName(engine)
-	for _, network := range networks {
-		if network.Metadata.Name != expectedName || network.Status == nil || network.Status.StatusCode != db.NETWORK_ERROR {
-			continue
-		}
-		bridgeName := ""
-		if network.Spec.BridgeName != nil {
-			bridgeName = strings.TrimSpace(*network.Spec.BridgeName)
-		}
-		message := ""
-		if network.Status.Message != nil {
-			message = strings.TrimSpace(*network.Status.Message)
-		}
-		return bridgeName, fmt.Errorf("KubernetesEngine network %s entered ERROR: %s", expectedName, message)
-	}
-	return "", nil
+	GinkgoWriter.Printf(format+"\n", args...)
+	*nextLogAt = time.Now().Add(time.Minute)
 }
 
-func logKubernetesEngineE2EOVSDiagnostics(t *testing.T, bridgeName string) {
-	t.Helper()
+// startKubernetesEngineE2EElapsedProgress は、Eventuallyによるポーリングを伴わない単発の長時間処理
+// （画像ダウンロード・カスタマイズ等）でもCIログが無出力にならないよう、1分間隔で経過時間をGinkgoWriter
+// へ出力するティッカーを開始する。呼び出し側は処理完了後に返り値の停止関数を呼び出すこと。
+func startKubernetesEngineE2EElapsedProgress(label string) func() {
+	start := time.Now()
+	done := make(chan struct{})
+	ticker := time.NewTicker(time.Minute)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				GinkgoWriter.Printf("%s: still in progress (elapsed=%s)\n", label, time.Since(start).Round(time.Second))
+			}
+		}
+	}()
+	return func() { close(done) }
+}
+
+func kubernetesEngineE2EStatusMessage(engine api.KubernetesEngine) string {
+	if engine.Status == nil || engine.Status.Message == nil {
+		return ""
+	}
+	return *engine.Status.Message
+}
+
+func logKubernetesEngineE2EOVSDiagnostics(bridgeName string) {
 	commands := [][]string{
 		{"ovs-vsctl", "show"},
 		{"ovs-vsctl", "list", "Bridge"},
@@ -218,7 +314,7 @@ func logKubernetesEngineE2EOVSDiagnostics(t *testing.T, bridgeName string) {
 	}
 	for _, command := range commands {
 		output, err := exec.Command(command[0], command[1:]...).CombinedOutput()
-		t.Logf("OVS diagnostic: %s\nerror=%v\n%s", strings.Join(command, " "), err, strings.TrimSpace(string(output)))
+		GinkgoWriter.Printf("OVS diagnostic: %s\nerror=%v\n%s\n", strings.Join(command, " "), err, strings.TrimSpace(string(output)))
 	}
 }
 
@@ -277,19 +373,19 @@ func kubernetesEngineE2ENodeRegistered(engine api.KubernetesEngine, expectedName
 	return false, nil
 }
 
-func cleanupKubernetesEngineVMEndToEnd(t *testing.T, ma *marmotd.Marmot, vmController, volumeController, networkController *controller, engine api.KubernetesEngine, imageID string) {
-	t.Helper()
+func cleanupKubernetesEngineVMEndToEnd(ma *marmotd.Marmot, vmController, volumeController, networkController *controller, engine api.KubernetesEngine, imageID string) {
+	var cleanupErrors []error
 	if api.KubernetesEngineID(engine) != "" {
 		if current, err := ma.Db.GetKubernetesEngineById(api.KubernetesEngineID(engine)); err == nil {
 			engine = current
 		}
 		servers, err := findKubernetesEngineNodeServers(ma.Db, engine)
 		if err != nil {
-			t.Errorf("cleanup: failed to list node servers: %v", err)
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to list node servers: %w", err))
 		}
 		for _, server := range servers {
 			if err := ma.Db.SetDeleteTimestamp(api.ServerID(server)); err != nil && !errors.Is(err, db.ErrNotFound) {
-				t.Errorf("cleanup: failed to mark server %s for deletion: %v", server.Metadata.Name, err)
+				cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to mark server %s for deletion: %w", server.Metadata.Name, err))
 			}
 		}
 		deadline := time.Now().Add(3 * time.Minute)
@@ -301,16 +397,16 @@ func cleanupKubernetesEngineVMEndToEnd(t *testing.T, ma *marmotd.Marmot, vmContr
 			}
 		}
 		if len(servers) > 0 {
-			t.Errorf("cleanup: %d KubernetesEngine node server(s) remain", len(servers))
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("%d KubernetesEngine node server(s) remain", len(servers)))
 		}
 		if engine.Status != nil && engine.Status.ControlPlaneIpAddress != nil {
 			if err := DeprovisionKubernetesEngineControlPlane(ma.Db, engine); err != nil {
-				t.Errorf("cleanup: failed to deprovision control plane: %v", err)
+				cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to deprovision control plane: %w", err))
 			}
 		}
 		if network, err := ma.Db.GetVirtualNetworkByName(kubernetesEngineNetworkName(engine)); err == nil {
 			if err := ma.DeleteVirtualNetwork(api.VirtualNetworkID(network)); err != nil {
-				t.Errorf("cleanup: failed to delete KubernetesEngine network: %v", err)
+				cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to delete KubernetesEngine network: %w", err))
 			}
 		}
 	}
@@ -325,7 +421,10 @@ func cleanupKubernetesEngineVMEndToEnd(t *testing.T, ma *marmotd.Marmot, vmContr
 	}
 	if imageID != "" {
 		if err := ma.DeleteImageManage(imageID); err != nil && !errors.Is(err, db.ErrNotFound) {
-			t.Errorf("cleanup: failed to delete image %s: %v", imageID, err)
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to delete image %s: %w", imageID, err))
 		}
+	}
+	if len(cleanupErrors) > 0 {
+		Fail(fmt.Sprintf("cleanup failed: %v", errors.Join(cleanupErrors...)))
 	}
 }

--- a/pkg/controller/kubernetes-engine-vm-e2e_test.go
+++ b/pkg/controller/kubernetes-engine-vm-e2e_test.go
@@ -1,0 +1,331 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
+	"github.com/takara9/marmot/pkg/marmotd"
+	"github.com/takara9/marmot/pkg/util"
+)
+
+func TestKubernetesEngineVMEndToEnd(t *testing.T) {
+	if os.Getenv("MARMOT_RUN_MKE_VM_E2E") != "1" {
+		t.Skip("set MARMOT_RUN_MKE_VM_E2E=1 to run the KubernetesEngine VM E2E test")
+	}
+
+	for _, command := range []string{"ansible-playbook", "curl", "docker", "ip", "systemctl", "virsh"} {
+		if _, err := exec.LookPath(command); err != nil {
+			t.Fatalf("required command %q is unavailable: %v", command, err)
+		}
+	}
+	if output, err := exec.Command("docker", "info").CombinedOutput(); err != nil {
+		t.Fatalf("docker daemon is unavailable: %v (output=%s)", err, strings.TrimSpace(string(output)))
+	}
+
+	nodeName := fmt.Sprintf("mke-e2e-%d", time.Now().Unix())
+	clusterName := fmt.Sprintf("ci-%d", time.Now().Unix())
+	endpoint := strings.TrimSpace(os.Getenv("MARMOT_TEST_ETCD_ENDPOINT"))
+	if endpoint == "" {
+		endpoint = startGatewayTestEtcdContainer(t)
+	}
+
+	ma, err := marmotd.NewMarmot(nodeName, endpoint)
+	if err != nil {
+		t.Fatalf("NewMarmot() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = ma.Db.Close() })
+	if err := ma.CollectAndUpdateHostStatus(); err != nil {
+		t.Fatalf("CollectAndUpdateHostStatus() failed: %v", err)
+	}
+
+	imageID, err := prepareKubernetesEngineE2EImage(ma, nodeName)
+	if err != nil {
+		if imageID != "" {
+			_ = ma.DeleteImageManage(imageID)
+		}
+		t.Fatalf("failed to prepare Ubuntu 24.04 image: %v", err)
+	}
+
+	var (
+		engine            api.KubernetesEngine
+		networkController *controller
+		volumeController  *controller
+		vmController      *controller
+		mkeController     *kubernetesEngineController
+		stopHostStatus    context.CancelFunc
+		hostStatusDone    chan struct{}
+	)
+	t.Cleanup(func() {
+		if mkeController != nil {
+			mkeController.Stop()
+		}
+		if stopHostStatus != nil {
+			stopHostStatus()
+			<-hostStatusDone
+		}
+		cleanupKubernetesEngineVMEndToEnd(t, ma, vmController, volumeController, networkController, engine, imageID)
+	})
+
+	networkController, err = StartNetController(nodeName, endpoint, 1)
+	if err != nil {
+		t.Fatalf("StartNetController() failed: %v", err)
+	}
+	volumeController, err = StartVolController(nodeName, endpoint, 1)
+	if err != nil {
+		t.Fatalf("StartVolController() failed: %v", err)
+	}
+	vmController, err = StartVmController(nodeName, endpoint, 1)
+	if err != nil {
+		t.Fatalf("StartVmController() failed: %v", err)
+	}
+	mkeController, err = StartKubernetesEngineController(nodeName, endpoint, "")
+	if err != nil {
+		t.Fatalf("StartKubernetesEngineController() failed: %v", err)
+	}
+
+	hostStatusContext, cancelHostStatus := context.WithCancel(context.Background())
+	stopHostStatus = cancelHostStatus
+	hostStatusDone = make(chan struct{})
+	go refreshKubernetesEngineE2EHostStatus(hostStatusContext, hostStatusDone, ma)
+
+	engine, err = ma.Db.CreateKubernetesEngine(api.KubernetesEngine{
+		ApiVersion: "v1",
+		Kind:       "KubernetesEngine",
+		Metadata: api.Metadata{
+			Name:     clusterName,
+			NodeName: util.StringPtr(nodeName),
+		},
+		Spec: api.KubernetesEngineSpec{
+			Version: "1.36",
+			Nodes:   1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateKubernetesEngine() failed: %v", err)
+	}
+
+	deadline := time.Now().Add(40 * time.Minute)
+	expectedNodeName := kubernetesEngineNodeName(engine, 0)
+	for time.Now().Before(deadline) {
+		current, getErr := ma.Db.GetKubernetesEngineById(api.KubernetesEngineID(engine))
+		if getErr != nil {
+			t.Fatalf("GetKubernetesEngineById() failed: %v", getErr)
+		}
+		engine = current
+		if bridgeName, err := failOnKubernetesEngineE2ENetworkError(ma.Db, engine); err != nil {
+			logKubernetesEngineE2EOVSDiagnostics(t, bridgeName)
+			t.Fatal(err)
+		}
+		if err := failOnKubernetesEngineE2EServerError(ma.Db, engine); err != nil {
+			t.Fatal(err)
+		}
+		registered, queryErr := kubernetesEngineE2ENodeRegistered(current, expectedNodeName)
+		if queryErr == nil && registered {
+			t.Logf("Kubernetes node %s registered successfully", expectedNodeName)
+			return
+		}
+		time.Sleep(10 * time.Second)
+	}
+
+	message := ""
+	if engine.Status != nil && engine.Status.Message != nil {
+		message = *engine.Status.Message
+	}
+	t.Fatalf("timed out waiting for Kubernetes node %s to register; engine status=%+v message=%q", expectedNodeName, engine.Status, message)
+}
+
+func prepareKubernetesEngineE2EImage(ma *marmotd.Marmot, nodeName string) (string, error) {
+	const imageName = "ubuntu24.04"
+	imageURL := strings.TrimSpace(os.Getenv("MARMOT_MKE_E2E_IMAGE_URL"))
+	if imageURL == "" {
+		imageURL = "http://hmc/ubuntu-24.04-server-cloudimg-amd64.img"
+	}
+	imageID, err := ma.Db.MakeImageEntryFromURLWithNode(imageName, imageURL, nodeName)
+	if err != nil {
+		return "", err
+	}
+	image, err := ma.Db.GetImage(imageID)
+	if err != nil {
+		return imageID, err
+	}
+	image.Spec.OsName = util.StringPtr("ubuntu")
+	image.Spec.OsVersion = util.StringPtr("24.04")
+	if err := ma.Db.UpdateImage(imageID, image); err != nil {
+		return imageID, err
+	}
+	_, err = ma.CreateNewImageManage(imageID)
+	return imageID, err
+}
+
+func refreshKubernetesEngineE2EHostStatus(ctx context.Context, done chan<- struct{}, ma *marmotd.Marmot) {
+	defer close(done)
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_ = ma.CollectAndUpdateHostStatus()
+		}
+	}
+}
+
+func failOnKubernetesEngineE2ENetworkError(database *db.Database, engine api.KubernetesEngine) (string, error) {
+	networks, err := database.GetVirtualNetworks()
+	if err != nil {
+		return "", err
+	}
+	expectedName := kubernetesEngineNetworkName(engine)
+	for _, network := range networks {
+		if network.Metadata.Name != expectedName || network.Status == nil || network.Status.StatusCode != db.NETWORK_ERROR {
+			continue
+		}
+		bridgeName := ""
+		if network.Spec.BridgeName != nil {
+			bridgeName = strings.TrimSpace(*network.Spec.BridgeName)
+		}
+		message := ""
+		if network.Status.Message != nil {
+			message = strings.TrimSpace(*network.Status.Message)
+		}
+		return bridgeName, fmt.Errorf("KubernetesEngine network %s entered ERROR: %s", expectedName, message)
+	}
+	return "", nil
+}
+
+func logKubernetesEngineE2EOVSDiagnostics(t *testing.T, bridgeName string) {
+	t.Helper()
+	commands := [][]string{
+		{"ovs-vsctl", "show"},
+		{"ovs-vsctl", "list", "Bridge"},
+		{"ovs-vsctl", "list", "Interface"},
+		{"ovs-appctl", "-t", "ovs-vswitchd", "dpif/show"},
+		{"ip", "-details", "link", "show"},
+		{"journalctl", "--no-pager", "-n", "200", "-u", "openvswitch-switch", "-u", "ovs-vswitchd"},
+	}
+	if bridgeName != "" {
+		commands = append(commands, []string{"ovs-vsctl", "get", "Interface", bridgeName, "error"})
+	}
+	for _, command := range commands {
+		output, err := exec.Command(command[0], command[1:]...).CombinedOutput()
+		t.Logf("OVS diagnostic: %s\nerror=%v\n%s", strings.Join(command, " "), err, strings.TrimSpace(string(output)))
+	}
+}
+
+func failOnKubernetesEngineE2EServerError(database *db.Database, engine api.KubernetesEngine) error {
+	servers, err := findKubernetesEngineNodeServers(database, engine)
+	if err != nil {
+		return err
+	}
+	for _, server := range servers {
+		if server.Status != nil && server.Status.StatusCode == db.SERVER_ERROR {
+			message := ""
+			if server.Status.Message != nil {
+				message = *server.Status.Message
+			}
+			return fmt.Errorf("KubernetesEngine node %s entered ERROR: %s", server.Metadata.Name, message)
+		}
+	}
+	return nil
+}
+
+func kubernetesEngineE2ENodeRegistered(engine api.KubernetesEngine, expectedName string) (bool, error) {
+	if engine.Status == nil || engine.Status.ControlPlaneIpAddress == nil || engine.Status.ApiServerPort == nil {
+		return false, nil
+	}
+	clusterName := strings.TrimSpace(engine.Metadata.Name)
+	adminCertPath, adminKeyPath, err := IssueKubernetesEngineCertificate(DefaultKubernetesEnginePkiDir, clusterName, KubernetesEngineCertRequest{
+		Name:          "e2e-admin",
+		CommonName:    "mke-e2e-admin",
+		Organizations: []string{"system:masters"},
+		Usage:         KubernetesEngineCertUsageClient,
+	})
+	if err != nil {
+		return false, err
+	}
+	caPath, _ := KubernetesEngineCAPaths(DefaultKubernetesEnginePkiDir, clusterName)
+	namespace, _, _, err := KubernetesEngineControlPlaneNetworkNames(clusterName)
+	if err != nil {
+		return false, err
+	}
+	endpoint := fmt.Sprintf("https://%s:%d/api/v1/nodes", *engine.Status.ControlPlaneIpAddress, *engine.Status.ApiServerPort)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, "ip", "netns", "exec", namespace, "curl", "--fail", "--silent", "--show-error", "--cacert", caPath, "--cert", adminCertPath, "--key", adminKeyPath, endpoint).CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("failed to list Kubernetes nodes: %w (output=%s)", err, strings.TrimSpace(string(output)))
+	}
+	var nodeList kubernetesNodeList
+	if err := json.Unmarshal(output, &nodeList); err != nil {
+		return false, err
+	}
+	for _, item := range nodeList.Items {
+		if item.Metadata.Name == expectedName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func cleanupKubernetesEngineVMEndToEnd(t *testing.T, ma *marmotd.Marmot, vmController, volumeController, networkController *controller, engine api.KubernetesEngine, imageID string) {
+	t.Helper()
+	if api.KubernetesEngineID(engine) != "" {
+		if current, err := ma.Db.GetKubernetesEngineById(api.KubernetesEngineID(engine)); err == nil {
+			engine = current
+		}
+		servers, err := findKubernetesEngineNodeServers(ma.Db, engine)
+		if err != nil {
+			t.Errorf("cleanup: failed to list node servers: %v", err)
+		}
+		for _, server := range servers {
+			if err := ma.Db.SetDeleteTimestamp(api.ServerID(server)); err != nil && !errors.Is(err, db.ErrNotFound) {
+				t.Errorf("cleanup: failed to mark server %s for deletion: %v", server.Metadata.Name, err)
+			}
+		}
+		deadline := time.Now().Add(3 * time.Minute)
+		for len(servers) > 0 && time.Now().Before(deadline) {
+			time.Sleep(5 * time.Second)
+			servers, err = findKubernetesEngineNodeServers(ma.Db, engine)
+			if err != nil {
+				break
+			}
+		}
+		if len(servers) > 0 {
+			t.Errorf("cleanup: %d KubernetesEngine node server(s) remain", len(servers))
+		}
+		if engine.Status != nil && engine.Status.ControlPlaneIpAddress != nil {
+			if err := DeprovisionKubernetesEngineControlPlane(ma.Db, engine); err != nil {
+				t.Errorf("cleanup: failed to deprovision control plane: %v", err)
+			}
+		}
+		if network, err := ma.Db.GetVirtualNetworkByName(kubernetesEngineNetworkName(engine)); err == nil {
+			if err := ma.DeleteVirtualNetwork(api.VirtualNetworkID(network)); err != nil {
+				t.Errorf("cleanup: failed to delete KubernetesEngine network: %v", err)
+			}
+		}
+	}
+	if vmController != nil {
+		vmController.Stop()
+	}
+	if volumeController != nil {
+		volumeController.Stop()
+	}
+	if networkController != nil {
+		networkController.Stop()
+	}
+	if imageID != "" {
+		if err := ma.DeleteImageManage(imageID); err != nil && !errors.Is(err, db.ErrNotFound) {
+			t.Errorf("cleanup: failed to delete image %s: %v", imageID, err)
+		}
+	}
+}

--- a/pkg/db/db-image_osvariant_test.go
+++ b/pkg/db/db-image_osvariant_test.go
@@ -4,16 +4,16 @@ import "testing"
 
 func TestDeriveImageOSFromVariant(t *testing.T) {
 	tests := []struct {
-		name       string
-		variant    string
-		wantName   string
-		wantVer    string
+		name     string
+		variant  string
+		wantName string
+		wantVer  string
 	}{
 		{
-			name:     "ubuntu 22.04",
-			variant:  "ubuntu22.04",
+			name:     "ubuntu 24.04",
+			variant:  "ubuntu24.04",
 			wantName: "ubuntu",
-			wantVer:  "22.04",
+			wantVer:  "24.04",
 		},
 		{
 			name:     "ubuntu 24.04 with suffix",

--- a/pkg/db/db-image_test.go
+++ b/pkg/db/db-image_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Image", Ordered, func() {
 			})
 
 			It("イメージの作成 #1", func() {
-				url := "http://hmc/ubuntu-22.04-server-cloudimg-amd64.img"
+				url := "http://hmc/ubuntu-24.04-server-cloudimg-amd64.img"
 				id, err = v.MakeImageEntryFromURLWithNode("test-image-1", url, "hv-test-01")
 				Expect(err).NotTo(HaveOccurred())
 				fmt.Println("Created image with ID:", id)

--- a/pkg/marmotd/Makefile
+++ b/pkg/marmotd/Makefile
@@ -85,4 +85,4 @@ test-hostid-internal:
 
 .PHONY: test-mke-vm-e2e
 test-mke-vm-e2e:
-	MARMOT_RUN_MKE_VM_E2E=1 $(GO) test ../controller -run '^TestKubernetesEngineVMEndToEnd$$' -v -count=1 -timeout 50m
+	MARMOT_RUN_MKE_VM_E2E=1 $(GO) test ../controller -run '^TestController$$' -ginkgo.focus-file kubernetes-engine-vm-e2e_test.go -ginkgo.v -ginkgo.fail-fast -ginkgo.show-node-events -count=1 -timeout 50m

--- a/pkg/marmotd/Makefile
+++ b/pkg/marmotd/Makefile
@@ -82,3 +82,7 @@ test-volume-backing-store:
 .PHONY: test-hostid-internal
 test-hostid-internal:
 	$(GO) test -run TestHostIDInternal -ginkgo.v -ginkgo.fail-fast -ginkgo.show-node-events
+
+.PHONY: test-mke-vm-e2e
+test-mke-vm-e2e:
+	MARMOT_RUN_MKE_VM_E2E=1 $(GO) test ../controller -run '^TestKubernetesEngineVMEndToEnd$$' -v -count=1 -timeout 50m

--- a/pkg/marmotd/Makefile
+++ b/pkg/marmotd/Makefile
@@ -85,4 +85,4 @@ test-hostid-internal:
 
 .PHONY: test-mke-vm-e2e
 test-mke-vm-e2e:
-	MARMOT_RUN_MKE_VM_E2E=1 $(GO) test ../controller -run '^TestController$$' -ginkgo.focus-file kubernetes-engine-vm-e2e_test.go -ginkgo.v -ginkgo.fail-fast -ginkgo.show-node-events -count=1 -timeout 50m
+	MARMOT_RUN_MKE_VM_E2E=1 $(GO) test -v ../controller -run '^TestController$$' -ginkgo.focus-file kubernetes-engine-vm-e2e_test.go -ginkgo.v -ginkgo.fail-fast -ginkgo.show-node-events -count=1 -timeout 50m

--- a/pkg/marmotd/api-core.go
+++ b/pkg/marmotd/api-core.go
@@ -248,7 +248,7 @@ func (s *Server) startRevokedAPIKeyCleanupWorker() {
 		ticker := time.NewTicker(revokedAPIKeyCleanupInterval)
 		defer ticker.Stop()
 
-		slog.Info("Started API key maintenance worker", "revokeInterval", idleLoginSessionRevokeInterval.String(), "cleanupInterval", revokedAPIKeyCleanupInterval.String(), "deleteAfter", revokedAPIKeyPhysicalDeleteAfter.String())
+		slog.Debug("Started API key maintenance worker", "revokeInterval", idleLoginSessionRevokeInterval.String(), "cleanupInterval", revokedAPIKeyCleanupInterval.String(), "deleteAfter", revokedAPIKeyPhysicalDeleteAfter.String())
 
 		for {
 			select {
@@ -261,7 +261,7 @@ func (s *Server) startRevokedAPIKeyCleanupWorker() {
 					continue
 				}
 				if revoked > 0 {
-					slog.Info("Idle login session revocation completed", "revoked", revoked)
+					slog.Debug("Idle login session revocation completed", "revoked", revoked)
 				}
 			case <-ticker.C:
 				deleted, err := s.Ma.Db.CleanupRevokedApiKeysOlderThan(revokedAPIKeyPhysicalDeleteAfter)

--- a/pkg/marmotd/api_test.go
+++ b/pkg/marmotd/api_test.go
@@ -125,7 +125,7 @@ var _ = Describe("関数テスト", Ordered, func() {
 			var meta api.Metadata
 			volume.Metadata = meta
 
-					   volume.Metadata.Name = "test-volume-001"
+			volume.Metadata.Name = "test-volume-001"
 			volume.Spec.Type = util.StringPtr("qcow2")
 			volume.Spec.Kind = util.StringPtr("data")
 			volume.Spec.Size = util.IntPtrInt(100)
@@ -175,10 +175,10 @@ var _ = Describe("関数テスト", Ordered, func() {
 			var spec api.VolSpec
 			vol.Spec = spec
 
-					   vol.Metadata.Name = "test-volume-002"
+			vol.Metadata.Name = "test-volume-002"
 			vol.Spec.Type = util.StringPtr("qcow2")
 			vol.Spec.Kind = util.StringPtr("os")
-			vol.Spec.OsVariant = util.StringPtr("ubuntu22.04")
+			vol.Spec.OsVariant = util.StringPtr("ubuntu24.04")
 
 			body, url, err := marmotClient.CreateVolume(vol)
 			Expect(err).NotTo(HaveOccurred())
@@ -231,10 +231,10 @@ var _ = Describe("関数テスト", Ordered, func() {
 			var meta api.Metadata
 			volume.Metadata = meta
 
-					   volume.Metadata.Name = "test-volume-002"
+			volume.Metadata.Name = "test-volume-002"
 			volume.Spec.Type = util.StringPtr("lvm")
 			volume.Spec.Kind = util.StringPtr("os")
-			volume.Spec.OsVariant = util.StringPtr("ubuntu22.04")
+			volume.Spec.OsVariant = util.StringPtr("ubuntu24.04")
 			body, url, err := marmotClient.CreateVolume(volume)
 			Expect(err).NotTo(HaveOccurred())
 			err = json.Unmarshal(body, &replyVolume)
@@ -292,7 +292,7 @@ var _ = Describe("関数テスト", Ordered, func() {
 			var meta api.Metadata
 			volume.Metadata = meta
 
-					   volume.Metadata.Name = "test-volume-002"
+			volume.Metadata.Name = "test-volume-002"
 			volume.Spec.Type = util.StringPtr("lvm")
 			volume.Spec.Kind = util.StringPtr("data")
 			volume.Spec.Size = util.IntPtrInt(1)
@@ -332,7 +332,7 @@ var _ = Describe("関数テスト", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println("ShowVolumeById Id  =", api.VolumeID(vol))
 			GinkgoWriter.Println("ShowVolumeById Key =", *vol.Metadata.Key)
-					   GinkgoWriter.Println("ShowVolumeById VolumeName =", vol.Metadata.Name)
+			GinkgoWriter.Println("ShowVolumeById VolumeName =", vol.Metadata.Name)
 			Expect(url).To(BeNil())
 		})
 
@@ -340,7 +340,7 @@ var _ = Describe("関数テスト", Ordered, func() {
 			var vol api.Volume
 			var meta api.Metadata
 			vol.Metadata = meta
-					   vol.Metadata.Name = "updated-volume-name"
+			vol.Metadata.Name = "updated-volume-name"
 			body, url, err := marmotClient.UpdateVolumeById(api.VolumeID(replyVolume), vol)
 			GinkgoWriter.Println("UpdateVolumeById err =", err)
 			Expect(err).NotTo(HaveOccurred())
@@ -355,8 +355,8 @@ var _ = Describe("関数テスト", Ordered, func() {
 			err = json.Unmarshal(body, &vol)
 			GinkgoWriter.Println("ShowVolumeById Id  =", api.VolumeID(vol))
 			//GinkgoWriter.Println("ShowVolumeById Key =", *vol.Metadata.Key)
-					   GinkgoWriter.Println("ShowVolumeById VolumeName =", vol.Metadata.Name)
-					   Expect(vol.Metadata.Name).To(Equal("updated-volume-name"))
+			GinkgoWriter.Println("ShowVolumeById VolumeName =", vol.Metadata.Name)
+			Expect(vol.Metadata.Name).To(Equal("updated-volume-name"))
 			Expect(url).To(BeNil())
 		})
 

--- a/pkg/marmotd/image_os_module_test.go
+++ b/pkg/marmotd/image_os_module_test.go
@@ -18,8 +18,8 @@ func TestResolveImageOSModuleFromSpec(t *testing.T) {
 		wantKey   string
 		wantErr   bool
 	}{
-		{name: "default", osName: "", osVersion: "", wantKey: "ubuntu22.04"},
-		{name: "ubuntu2204", osName: "ubuntu", osVersion: "22.04", wantKey: "ubuntu22.04"},
+		{name: "default", osName: "", osVersion: "", wantKey: "ubuntu24.04"},
+		{name: "ubuntu2204", osName: "ubuntu", osVersion: "24.04", wantKey: "ubuntu24.04"},
 		{name: "ubuntu2404", osName: "ubuntu", osVersion: "24.04", wantKey: "ubuntu24.04"},
 		{name: "ubuntuFallback", osName: "ubuntu", osVersion: "26.04", wantKey: "ubuntu"},
 		{name: "alpine323", osName: "alpine", osVersion: "3.23", wantKey: "alpine3.23"},
@@ -91,7 +91,7 @@ func TestImageModuleCustomizeDelegatesToCommonCustomizer(t *testing.T) {
 	t.Parallel()
 
 	// Empty path should fail in the shared customizer, proving delegation works.
-	mod, err := resolveImageOSModuleFromSpec("ubuntu", "22.04")
+	mod, err := resolveImageOSModuleFromSpec("ubuntu", "24.04")
 	if err != nil {
 		t.Fatalf("resolveImageOSModuleFromSpec() error = %v", err)
 	}

--- a/pkg/marmotd/osimage_test.go
+++ b/pkg/marmotd/osimage_test.go
@@ -23,7 +23,7 @@ var _ = Describe("ImageManagmentTest", Ordered, func() {
 		etcdctlExe  = "/usr/bin/etcdctl"
 		nodeName    = "hvc"
 		etcdImage   = "ghcr.io/takara9/etcd:3.6.5"
-		osImage1    = "ubuntu-22.04-server-cloudimg-amd64.img"
+		osImage1    = "ubuntu-24.04-server-cloudimg-amd64.img"
 		osImage1URL = "http://hmc/" + osImage1
 		osImage2    = "ubuntu-24.04-server-cloudimg-amd64.img"
 		osImage2URL = "http://hmc/" + osImage2
@@ -94,12 +94,12 @@ var _ = Describe("ImageManagmentTest", Ordered, func() {
 		It("URLを指定してイメージのIDを取得", func() {
 			var err error
 			GinkgoWriter.Println("URLを指定してイメージのIDを取得")
-			osImageid1, err = marmotServer.Ma.Db.MakeImageEntryFromURLWithNode("ubuntu-22.04", osImage1URL, nodeName)
+			osImageid1, err = marmotServer.Ma.Db.MakeImageEntryFromURLWithNode("ubuntu-24.04", osImage1URL, nodeName)
 			Expect(err).NotTo(HaveOccurred())
 			img, err := marmotServer.Ma.Db.GetImage(osImageid1)
 			Expect(err).NotTo(HaveOccurred())
 			img.Spec.OsName = util.StringPtr("ubuntu")
-			img.Spec.OsVersion = util.StringPtr("22.04")
+			img.Spec.OsVersion = util.StringPtr("24.04")
 			err = marmotServer.Ma.Db.UpdateImage(osImageid1, img)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println("取得したイメージID: ", osImageid1)

--- a/pkg/marmotd/server-image_test.go
+++ b/pkg/marmotd/server-image_test.go
@@ -25,7 +25,7 @@ var _ = Describe("ServerImageCopyingTest", Ordered, func() {
 		etcdctlExe = "/usr/bin/etcdctl"
 		nodeName   = "hvc"
 		etcdImage  = "ghcr.io/takara9/etcd:3.6.5"
-		osImage    = "ubuntu-22.04-server-cloudimg-amd64.img"
+		osImage    = "ubuntu-24.04-server-cloudimg-amd64.img"
 		osImageURL = "http://hmc/" + osImage
 	)
 	var (
@@ -146,12 +146,12 @@ var _ = Describe("ServerImageCopyingTest", Ordered, func() {
 	Context("イメージ作成", func() {
 		It("URLを指定してイメージのIDを取得 DB操作のみ", func() {
 			var err error
-			osImageid, err = marmotServer.Ma.Db.MakeImageEntryFromURLWithNode("ubuntu22.04", osImageURL, nodeName)
+			osImageid, err = marmotServer.Ma.Db.MakeImageEntryFromURLWithNode("ubuntu24.04", osImageURL, nodeName)
 			Expect(err).NotTo(HaveOccurred())
 			img, err := marmotServer.Ma.Db.GetImage(osImageid)
 			Expect(err).NotTo(HaveOccurred())
 			img.Spec.OsName = util.StringPtr("ubuntu")
-			img.Spec.OsVersion = util.StringPtr("22.04")
+			img.Spec.OsVersion = util.StringPtr("24.04")
 			err = marmotServer.Ma.Db.UpdateImage(osImageid, img)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println("取得したイメージID: ", osImageid)

--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -372,6 +372,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 		slog.Error("GetServerById()", "err", err)
 		return "", err
 	}
+	normalizeServerImageDefault(&serverConfig)
 	if err := validateServerAuthSpec(serverConfig.Spec.Auth); err != nil {
 		return "", err
 	}
@@ -389,12 +390,6 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 	}
 	assignNodeNameIfUnset(&serverConfig.Metadata, assignedNodeName)
 
-	slog.Debug("OS指定がなければ、OSバリアントのデフォルトを設定")
-	if serverConfig.Spec.OsVariant == nil {
-		bootVol.Spec.OsVariant = util.StringPtr("ubuntu22.04")
-		serverConfig.Spec.OsVariant = util.StringPtr("ubuntu22.04")
-	}
-
 	slog.Debug("ブートボリュームの生成と設定")
 	bootVol.Metadata.Name = "boot-" + api.ServerID(serverConfig)
 	// サーバー割当ノードをブートボリュームのメタデータに付与する。
@@ -402,11 +397,6 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 	bootVol.Spec.Kind = util.StringPtr("os")
 	bootVol.Spec.Path = util.StringPtr("")
 	bootVol.Spec.Size = util.IntPtrInt(0)
-
-	slog.Debug("** OSの種類が指定されていなければ、デフォルトを設定 ** ", "os_variant", serverConfig.Spec.OsVariant)
-	if serverConfig.Spec.OsVariant == nil {
-		serverConfig.Spec.OsVariant = util.StringPtr("ubuntu22.04")
-	}
 
 	slog.Debug("ボリュームタイプの指定がなければ、デフォルトqcow2を設定", "boot volume type", serverConfig.Spec.BootVolume)
 	if serverConfig.Spec.BootVolume == nil || serverConfig.Spec.BootVolume.Spec.Type == nil {
@@ -430,7 +420,7 @@ func (m *Marmot) CreateServerManage(id string) (string, error) {
 
 	slog.Debug("ブートディスクにOSの指定がなければ、デフォルトのOSを設定")
 	if serverConfig.Spec.OsVariant == nil {
-		bootVol.Spec.OsVariant = util.StringPtr("ubuntu22.04") // デフォルトをコンフィグに持たせるべき？
+		bootVol.Spec.OsVariant = util.StringPtr("ubuntu24.04") // デフォルトをコンフィグに持たせるべき？
 	} else {
 		bootVol.Spec.OsVariant = serverConfig.Spec.OsVariant
 	}

--- a/pkg/marmotd/server_image_module.go
+++ b/pkg/marmotd/server_image_module.go
@@ -41,6 +41,14 @@ var (
 	serverImageModuleAlpine323  = commonServerImageModule{key: "alpine3.23", setupBootVolumeFn: util.SetupAlpineLinux}
 )
 
+func normalizeServerImageDefault(server *api.Server) {
+	server.NormalizeMMImageAlias()
+	if server.Spec.MmImage == nil || strings.TrimSpace(*server.Spec.MmImage) == "" {
+		server.Spec.MmImage = util.StringPtr("ubuntu24.04")
+		server.NormalizeMMImageAlias()
+	}
+}
+
 func resolveServerImageModule(m *Marmot, bootVol api.Volume) (serverImageModule, error) {
 	osName, osVersion := "", ""
 	if img, err := resolveImageTemplateByVolumeNode(m, bootVol); err == nil {

--- a/pkg/marmotd/server_image_module_test.go
+++ b/pkg/marmotd/server_image_module_test.go
@@ -1,6 +1,11 @@
 package marmotd
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/takara9/marmot/api"
+)
 
 func TestResolveServerImageModuleFromOS(t *testing.T) {
 	tests := []struct {
@@ -10,7 +15,7 @@ func TestResolveServerImageModuleFromOS(t *testing.T) {
 		wantKey   string
 		wantErr   bool
 	}{
-		{name: "ubuntu 22.04", osName: "ubuntu", osVersion: "22.04", wantKey: "ubuntu22.04"},
+		{name: "ubuntu 24.04", osName: "ubuntu", osVersion: "24.04", wantKey: "ubuntu24.04"},
 		{name: "ubuntu 24.04", osName: "ubuntu", osVersion: "24.04", wantKey: "ubuntu24.04"},
 		{name: "alpine 3.23", osName: "alpine", osVersion: "3.23", wantKey: "alpine3.23"},
 		{name: "ubuntu fallback", osName: "ubuntu", osVersion: "26.04", wantKey: "ubuntu"},
@@ -40,13 +45,38 @@ func TestResolveServerImageModuleFromOS(t *testing.T) {
 	}
 }
 
+func TestNormalizeServerImageDefault(t *testing.T) {
+	mmImage := "alpine3.23"
+	legacyServer := api.Server{}
+	if err := json.Unmarshal([]byte(`{"spec":{"osVariant":"ubuntu22.04"}}`), &legacyServer); err != nil {
+		t.Fatalf("failed to build legacy server input: %v", err)
+	}
+	tests := []struct {
+		name      string
+		server    api.Server
+		wantImage string
+	}{
+		{name: "default", server: api.Server{}, wantImage: "ubuntu24.04"},
+		{name: "mmImage", server: api.Server{Spec: api.ServerSpec{MmImage: &mmImage}}, wantImage: "alpine3.23"},
+		{name: "legacy osVariant", server: legacyServer, wantImage: "ubuntu22.04"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalizeServerImageDefault(&tt.server)
+			if tt.server.Spec.MmImage == nil || *tt.server.Spec.MmImage != tt.wantImage {
+				t.Fatalf("MmImage = %v, want %q", tt.server.Spec.MmImage, tt.wantImage)
+			}
+		})
+	}
+}
+
 func TestDeriveOSFromVariant(t *testing.T) {
 	tests := []struct {
 		variant     string
 		wantName    string
 		wantVersion string
 	}{
-		{variant: "ubuntu22.04", wantName: "ubuntu", wantVersion: "22.04"},
+		{variant: "ubuntu24.04", wantName: "ubuntu", wantVersion: "24.04"},
 		{variant: "ubuntu24.04", wantName: "ubuntu", wantVersion: "24.04"},
 		{variant: "alpine3.23", wantName: "alpine", wantVersion: "3.23"},
 		{variant: "unknown", wantName: "", wantVersion: ""},

--- a/pkg/marmotd/server_test.go
+++ b/pkg/marmotd/server_test.go
@@ -25,7 +25,7 @@ var _ = Describe("サーバーテスト", Ordered, func() {
 		etcdctlExe = "/usr/bin/etcdctl"
 		nodeName   = "hvc"
 		etcdImage  = "ghcr.io/takara9/etcd:3.6.5"
-		osImage    = "ubuntu-22.04-server-cloudimg-amd64.img"
+		osImage    = "ubuntu-24.04-server-cloudimg-amd64.img"
 		osImageURL = "http://hmc/" + osImage
 	)
 	var (
@@ -74,7 +74,7 @@ var _ = Describe("サーバーテスト", Ordered, func() {
 		if waitServerDone != nil {
 			waitServerDone() // goroutine の終了を待つ
 		}
-		// /var/lib/marmot/images/9e24c/ubuntu-22.04-server-cloudimg-amd64.img のようなファイルを削除する
+		// /var/lib/marmot/images/9e24c/ubuntu-24.04-server-cloudimg-amd64.img のようなファイルを削除する
 
 		// 以下の後処理は、本来、それぞれの削除関数の中で実施するべきもの
 		// OS論理ボリューム vg1/boot-9e24c のようなものができるはずなので、削除する
@@ -166,12 +166,12 @@ var _ = Describe("サーバーテスト", Ordered, func() {
 		It("URLを指定してイメージのIDを取得", func() {
 			var err error
 			GinkgoWriter.Println("URLを指定してイメージのIDを取得")
-			osImageid, err = marmotServer.Ma.Db.MakeImageEntryFromURLWithNode("ubuntu22.04", osImageURL, nodeName)
+			osImageid, err = marmotServer.Ma.Db.MakeImageEntryFromURLWithNode("ubuntu24.04", osImageURL, nodeName)
 			Expect(err).NotTo(HaveOccurred())
 			img, err := marmotServer.Ma.Db.GetImage(osImageid)
 			Expect(err).NotTo(HaveOccurred())
 			img.Spec.OsName = util.StringPtr("ubuntu")
-			img.Spec.OsVersion = util.StringPtr("22.04")
+			img.Spec.OsVersion = util.StringPtr("24.04")
 			err = marmotServer.Ma.Db.UpdateImage(osImageid, img)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println("取得したイメージID: ", osImageid)

--- a/pkg/marmotd/volume_test.go
+++ b/pkg/marmotd/volume_test.go
@@ -24,7 +24,7 @@ var _ = Describe("ボリュームテスト", Ordered, func() {
 		nodeName          = "hvc"
 		etcdImage         = "ghcr.io/takara9/etcd:3.6.5"
 		etcdContainerName = "etcd-volume"
-		osImage           = "ubuntu-22.04-server-cloudimg-amd64.img"
+		osImage           = "ubuntu-24.04-server-cloudimg-amd64.img"
 		osImageURL        = "http://hmc/" + osImage
 	)
 	var (
@@ -62,7 +62,7 @@ var _ = Describe("ボリュームテスト", Ordered, func() {
 		cancel()         // モックサーバー停止シグナル
 		waitServerDone() // goroutine の終了を待つ
 
-		// /var/lib/marmot/images/9e24c/ubuntu-22.04-server-cloudimg-amd64.img のようなファイルを削除する
+		// /var/lib/marmot/images/9e24c/ubuntu-24.04-server-cloudimg-amd64.img のようなファイルを削除する
 		imagePath := "/var/lib/marmot/images/" + osImageID
 		err = os.RemoveAll(imagePath)
 		Expect(err).NotTo(HaveOccurred())
@@ -96,13 +96,13 @@ var _ = Describe("ボリュームテスト", Ordered, func() {
 		It("URLを指定してイメージのIDを取得", func() {
 			var err error
 			GinkgoWriter.Println("URLを指定してイメージのIDを取得")
-			//url := "http://hmc/ubuntu-22.04-server-cloudimg-amd64.img"
-			osImageID, err = marmotServer.Ma.Db.MakeImageEntryFromURLWithNode("ubuntu22.04", osImageURL, nodeName)
+			//url := "http://hmc/ubuntu-24.04-server-cloudimg-amd64.img"
+			osImageID, err = marmotServer.Ma.Db.MakeImageEntryFromURLWithNode("ubuntu24.04", osImageURL, nodeName)
 			Expect(err).NotTo(HaveOccurred())
 			img, err := marmotServer.Ma.Db.GetImage(osImageID)
 			Expect(err).NotTo(HaveOccurred())
 			img.Spec.OsName = ut.StringPtr("ubuntu")
-			img.Spec.OsVersion = ut.StringPtr("22.04")
+			img.Spec.OsVersion = ut.StringPtr("24.04")
 			err = marmotServer.Ma.Db.UpdateImage(osImageID, img)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println("取得したイメージID: ", osImageID)
@@ -137,7 +137,7 @@ var _ = Describe("ボリュームテスト", Ordered, func() {
 				Spec: api.VolSpec{
 					Type:      ut.StringPtr("lvm"),
 					Kind:      ut.StringPtr("os"),
-					OsVariant: ut.StringPtr("ubuntu22.04"),
+					OsVariant: ut.StringPtr("ubuntu24.04"),
 				},
 			}
 			GinkgoWriter.Println("Creating OS volume", "volume", v)
@@ -207,7 +207,7 @@ var _ = Describe("ボリュームテスト", Ordered, func() {
 				Spec: api.VolSpec{
 					Type:      ut.StringPtr("noexist"),
 					Kind:      ut.StringPtr("os"),
-					OsVariant: ut.StringPtr("ubuntu22.04"),
+					OsVariant: ut.StringPtr("ubuntu24.04"),
 				},
 			}
 			GinkgoWriter.Println("Creating OS volume", "volume", v)
@@ -330,7 +330,7 @@ var _ = Describe("ボリュームテスト", Ordered, func() {
 				Spec: api.VolSpec{
 					Type:      ut.StringPtr("lvm"),
 					Kind:      ut.StringPtr("os"),
-					OsVariant: ut.StringPtr("ubuntu22.04"),
+					OsVariant: ut.StringPtr("ubuntu24.04"),
 				},
 			}
 			GinkgoWriter.Println("Creating OS volume", "volume", v)
@@ -352,7 +352,7 @@ var _ = Describe("ボリュームテスト", Ordered, func() {
 				Spec: api.VolSpec{
 					Type:      ut.StringPtr("lvm"),
 					Kind:      ut.StringPtr("os"),
-					OsVariant: ut.StringPtr("ubuntu22.04"),
+					OsVariant: ut.StringPtr("ubuntu24.04"),
 				},
 			}
 			GinkgoWriter.Println("Creating OS volume", "volume", v)
@@ -522,7 +522,7 @@ var _ = Describe("ボリュームテスト", Ordered, func() {
 				Spec: api.VolSpec{
 					Type:      ut.StringPtr("qcow2"),
 					Kind:      ut.StringPtr("os"),
-					OsVariant: ut.StringPtr("ubuntu22.04"),
+					OsVariant: ut.StringPtr("ubuntu24.04"),
 				},
 			}
 			GinkgoWriter.Println("Creating qcow2 volume", "volume", v)

--- a/tools/setup-libvirt-networks.sh
+++ b/tools/setup-libvirt-networks.sh
@@ -15,40 +15,135 @@ if ! command -v virsh >/dev/null 2>&1; then
   exit 1
 fi
 
+for command_name in ovs-appctl ovs-vsctl ip; do
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "${command_name} command not found" >&2
+    exit 1
+  fi
+done
+
 ensure_service_if_exists() {
   local unit_name="$1"
+  local required="${2:-false}"
   if systemctl list-unit-files | grep -q "^${unit_name}\\.service"; then
     sudo systemctl enable "${unit_name}.service" || true
-    sudo systemctl start "${unit_name}.service" || true
+    if ! sudo systemctl start "${unit_name}.service"; then
+      if [[ "${required}" == "true" ]]; then
+        return 1
+      fi
+      echo "optional service ${unit_name}.service could not be started" >&2
+    fi
   fi
 }
 
 ensure_ovn_ovs_runtime() {
-  ensure_service_if_exists openvswitch-switch
-  ensure_service_if_exists ovsdb-server
-  ensure_service_if_exists ovs-vswitchd
+  ensure_service_if_exists openvswitch-switch true
+  ensure_service_if_exists ovsdb-server true
+  ensure_service_if_exists ovs-vswitchd true
   ensure_service_if_exists ovn-central
   ensure_service_if_exists ovn-northd
   ensure_service_if_exists ovn-controller
   ensure_service_if_exists ovn-host
 }
 
+print_ovs_diagnostics() {
+  echo "OVS runtime diagnostics:" >&2
+  sudo systemctl --no-pager --full status openvswitch-switch ovsdb-server ovs-vswitchd 2>&1 || true
+  sudo ovs-vsctl show 2>&1 || true
+  sudo ovs-appctl -t ovs-vswitchd dpif/show 2>&1 || true
+  ip -details link show 2>&1 || true
+}
+
+wait_for_linux_bridge() {
+  local bridge_name="$1"
+  local attempt
+
+  for attempt in $(seq 1 30); do
+    if ip link show "${bridge_name}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+create_ovs_bridge() {
+  local bridge_name="$1"
+
+  sudo ovs-vsctl --if-exists del-br "${bridge_name}"
+  sudo ovs-vsctl --may-exist add-br "${bridge_name}"
+  wait_for_linux_bridge "${bridge_name}"
+}
+
+restart_ovs_runtime() {
+  if systemctl list-unit-files | grep -q '^openvswitch-switch\.service'; then
+    sudo systemctl restart openvswitch-switch.service
+    return
+  fi
+  sudo systemctl restart ovsdb-server.service ovs-vswitchd.service
+}
+
 ensure_ovs_bridge() {
   local bridge_name="$1"
-  if ! command -v ovs-vsctl >/dev/null 2>&1; then
-    echo "ovs-vsctl command not found" >&2
-    return 0
-  fi
-  if ovs-vsctl br-exists "${bridge_name}"; then
+  if sudo ovs-vsctl br-exists "${bridge_name}" && ip link show "${bridge_name}" >/dev/null 2>&1; then
     echo "${bridge_name} already exists"
     return 0
   fi
+
   echo "creating ovs bridge ${bridge_name}"
-  sudo ovs-vsctl --may-exist add-br "${bridge_name}"
+  if ! create_ovs_bridge "${bridge_name}"; then
+    echo "${bridge_name} Linux device was not created; restarting OVS runtime" >&2
+    restart_ovs_runtime
+    sudo ovs-appctl -t ovs-vswitchd version >/dev/null
+    if create_ovs_bridge "${bridge_name}"; then
+      return 0
+    fi
+    echo "${bridge_name} exists in OVSDB but its Linux device was not created" >&2
+    print_ovs_diagnostics
+    return 1
+  fi
+}
+
+cleanup_stale_marmot_bridges() {
+  local bridge_name
+  local deleted=0
+
+  while IFS= read -r bridge_name; do
+    if [[ "${bridge_name}" =~ ^br-[0-9a-f]{5}$ ]]; then
+      echo "deleting stale Marmot OVS bridge ${bridge_name}"
+      sudo ovs-vsctl --if-exists del-br "${bridge_name}"
+      deleted=$((deleted + 1))
+    fi
+  done < <(sudo ovs-vsctl list-br)
+  echo "deleted ${deleted} stale Marmot OVS bridge(s)"
+}
+
+probe_dynamic_ovs_bridge() {
+  local bridge_name="mkeprb-$$"
+
+  echo "probing dynamic OVS bridge ${bridge_name}"
+  if ! create_ovs_bridge "${bridge_name}"; then
+    echo "dynamic OVS bridge probe failed" >&2
+    print_ovs_diagnostics
+    return 1
+  fi
+  sudo ovs-vsctl --if-exists del-br "${bridge_name}"
+  if ip link show "${bridge_name}" >/dev/null 2>&1; then
+    echo "dynamic OVS bridge probe device remains after deletion: ${bridge_name}" >&2
+    print_ovs_diagnostics
+    return 1
+  fi
 }
 
 ensure_ovn_ovs_runtime
+if ! sudo ovs-appctl -t ovs-vswitchd version >/dev/null 2>&1; then
+  echo "ovs-vswitchd is not responding" >&2
+  print_ovs_diagnostics
+  exit 1
+fi
 ensure_ovs_bridge "ovsbr0"
+cleanup_stale_marmot_bridges
+probe_dynamic_ovs_bridge
 
 active_networks="$(virsh net-list --name)"
 

--- a/tools/setup-libvirt-networks.sh
+++ b/tools/setup-libvirt-networks.sh
@@ -110,6 +110,11 @@ cleanup_stale_marmot_bridges() {
 
   while IFS= read -r bridge_name; do
     if [[ "${bridge_name}" =~ ^br-[0-9a-f]{5}$ ]]; then
+      ports="$(sudo ovs-vsctl list-ports "${bridge_name}" 2>/dev/null || true)"
+      if [[ -n "${ports}" ]]; then
+        echo "skipping ${bridge_name} because it still has ports attached: ${ports}"
+        continue
+      fi
       echo "deleting stale Marmot OVS bridge ${bridge_name}"
       sudo ovs-vsctl --if-exists del-br "${bridge_name}"
       deleted=$((deleted + 1))


### PR DESCRIPTION
## 概要

MKE（Marmot Kubernetes Engine）フェーズ7として、KubernetesノードVMのプロビジョニングを実装しました。

あわせて、CIで使用するゲストOS関連のテストデータをUbuntu 24.04へ更新しました。

## 変更内容

- `spec.nodes`に従ってノードVM用Serverリソースを冪等に作成
- 外部ネットワークとクラスタ専用ノード間ネットワークへ接続
- ノード用証明書とkubeconfigを生成
- Ansibleで以下をノードVMへ導入
  - containerd
  - runc
  - kubelet
  - kube-proxy
- systemd unitを配置して各サービスを起動
- Kubernetes APIの`/api/v1/nodes`からNode Readyを確認
- 全ノードがReadyになった時点でKubernetesEngineを`RUNNING`へ遷移
- 再リコンサイル時の重複VM作成と不要なサービス再起動を防止
- 同名Serverが別リソースに使用されている場合の衝突検出を追加
- 実VM系を含む既存テストのゲストOSをUbuntu 22.04から24.04へ更新

## ノードVMの既定値

- OS: Ubuntu 24.04
- CPU: 2
- Memory: 2048MB
- 外部ネットワーク: `default`
- ノード間ネットワーク: `mke-<cluster-name>`

`spec.nodeSpec`が指定されている場合は、そのCPU、メモリ、外部ネットワーク設定を使用します。

## テスト

以下を確認済みです。

- ノードVMのServer spec生成
- 外部・ノード間ネットワークの2 NIC構成
- Ansible playbook生成
- ノード間ネットワーク上のIPアドレス取得
- Kubernetes Node Ready判定
- `PROVISIONING`から`RUNNING`への状態遷移

```bash
go test ./pkg/controller \
  -run 'Test(BuildKubernetesEngineNodeServerSpec|RenderKubernetesEngineNodePlaybook|KubernetesEngineNodesReady|KubernetesEngineNodeInternalIP|ReconcileKubernetesEngineProvisioningTransitionsWhenNodesReady)$'