### PR TITLE
削除できない問題を修正

### DIFF
--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -281,6 +281,7 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.Ku
 	if len(networks) > 0 {
 		// ヘッド/フォロワーを問わず、このクラスタが所有する全てのネットワークエントリに
 		// 削除要求を出し、それら全てが消えるまでクラスタ本体の削除を待つ。
+		deprovisionAttempted := false
 		for _, network := range networks {
 			networkID := api.VirtualNetworkID(network)
 			if network.Status == nil {
@@ -294,8 +295,10 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.Ku
 			// （systemdユニット・etcd・netns・専用IP）が未解体ならここで解体する。
 			// 解体しないとコントロールプレーンIPがIPAM上に残り続け、
 			// CheckIPnetInUse()が常にtrueを返してネットワーク削除が永久にブロックされる。
-			if network.Metadata.Name == kubernetesEngineNetworkName(current) &&
+			if !deprovisionAttempted &&
+				network.Metadata.Name == kubernetesEngineNetworkName(current) &&
 				current.Status != nil && current.Status.ControlPlaneIpAddress != nil {
+				deprovisionAttempted = true
 				if deprovErr := DeprovisionKubernetesEngineControlPlane(c.db, current); deprovErr != nil {
 					slog.Warn("DeprovisionKubernetesEngineControlPlane() failed", "id", id, "err", deprovErr)
 				}

--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -242,7 +242,8 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineRunning(ke api.Kub
 	slog.Debug("KubernetesEngineはRUNNING状態です（ヘルスチェックは未実装）", "id", id, "name", ke.Metadata.Name)
 }
 
-// reconcileKubernetesEngineDeleting は猶予期間経過後に呼び出され、専用ネットワークの削除要求を行い、
+// reconcileKubernetesEngineDeleting は猶予期間経過後に呼び出され、コントロールプレーンの解体
+// （systemdユニット・etcd・netns・専用IPの解放）と専用ネットワークの削除要求を行い、
 // ネットワークの削除完了を確認してからetcdから実削除する。
 // TODO: 次フェーズでノード(Server)等の関連リソース削除を先行させる。
 func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.KubernetesEngine) {
@@ -287,6 +288,17 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineDeleting(ke api.Ku
 				// nilのままSetDeleteTimestampVirtualNetwork()を呼ぶとDB層でパニックするため回避する。
 				slog.Warn("network status is nil, skip delete timestamp update", "id", id, "networkId", networkID)
 				continue
+			}
+			// このクラスタ自身のノード間通信ネットワークについては、削除要求のタイムスタンプが
+			// 既に設定済み（=以前のreconcileで削除待ちに入った後）でも、コントロールプレーン
+			// （systemdユニット・etcd・netns・専用IP）が未解体ならここで解体する。
+			// 解体しないとコントロールプレーンIPがIPAM上に残り続け、
+			// CheckIPnetInUse()が常にtrueを返してネットワーク削除が永久にブロックされる。
+			if network.Metadata.Name == kubernetesEngineNetworkName(current) &&
+				current.Status != nil && current.Status.ControlPlaneIpAddress != nil {
+				if deprovErr := DeprovisionKubernetesEngineControlPlane(c.db, current); deprovErr != nil {
+					slog.Warn("DeprovisionKubernetesEngineControlPlane() failed", "id", id, "err", deprovErr)
+				}
 			}
 			if network.Status.DeletionTimeStamp == nil {
 				if delErr := c.db.SetDeleteTimestampVirtualNetwork(networkID); delErr != nil {


### PR DESCRIPTION
## 概要

MKE（marmot Kubernetes Engine）クラスタの削除が、ノードServerを手動削除した後も永久に完了せず、専用ネットワークが `IP network still in use` で削除できないまま残り続ける不具合を修正します。

## 原因

コントロールプレーンには、Server削除時のIPAM解放処理（`Metadata.Name`ベースのマッチング）では検出できない専用IP（`mke-control-plane-<id>`のhostIdで確保）が割り当てられています。このIPを解放する `DeprovisionKubernetesEngineControlPlane()`（systemdユニット・etcd・netns・専用IPの解体を行う関数）自体は実装・テスト済みでしたが、実際の削除reconcileループ（`reconcileKubernetesEngineDeleting`）からは一度も呼び出されておらず、コントロールプレーンIPがIPAM上に残り続けていました。

この残留IPにより `CheckIPnetInUse()` が常に `true` を返し、専用ネットワークの削除が永久にブロックされていました。

## 変更内容

- `reconcileKubernetesEngineDeleting()` に `DeprovisionKubernetesEngineControlPlane()` の呼び出しを追加
  - このクラスタ自身のノード間通信ネットワークについては、削除要求タイムスタンプの有無に関わらず、`current.Status.ControlPlaneIpAddress != nil`（＝コントロールプレーンが未解体）を条件に解体を実行するようガードを設定
  - タイムスタンプ済み（＝既に削除待ちに入っている、修正前からスタックしていたクラスタ）にも解体処理が及ぶよう、既存の`network.Status.DeletionTimeStamp == nil` の判定とは独立させています
  - 解体失敗時は処理をブロックせず `slog.Warn` でログ出力のみ行い、次回reconcileで再試行される形にしています

## 動作確認

- `go build ubuntu.` : 成功
- `go test ./pkg/controller/... -run 'KubernetesEngine' -v` : 本修正に関連するテストはPASS
  - `TestReconcileKubernetesEngineDeletingWaitsForNetworkRemoval` / `...WaitsForFollowerNetworkRemoval` の2件は、テスト自体が `SetDeleteTimestampKubernetesEngine` を呼ばずに `PROVISIONING` 状態のまま `reconcileKubernetesEngineDeleting` を直接呼び出しており、既存の状態ガード（`StatusCode != DELETING` で早期return）により本修正とは無関係にFAILする既存の不具合です（本PRでは対象外・別issueとして報告予定）
- 実機（hv1）にて、スタック中のクラスタ（`mke1`, `test-cluster-1`）が本修正の適用後に `DELETING` から正常に削除完了することを確認予定

## 影響範囲

- kubernetes-engine-controller.go のみ
- ノード（Server）関連のリソース削除ロジックへの変更なし
