### PR TITLE
MKE実装:フェーズ8: CNI有効化

### DIFF
--- a/docs/MEMO-marmot-kubernetes-engine.md
+++ b/docs/MEMO-marmot-kubernetes-engine.md
@@ -138,6 +138,7 @@ spec:
 - ここで初めて `kubectl get nodes` が通る状態になる
 
 ## フェーズ8: CNI有効化
+- Bridge選択時は、設定とルーティング設定追加
 - Cilium選択時のインストール・設定
 
 ## フェーズ9: CSI（Ceph）連携

--- a/pkg/controller/kubernetes-engine-cni-cilium.go
+++ b/pkg/controller/kubernetes-engine-cni-cilium.go
@@ -199,6 +199,12 @@ func applyKubernetesEngineManifestObject(namespace, caPath, certPath, keyPath, a
 func kubernetesEngineAPIResourceExists(namespace, caPath, certPath, keyPath, url string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+	output, err := exec.CommandContext(ctx, "ip", "netns", "exec", namespace, "curl",
+		"--silent", "--show-error", "--output", "/dev/null", "--write-out", "%{http_code}",
+		"--cacert", caPath, "--cert", certPath, "--key", keyPath, url).CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("failed to check existing resource at %s: %w (output=%s)", url, err, strings.TrimSpace(string(output)))
+	}
 	code := strings.TrimSpace(string(output))
 	switch code {
 	case "200":

--- a/pkg/controller/kubernetes-engine-cni-cilium.go
+++ b/pkg/controller/kubernetes-engine-cni-cilium.go
@@ -1,0 +1,209 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/marmotd"
+	"gopkg.in/yaml.v3"
+)
+
+// kubernetesEngineManifestResourceMeta は、Kindごとにkube-apiserverのREST APIパスを
+// 組み立てるための情報を保持する。
+type kubernetesEngineManifestResourceMeta struct {
+	group      string // 空文字はcore(v1) APIグループ
+	version    string
+	resource   string // 複数形のリソース名
+	namespaced bool
+}
+
+// kubernetesEngineManifestResources は、Ciliumのインストールマニフェストに含まれ得る
+// リソース種別のうち、対応済みのものの一覧。ここに無いKindのマニフェストが渡された
+// 場合は、サイレントに無視せずエラーとする。
+var kubernetesEngineManifestResources = map[string]kubernetesEngineManifestResourceMeta{
+	"v1/Namespace":       {version: "v1", resource: "namespaces", namespaced: false},
+	"v1/ServiceAccount":  {version: "v1", resource: "serviceaccounts", namespaced: true},
+	"v1/ConfigMap":       {version: "v1", resource: "configmaps", namespaced: true},
+	"v1/Secret":          {version: "v1", resource: "secrets", namespaced: true},
+	"v1/Service":         {version: "v1", resource: "services", namespaced: true},
+	"apps/v1/DaemonSet":  {group: "apps", version: "v1", resource: "daemonsets", namespaced: true},
+	"apps/v1/Deployment": {group: "apps", version: "v1", resource: "deployments", namespaced: true},
+	"rbac.authorization.k8s.io/v1/ClusterRole":        {group: "rbac.authorization.k8s.io", version: "v1", resource: "clusterroles", namespaced: false},
+	"rbac.authorization.k8s.io/v1/ClusterRoleBinding": {group: "rbac.authorization.k8s.io", version: "v1", resource: "clusterrolebindings", namespaced: false},
+	"rbac.authorization.k8s.io/v1/Role":               {group: "rbac.authorization.k8s.io", version: "v1", resource: "roles", namespaced: true},
+	"rbac.authorization.k8s.io/v1/RoleBinding":        {group: "rbac.authorization.k8s.io", version: "v1", resource: "rolebindings", namespaced: true},
+	"apiextensions.k8s.io/v1/CustomResourceDefinition": {group: "apiextensions.k8s.io", version: "v1", resource: "customresourcedefinitions", namespaced: false},
+	"policy/v1/PodDisruptionBudget":                     {group: "policy", version: "v1", resource: "poddisruptionbudgets", namespaced: true},
+}
+
+// kubernetesEngineManifestObject は、マニフェスト中の1ドキュメントからkind/name/namespaceを
+// 読み取るための最小限の構造体。
+type kubernetesEngineManifestObject struct {
+	ApiVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name      string `yaml:"name"`
+		Namespace string `yaml:"namespace"`
+	} `yaml:"metadata"`
+}
+
+const kubernetesEngineCiliumNamespace = "kube-system"
+
+// kubernetesEngineCiliumProbeURLPath は、Ciliumが既にインストール済みかどうかの判定に使う
+// DaemonSetのURLパス。
+const kubernetesEngineCiliumProbeURLPath = "/apis/apps/v1/namespaces/kube-system/daemonsets/cilium"
+
+// EnsureKubernetesEngineCiliumCNI は spec.nodeSpec.network.kind=cilium のクラスタに対して、
+// mkeConf.CiliumManifestURL で指定されたKubernetesインストールマニフェストを
+// コントロールプレーンのAPIサーバーへ適用する。既にCiliumのDaemonSetが存在する場合は
+// 何もしない（冪等）。
+//
+// 制約: マニフェストの適用は「存在しなければ作成する」のみを行い、既存リソースの
+// 更新（kubectl applyのようなdiffベースの更新）は行わない。バージョンアップ等で
+// マニフェストの内容を更新したい場合は、既存リソースを削除してから再実行すること。
+func EnsureKubernetesEngineCiliumCNI(mkeConf *marmotd.MKEConfig, ke api.KubernetesEngine) error {
+	manifestURL := strings.TrimSpace(mkeConf.CiliumManifestURL)
+	if manifestURL == "" {
+		return fmt.Errorf("nodeSpec.network.kind=cilium requires cilium_manifest_url to be configured in %s", marmotd.DefaultMKEConfigPath)
+	}
+	if ke.Status == nil || ke.Status.ControlPlaneIpAddress == nil || ke.Status.ApiServerPort == nil {
+		return fmt.Errorf("KubernetesEngine control plane status is incomplete")
+	}
+	clusterName := strings.TrimSpace(ke.Metadata.Name)
+	namespace, _, _, err := KubernetesEngineControlPlaneNetworkNames(clusterName)
+	if err != nil {
+		return err
+	}
+	caPath, _ := KubernetesEngineCAPaths(DefaultKubernetesEnginePkiDir, clusterName)
+	adminCertPath, adminKeyPath, err := IssueKubernetesEngineCertificate(DefaultKubernetesEnginePkiDir, clusterName, KubernetesEngineCertRequest{
+		Name:          "controller-admin",
+		CommonName:    "mke-controller-admin",
+		Organizations: []string{"system:masters"},
+		Usage:         KubernetesEngineCertUsageClient,
+	})
+	if err != nil {
+		return err
+	}
+	apiEndpointBase := fmt.Sprintf("https://%s:%d", *ke.Status.ControlPlaneIpAddress, *ke.Status.ApiServerPort)
+
+	installed, err := kubernetesEngineAPIResourceExists(namespace, caPath, adminCertPath, adminKeyPath,
+		apiEndpointBase+kubernetesEngineCiliumProbeURLPath)
+	if err != nil {
+		return err
+	}
+	if installed {
+		return nil
+	}
+
+	manifest, err := kubernetesDownload(manifestURL)
+	if err != nil {
+		return fmt.Errorf("failed to download Cilium manifest from %s: %w", manifestURL, err)
+	}
+	for _, doc := range splitKubernetesEngineYAMLDocuments(manifest) {
+		if err := applyKubernetesEngineManifestObject(namespace, caPath, adminCertPath, adminKeyPath, apiEndpointBase, doc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// splitKubernetesEngineYAMLDocuments は、"---"区切りのマニフェストを個々のYAMLドキュメントへ
+// 分割する。各ドキュメントはkube-apiserverへそのまま送信するため、元のテキストを維持する。
+func splitKubernetesEngineYAMLDocuments(data []byte) [][]byte {
+	lines := strings.Split(string(data), "\n")
+	var docs [][]byte
+	var current []string
+	flush := func() {
+		joined := strings.TrimSpace(strings.Join(current, "\n"))
+		if joined != "" {
+			docs = append(docs, []byte(joined))
+		}
+		current = nil
+	}
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "---" {
+			flush()
+			continue
+		}
+		current = append(current, line)
+	}
+	flush()
+	return docs
+}
+
+// applyKubernetesEngineManifestObject は、1つのYAMLドキュメントが表すリソースが
+// 存在しなければkube-apiserverへ作成する（既に存在する場合は何もしない）。
+func applyKubernetesEngineManifestObject(namespace, caPath, certPath, keyPath, apiEndpointBase string, doc []byte) error {
+	var obj kubernetesEngineManifestObject
+	if err := yaml.Unmarshal(doc, &obj); err != nil {
+		return fmt.Errorf("failed to parse manifest document: %w", err)
+	}
+	if strings.TrimSpace(obj.Kind) == "" {
+		// 空ドキュメントやコメントのみのドキュメントはスキップ
+		return nil
+	}
+	key := strings.TrimSpace(obj.ApiVersion) + "/" + strings.TrimSpace(obj.Kind)
+	meta, ok := kubernetesEngineManifestResources[key]
+	if !ok {
+		return fmt.Errorf("unsupported manifest resource %q; add it to kubernetesEngineManifestResources to support installing it", key)
+	}
+	if strings.TrimSpace(obj.Metadata.Name) == "" {
+		return fmt.Errorf("manifest resource %s is missing metadata.name", key)
+	}
+
+	urlPath := "/api/" + meta.version
+	if meta.group != "" {
+		urlPath = "/apis/" + meta.group + "/" + meta.version
+	}
+	if meta.namespaced {
+		ns := strings.TrimSpace(obj.Metadata.Namespace)
+		if ns == "" {
+			ns = kubernetesEngineCiliumNamespace
+		}
+		urlPath += "/namespaces/" + ns
+	}
+	urlPath += "/" + meta.resource
+
+	exists, err := kubernetesEngineAPIResourceExists(namespace, caPath, certPath, keyPath,
+		apiEndpointBase+urlPath+"/"+obj.Metadata.Name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ip", "netns", "exec", namespace, "curl",
+		"--fail", "--silent", "--show-error",
+		"--cacert", caPath, "--cert", certPath, "--key", keyPath,
+		"-H", "Content-Type: application/yaml",
+		"-X", "POST", "--data-binary", "@-",
+		apiEndpointBase+urlPath)
+	cmd.Stdin = bytes.NewReader(doc)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create %s %q: %w (output=%s)", key, obj.Metadata.Name, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// kubernetesEngineAPIResourceExists は、コントロールプレーンのAPIサーバー上に
+// 指定URLのリソースが既に存在するかどうかをGETのHTTPステータスコードで判定する。
+func kubernetesEngineAPIResourceExists(namespace, caPath, certPath, keyPath, url string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, "ip", "netns", "exec", namespace, "curl",
+		"--silent", "--show-error", "--output", "/dev/null", "--write-out", "%{http_code}",
+		"--cacert", caPath, "--cert", certPath, "--key", keyPath, url).CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("failed to check existing resource at %s: %w (output=%s)", url, err, strings.TrimSpace(string(output)))
+	}
+	return strings.TrimSpace(string(output)) == "200", nil
+}

--- a/pkg/controller/kubernetes-engine-cni-cilium.go
+++ b/pkg/controller/kubernetes-engine-cni-cilium.go
@@ -71,6 +71,9 @@ func EnsureKubernetesEngineCiliumCNI(mkeConf *marmotd.MKEConfig, ke api.Kubernet
 	if manifestURL == "" {
 		return fmt.Errorf("nodeSpec.network.kind=cilium requires cilium_manifest_url to be configured in %s", marmotd.DefaultMKEConfigPath)
 	}
+	if !strings.HasPrefix(manifestURL, "https://") {
+		return fmt.Errorf("cilium_manifest_url must use https:// (got %q)", manifestURL)
+	}
 	if ke.Status == nil || ke.Status.ControlPlaneIpAddress == nil || ke.Status.ApiServerPort == nil {
 		return fmt.Errorf("KubernetesEngine control plane status is incomplete")
 	}

--- a/pkg/controller/kubernetes-engine-cni-cilium.go
+++ b/pkg/controller/kubernetes-engine-cni-cilium.go
@@ -199,11 +199,13 @@ func applyKubernetesEngineManifestObject(namespace, caPath, certPath, keyPath, a
 func kubernetesEngineAPIResourceExists(namespace, caPath, certPath, keyPath, url string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	output, err := exec.CommandContext(ctx, "ip", "netns", "exec", namespace, "curl",
-		"--silent", "--show-error", "--output", "/dev/null", "--write-out", "%{http_code}",
-		"--cacert", caPath, "--cert", certPath, "--key", keyPath, url).CombinedOutput()
-	if err != nil {
-		return false, fmt.Errorf("failed to check existing resource at %s: %w (output=%s)", url, err, strings.TrimSpace(string(output)))
+	code := strings.TrimSpace(string(output))
+	switch code {
+	case "200":
+		return true, nil
+	case "404":
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status %s when checking existing resource at %s", code, url)
 	}
-	return strings.TrimSpace(string(output)) == "200", nil
 }

--- a/pkg/controller/kubernetes-engine-cni-cilium_test.go
+++ b/pkg/controller/kubernetes-engine-cni-cilium_test.go
@@ -1,0 +1,57 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("splitKubernetesEngineYAMLDocuments", func() {
+	It("splits documents separated by ---", func() {
+		input := []byte("apiVersion: v1\nkind: Namespace\n---\napiVersion: v1\nkind: ServiceAccount\n")
+		docs := splitKubernetesEngineYAMLDocuments(input)
+		Expect(docs).To(HaveLen(2))
+		Expect(string(docs[0])).To(ContainSubstring("Namespace"))
+		Expect(string(docs[1])).To(ContainSubstring("ServiceAccount"))
+	})
+
+	It("returns a single document when there is no --- separator", func() {
+		input := []byte("apiVersion: v1\nkind: ConfigMap\n")
+		docs := splitKubernetesEngineYAMLDocuments(input)
+		Expect(docs).To(HaveLen(1))
+		Expect(string(docs[0])).To(ContainSubstring("ConfigMap"))
+	})
+
+	It("skips empty documents", func() {
+		input := []byte("---\napiVersion: v1\nkind: Secret\n---\n---\n")
+		docs := splitKubernetesEngineYAMLDocuments(input)
+		Expect(docs).To(HaveLen(1))
+		Expect(string(docs[0])).To(ContainSubstring("Secret"))
+	})
+
+	It("returns empty slice for blank input", func() {
+		docs := splitKubernetesEngineYAMLDocuments([]byte(""))
+		Expect(docs).To(BeEmpty())
+	})
+})
+
+var _ = Describe("applyKubernetesEngineManifestObject", func() {
+	It("returns error for unsupported resource kind", func() {
+		doc := []byte("apiVersion: v1\nkind: Pod\nmetadata:\n  name: test\n")
+		err := applyKubernetesEngineManifestObject("ns", "/ca", "/cert", "/key", "https://127.0.0.1:6443", doc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unsupported manifest resource"))
+	})
+
+	It("returns nil for a blank/comment-only document", func() {
+		doc := []byte("# comment only\n")
+		err := applyKubernetesEngineManifestObject("ns", "/ca", "/cert", "/key", "https://127.0.0.1:6443", doc)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns error for a resource missing metadata.name", func() {
+		doc := []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: \"\"\n")
+		err := applyKubernetesEngineManifestObject("ns", "/ca", "/cert", "/key", "https://127.0.0.1:6443", doc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("missing metadata.name"))
+	})
+})

--- a/pkg/controller/kubernetes-engine-node-ssh.go
+++ b/pkg/controller/kubernetes-engine-node-ssh.go
@@ -228,7 +228,7 @@ func installKubernetesEngineBridgeCNI(runner kubernetesEngineNodeCommandRunner, 
 		data.CNIPluginsVersion, arch, data.CNIPluginsVersion)
 	if err := runner.step("install CNI plugins", func() error {
 		return runner.run(fmt.Sprintf("mkdir -p /opt/cni/bin && "+
-			"test -e /opt/cni/bin/bridge || (curl -fsSL %s | tar -xz -C /opt/cni/bin)",
+			"test -e /opt/cni/bin/bridge || (url=%[1]s; fn=$(basename $url); curl -fsSL $url -o /tmp/$fn && curl -fsSL $url.sha256 -o /tmp/$fn.sha256 && (cd /tmp && sha256sum -c $fn.sha256) && tar -xz -C /opt/cni/bin -f /tmp/$fn && rm -f /tmp/$fn /tmp/$fn.sha256)",
 			shellQuote(cniURL)), nil)
 	}); err != nil {
 		return err

--- a/pkg/controller/kubernetes-engine-node-ssh.go
+++ b/pkg/controller/kubernetes-engine-node-ssh.go
@@ -34,6 +34,25 @@ type kubernetesEngineNodeProvisionData struct {
 	KubeProxyKubeconfig []byte
 	KubeletConfig       []byte
 	KubeProxyConfig     []byte
+
+	// NetworkKind は spec.nodeSpec.network.kind ("none"=bridge または "cilium")。
+	// "cilium" の場合、ノード側でのBridge CNIのインストール・設定は行わない
+	// （Ciliumのインストールマニフェスト側がCNI設定を配置する）。
+	NetworkKind string
+	// PodCIDR は、このノード専用のPod CIDR（例: 10.244.1.0/24）。Bridge CNI選択時のみ使用。
+	PodCIDR string
+	// PodNetworkSupernet は、全ノードのPod CIDRを包含するスーパーネット。
+	// Bridge CNI選択時、この範囲宛の通信はマスカレードせず直接ルーティングする。
+	PodNetworkSupernet string
+	// CNIPluginsVersion は containernetworking/plugins のリリースバージョン。
+	CNIPluginsVersion string
+}
+
+// kubernetesEngineNodeRoute は、Bridge CNI選択時にノードへ追加する、
+// 他ノードのPod CIDR宛の静的経路。
+type kubernetesEngineNodeRoute struct {
+	CIDR string
+	Via  string
 }
 
 // kubernetesEngineNodeCommandRunner executes commands on a KubernetesEngine node,
@@ -120,6 +139,12 @@ func runKubernetesEngineNodeProvisionSteps(runner kubernetesEngineNodeCommandRun
 		}
 	}
 
+	if data.NetworkKind != kubernetesEngineNetworkKindCilium {
+		if err := installKubernetesEngineBridgeCNI(runner, data); err != nil {
+			return err
+		}
+	}
+
 	credentialFiles := []struct {
 		path    string
 		content []byte
@@ -188,6 +213,102 @@ func detectKubernetesEngineNodeArch(runner kubernetesEngineNodeCommandRunner) (s
 		return "amd64", nil
 	}
 	return "arm64", nil
+}
+
+// installKubernetesEngineBridgeCNI は、Bridge CNI（既定のnetwork.kind=none）選択時に、
+// CNIプラグインバイナリの導入、ノード専用Pod CIDRを使ったbridge CNI設定の生成、
+// クラスタ外向け通信のみをマスカレードするiptables設定を行う。
+func installKubernetesEngineBridgeCNI(runner kubernetesEngineNodeCommandRunner, data kubernetesEngineNodeProvisionData) error {
+	arch, err := detectKubernetesEngineNodeArch(runner)
+	if err != nil {
+		return fmt.Errorf("failed to detect node architecture: %w", err)
+	}
+
+	cniURL := fmt.Sprintf("https://github.com/containernetworking/plugins/releases/download/v%s/cni-plugins-linux-%s-v%s.tgz",
+		data.CNIPluginsVersion, arch, data.CNIPluginsVersion)
+	if err := runner.step("install CNI plugins", func() error {
+		return runner.run(fmt.Sprintf("mkdir -p /opt/cni/bin && "+
+			"test -e /opt/cni/bin/bridge || (curl -fsSL %s | tar -xz -C /opt/cni/bin)",
+			shellQuote(cniURL)), nil)
+	}); err != nil {
+		return err
+	}
+
+	if err := runner.step("configure bridge CNI", func() error {
+		return runner.writeFile("/etc/cni/net.d/10-bridge.conflist", "0644",
+			[]byte(renderKubernetesEngineBridgeCNIConf(data.PodCIDR)))
+	}); err != nil {
+		return err
+	}
+
+	return runner.step("configure pod network NAT", func() error {
+		return runner.run(kubernetesEnginePodNetworkNATScript(data.PodNetworkSupernet), nil)
+	})
+}
+
+// renderKubernetesEngineBridgeCNIConf は、ノード専用のPod CIDRをhost-local IPAMで
+// 払い出すbridge CNIのconflistを生成する。ノード間のPod間通信は
+// reconcileKubernetesEngineNodeRoutes が設定する静的経路で疎通させるため、
+// ipMasqはfalseとする（クラスタ外向けの通信は別途iptablesでマスカレードする）。
+func renderKubernetesEngineBridgeCNIConf(podCIDR string) string {
+	return fmt.Sprintf(`{
+  "cniVersion": "1.0.0",
+  "name": "mke-bridge",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "isDefaultGateway": true,
+      "ipMasq": false,
+      "hairpinMode": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [[{ "subnet": "%s" }]],
+        "routes": [{ "dst": "0.0.0.0/0" }]
+      }
+    },
+    { "type": "portmap", "capabilities": { "portMappings": true } }
+  ]
+}
+`, podCIDR)
+}
+
+// kubernetesEnginePodNetworkNATScript は、Podネットワーク（podNetworkSupernet）宛の
+// 通信はマスカレードせず直接ルーティングし、それ以外（クラスタ外）向けの通信のみを
+// マスカレードするiptablesルールを冪等に追加するシェルスクリプトを返す。
+func kubernetesEnginePodNetworkNATScript(podNetworkSupernet string) string {
+	exempt := fmt.Sprintf("-s %s -d %s -j RETURN", podNetworkSupernet, podNetworkSupernet)
+	masquerade := fmt.Sprintf("-s %s ! -d %s -j MASQUERADE", podNetworkSupernet, podNetworkSupernet)
+	return fmt.Sprintf(
+		"iptables -t nat -C POSTROUTING %s 2>/dev/null || iptables -t nat -I POSTROUTING %s\n"+
+			"iptables -t nat -C POSTROUTING %s 2>/dev/null || iptables -t nat -A POSTROUTING %s",
+		exempt, exempt, masquerade, masquerade)
+}
+
+// runKubernetesEngineNodeRouting はテストからモック可能にするための注入ポイント。
+var runKubernetesEngineNodeRouting = applyKubernetesEngineNodeRoutes
+
+// applyKubernetesEngineNodeRoutes は、指定ノードへSSH接続し、routesで示された
+// 他ノードのPod CIDR宛の静的経路を(ip route replaceで冪等に)設定する。
+func applyKubernetesEngineNodeRoutes(address, privateKeyPath, namespace, nodeID string, routes []kubernetesEngineNodeRoute) error {
+	if len(routes) == 0 {
+		return nil
+	}
+	client, err := dialKubernetesEngineNodeSSH(address, privateKeyPath, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to connect to node for routing: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	runner := &kubernetesEngineNodeSSHRunner{client: client, resourceID: nodeID}
+	return runner.step("configure pod network routes", func() error {
+		cmds := make([]string, 0, len(routes))
+		for _, route := range routes {
+			cmds = append(cmds, fmt.Sprintf("ip route replace %s via %s", shellQuote(route.CIDR), shellQuote(route.Via)))
+		}
+		return runner.run(strings.Join(cmds, " && "), nil)
+	})
 }
 
 func kubernetesEngineNodeContainerdUnit() string {

--- a/pkg/controller/kubernetes-engine-node-ssh.go
+++ b/pkg/controller/kubernetes-engine-node-ssh.go
@@ -228,7 +228,7 @@ func installKubernetesEngineBridgeCNI(runner kubernetesEngineNodeCommandRunner, 
 		data.CNIPluginsVersion, arch, data.CNIPluginsVersion)
 	if err := runner.step("install CNI plugins", func() error {
 		return runner.run(fmt.Sprintf("mkdir -p /opt/cni/bin && "+
-			"test -e /opt/cni/bin/bridge || (url=%[1]s; fn=$(basename $url); curl -fsSL $url -o /tmp/$fn && curl -fsSL $url.sha256 -o /tmp/$fn.sha256 && (cd /tmp && sha256sum -c $fn.sha256) && tar -xz -C /opt/cni/bin -f /tmp/$fn && rm -f /tmp/$fn /tmp/$fn.sha256)",
+			"(test -e /opt/cni/bin/bridge && test -e /opt/cni/bin/host-local && test -e /opt/cni/bin/loopback && test -e /opt/cni/bin/portmap) || (url=%[1]s; fn=$(basename $url); curl -fsSL $url -o /tmp/$fn && curl -fsSL $url.sha256 -o /tmp/$fn.sha256 && (cd /tmp && sha256sum -c $fn.sha256) && tar -xz -C /opt/cni/bin -f /tmp/$fn && rm -f /tmp/$fn /tmp/$fn.sha256)",
 			shellQuote(cniURL)), nil)
 	}); err != nil {
 		return err

--- a/pkg/controller/kubernetes-engine-node-ssh_test.go
+++ b/pkg/controller/kubernetes-engine-node-ssh_test.go
@@ -127,6 +127,10 @@ func newTestKubernetesEngineNodeProvisionData() kubernetesEngineNodeProvisionDat
 		KubeProxyKubeconfig: []byte("kube-proxy-kubeconfig"),
 		KubeletConfig:       []byte("kubelet-config"),
 		KubeProxyConfig:     []byte("kube-proxy-config"),
+		NetworkKind:         kubernetesEngineNetworkKindBridge,
+		PodCIDR:             "10.244.1.0/24",
+		PodNetworkSupernet:  kubernetesEnginePodNetworkSupernet,
+		CNIPluginsVersion:   "1.4.0",
 	}
 }
 
@@ -196,5 +200,51 @@ var _ = Describe("runKubernetesEngineNodeProvisionSteps", func() {
 		err := runKubernetesEngineNodeProvisionSteps(runner, data)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("install runtime dependencies"))
+	})
+
+	It("installs and configures the bridge CNI when network.kind is not cilium", func() {
+		runner := &fakeKubernetesEngineNodeCommandRunner{outputs: map[string]string{"uname -m": "x86_64"}}
+		data := newTestKubernetesEngineNodeProvisionData()
+
+		Expect(runKubernetesEngineNodeProvisionSteps(runner, data)).To(Succeed())
+
+		joined := strings.Join(runner.commands, "\n")
+		Expect(joined).To(ContainSubstring("cni-plugins-linux-amd64-v1.4.0.tgz"))
+		Expect(joined).To(ContainSubstring("iptables -t nat"))
+		Expect(runner.files).To(HaveKey("/etc/cni/net.d/10-bridge.conflist"))
+		Expect(runner.files["/etc/cni/net.d/10-bridge.conflist"]).To(ContainSubstring(`"subnet": "10.244.1.0/24"`))
+	})
+
+	It("skips the bridge CNI installation when network.kind is cilium", func() {
+		runner := &fakeKubernetesEngineNodeCommandRunner{outputs: map[string]string{"uname -m": "x86_64"}}
+		data := newTestKubernetesEngineNodeProvisionData()
+		data.NetworkKind = kubernetesEngineNetworkKindCilium
+
+		Expect(runKubernetesEngineNodeProvisionSteps(runner, data)).To(Succeed())
+
+		joined := strings.Join(runner.commands, "\n")
+		Expect(joined).NotTo(ContainSubstring("cni-plugins-linux"))
+		Expect(runner.files).NotTo(HaveKey("/etc/cni/net.d/10-bridge.conflist"))
+	})
+})
+
+var _ = Describe("kubernetesEnginePodNetworkNATScript", func() {
+	It("exempts pod-to-pod traffic and masquerades traffic leaving the pod network", func() {
+		script := kubernetesEnginePodNetworkNATScript("10.244.0.0/16")
+		Expect(script).To(ContainSubstring("-s 10.244.0.0/16 -d 10.244.0.0/16 -j RETURN"))
+		Expect(script).To(ContainSubstring("-s 10.244.0.0/16 ! -d 10.244.0.0/16 -j MASQUERADE"))
+		Expect(script).To(ContainSubstring("iptables -t nat -C POSTROUTING"))
+	})
+})
+
+var _ = Describe("applyKubernetesEngineNodeRoutes", func() {
+	It("does nothing when there are no routes to apply", func() {
+		Expect(applyKubernetesEngineNodeRoutes("172.16.1.10", "/nonexistent/key", "", "node-1", nil)).To(Succeed())
+	})
+
+	It("fails to dial when the private key cannot be read", func() {
+		routes := []kubernetesEngineNodeRoute{{CIDR: "10.244.2.0/24", Via: "172.16.1.11"}}
+		err := applyKubernetesEngineNodeRoutes("172.16.1.10", "/nonexistent/key", "", "node-1", routes)
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/controller/kubernetes-engine-node.go
+++ b/pkg/controller/kubernetes-engine-node.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,7 +26,20 @@ const (
 	kubernetesEngineNodeLabelProvisioned = "kubernetesEngineNodeProvisioned"
 	defaultKubernetesEngineNodeCPU       = 2
 	defaultKubernetesEngineNodeMemory    = 2048
+
+	// kubernetesEngineNetworkKindBridge は、ノード間通信用ネットワーク上でシンプルな
+	// bridge CNIを使用するモード（spec.nodeSpec.network.kindの既定値）。
+	kubernetesEngineNetworkKindBridge = "none"
+	// kubernetesEngineNetworkKindCilium は、CiliumをCNIとしてインストールするモード。
+	kubernetesEngineNetworkKindCilium = "cilium"
+
+	// kubernetesEnginePodNetworkSupernet は、全ノードのPod CIDR(10.244.<index+1>.0/24)を
+	// 包含するスーパーネット。Bridge CNI選択時、この範囲宛の通信はマスカレードせず
+	// 直接ルーティングする。
+	kubernetesEnginePodNetworkSupernet = "10.244.0.0/16"
 )
+
+var kubernetesEngineNodeNamePattern = regexp.MustCompile(`-node-(\d+)$`)
 
 var (
 	kubernetesEngineNodePrivateKeyPath  = marmotd.GatewayPrivateKeyPath()
@@ -57,6 +72,11 @@ func ProvisionKubernetesEngineNodes(database *db.Database, mkeConf *marmotd.MKEC
 	}
 	if err := ensureKubernetesEngineNodeSSHAssets(); err != nil {
 		return false, fmt.Errorf("failed to prepare KubernetesEngine node SSH assets: %w", err)
+	}
+	if kubernetesEngineNodeNetworkKind(ke) == kubernetesEngineNetworkKindCilium {
+		if err := EnsureKubernetesEngineCiliumCNI(mkeConf, ke); err != nil {
+			return false, fmt.Errorf("failed to install Cilium CNI: %w", err)
+		}
 	}
 
 	servers, err := findKubernetesEngineNodeServers(database, ke)
@@ -97,8 +117,12 @@ func ProvisionKubernetesEngineNodes(database *db.Database, mkeConf *marmotd.MKEC
 		if server.Metadata.Labels != nil {
 			labels = *server.Metadata.Labels
 		}
+		nodeIndex, err := kubernetesEngineNodeIndex(server.Metadata.Name)
+		if err != nil {
+			return false, err
+		}
 		if labels[kubernetesEngineNodeLabelProvisioned] != "true" {
-			if err := configureKubernetesEngineNode(mkeConf, ke, server.Metadata.Name, nodeIP); err != nil {
+			if err := configureKubernetesEngineNode(mkeConf, ke, server.Metadata.Name, nodeIP, nodeIndex); err != nil {
 				return false, err
 			}
 			labels[kubernetesEngineNodeLabelProvisioned] = "true"
@@ -107,6 +131,12 @@ func ProvisionKubernetesEngineNodes(database *db.Database, mkeConf *marmotd.MKEC
 			}
 		}
 		expectedNames = append(expectedNames, server.Metadata.Name)
+	}
+
+	if kubernetesEngineNodeNetworkKind(ke) != kubernetesEngineNetworkKindCilium {
+		if err := reconcileKubernetesEngineNodeRoutes(ke, servers); err != nil {
+			return false, fmt.Errorf("failed to configure pod network routes: %w", err)
+		}
 	}
 
 	ready, err := queryKubernetesEngineNodes(ke, expectedNames)
@@ -197,6 +227,9 @@ func buildKubernetesEngineNodeServerSpec(ke api.KubernetesEngine, index int, pub
 	if externalNetwork != "default" && externalNetwork != "host-bridge" {
 		return api.Server{}, fmt.Errorf("nodeSpec.network.external must be default or host-bridge")
 	}
+	if _, err := validatedKubernetesEngineNodeNetworkKind(ke); err != nil {
+		return api.Server{}, err
+	}
 	if strings.TrimSpace(publicKey) == "" {
 		return api.Server{}, fmt.Errorf("KubernetesEngine node public key is empty")
 	}
@@ -233,6 +266,107 @@ func kubernetesEngineNodeName(ke api.KubernetesEngine, index int) string {
 	return fmt.Sprintf("mke-%s-node-%d", strings.TrimSpace(ke.Metadata.Name), index+1)
 }
 
+// kubernetesEngineNodeIndex は "mke-<cluster>-node-<n>" 形式のノード名から、
+// buildKubernetesEngineNodeServerSpecが採番した0始まりのインデックス(n-1)を復元する。
+func kubernetesEngineNodeIndex(name string) (int, error) {
+	matches := kubernetesEngineNodeNamePattern.FindStringSubmatch(name)
+	if matches == nil {
+		return 0, fmt.Errorf("cannot determine node index from name %q", name)
+	}
+	n, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("cannot determine node index from name %q: %w", name, err)
+	}
+	return n - 1, nil
+}
+
+// kubernetesEnginePodCIDR は、ノードindexから固定ベース(10.244.0.0/16)配下の
+// 専用Pod CIDRを採番する。例: index=0 -> 10.244.1.0/24
+func kubernetesEnginePodCIDR(index int) string {
+	return fmt.Sprintf("10.244.%d.0/24", index+1)
+}
+
+// validatedKubernetesEngineNodeNetworkKind は spec.nodeSpec.network.kind を検証したうえで返す。
+func validatedKubernetesEngineNodeNetworkKind(ke api.KubernetesEngine) (string, error) {
+	kind := kubernetesEngineNetworkKindBridge
+	if ke.Spec.NodeSpec != nil && ke.Spec.NodeSpec.Network != nil && ke.Spec.NodeSpec.Network.Kind != nil {
+		trimmed := strings.ToLower(strings.TrimSpace(*ke.Spec.NodeSpec.Network.Kind))
+		if trimmed != "" {
+			kind = trimmed
+		}
+	}
+	if kind != kubernetesEngineNetworkKindBridge && kind != kubernetesEngineNetworkKindCilium {
+		return "", fmt.Errorf("nodeSpec.network.kind must be %s or %s", kubernetesEngineNetworkKindBridge, kubernetesEngineNetworkKindCilium)
+	}
+	return kind, nil
+}
+
+// kubernetesEngineNodeNetworkKind は検証済みのnetwork.kindを返す。呼び出し時点では
+// buildKubernetesEngineNodeServerSpec(または本関数自身の検証)を経由済みである前提のため、
+// 不正な値は既定値(bridge)として扱う。
+func kubernetesEngineNodeNetworkKind(ke api.KubernetesEngine) string {
+	kind, err := validatedKubernetesEngineNodeNetworkKind(ke)
+	if err != nil {
+		return kubernetesEngineNetworkKindBridge
+	}
+	return kind
+}
+
+// kubernetesEngineNodePeer は、Bridge CNI選択時にノード間で交換する経路情報。
+type kubernetesEngineNodePeer struct {
+	name       string
+	internalIP string
+	podCIDR    string
+}
+
+// reconcileKubernetesEngineNodeRoutes は、Bridge CNI選択時に稼働中の全ノードへ、
+// 他ノードのPod CIDR宛の静的経路をSSH経由で設定する。ノードの増減があった場合に
+// 備え、対象ノードが2台以上稼働している間は毎回冪等に再設定する。
+func reconcileKubernetesEngineNodeRoutes(ke api.KubernetesEngine, servers []api.Server) error {
+	networkName := kubernetesEngineNetworkName(ke)
+	peers := make([]kubernetesEngineNodePeer, 0, len(servers))
+	for _, server := range servers {
+		if server.Status == nil || server.Status.StatusCode != db.SERVER_RUNNING {
+			continue
+		}
+		internalIP, err := kubernetesEngineNodeInternalIP(server, networkName)
+		if err != nil {
+			continue
+		}
+		index, err := kubernetesEngineNodeIndex(server.Metadata.Name)
+		if err != nil {
+			return err
+		}
+		peers = append(peers, kubernetesEngineNodePeer{
+			name:       server.Metadata.Name,
+			internalIP: internalIP,
+			podCIDR:    kubernetesEnginePodCIDR(index),
+		})
+	}
+	if len(peers) < 2 {
+		return nil
+	}
+	clusterName := strings.TrimSpace(ke.Metadata.Name)
+	namespace, _, _, err := KubernetesEngineControlPlaneNetworkNames(clusterName)
+	if err != nil {
+		return err
+	}
+	for _, target := range peers {
+		routes := make([]kubernetesEngineNodeRoute, 0, len(peers)-1)
+		for _, peer := range peers {
+			if peer.name == target.name {
+				continue
+			}
+			routes = append(routes, kubernetesEngineNodeRoute{CIDR: peer.podCIDR, Via: peer.internalIP})
+		}
+		nodeID := fmt.Sprintf("%s-%s-routes", api.KubernetesEngineID(ke), target.name)
+		if err := runKubernetesEngineNodeRouting(target.internalIP, kubernetesEngineNodePrivateKeyPath, namespace, nodeID, routes); err != nil {
+			return fmt.Errorf("node %s: %w", target.name, err)
+		}
+	}
+	return nil
+}
+
 func kubernetesEngineNodeInternalIP(server api.Server, networkName string) (string, error) {
 	if server.Spec.NetworkInterface == nil {
 		return "", fmt.Errorf("node %s has no network interfaces", server.Metadata.Name)
@@ -245,7 +379,7 @@ func kubernetesEngineNodeInternalIP(server api.Server, networkName string) (stri
 	return "", fmt.Errorf("node %s has no address on network %s", server.Metadata.Name, networkName)
 }
 
-func configureKubernetesEngineNode(mkeConf *marmotd.MKEConfig, ke api.KubernetesEngine, nodeName, nodeIP string) error {
+func configureKubernetesEngineNode(mkeConf *marmotd.MKEConfig, ke api.KubernetesEngine, nodeName, nodeIP string, nodeIndex int) error {
 	clusterName := strings.TrimSpace(ke.Metadata.Name)
 	caPath, _ := KubernetesEngineCAPaths(DefaultKubernetesEnginePkiDir, clusterName)
 	kubeletCertPath, kubeletKeyPath, err := IssueKubernetesEngineCertificate(DefaultKubernetesEnginePkiDir, clusterName, KubernetesEngineCertRequest{
@@ -290,6 +424,10 @@ func configureKubernetesEngineNode(mkeConf *marmotd.MKEConfig, ke api.Kubernetes
 		KubeProxyKubeconfig: []byte(renderKubernetesEngineNodeKubeconfig(endpoint, "system:kube-proxy", "/etc/kubernetes/pki/kube-proxy.crt", "/etc/kubernetes/pki/kube-proxy.key")),
 		KubeletConfig:       []byte(renderKubernetesEngineKubeletConfig()),
 		KubeProxyConfig:     []byte(renderKubernetesEngineKubeProxyConfig()),
+		NetworkKind:         kubernetesEngineNodeNetworkKind(ke),
+		PodCIDR:             kubernetesEnginePodCIDR(nodeIndex),
+		PodNetworkSupernet:  kubernetesEnginePodNetworkSupernet,
+		CNIPluginsVersion:   strings.TrimPrefix(strings.TrimSpace(mkeConf.CNIPluginsVersion), "v"),
 	}
 	nodeID := fmt.Sprintf("%s-%s", api.KubernetesEngineID(ke), nodeName)
 	// ノードのIPは「ノード間通信用ネットワーク」上のアドレスであり、ホストのroot netnsからは

--- a/pkg/controller/kubernetes-engine-node.go
+++ b/pkg/controller/kubernetes-engine-node.go
@@ -70,10 +70,14 @@ func ProvisionKubernetesEngineNodes(database *db.Database, mkeConf *marmotd.MKEC
 	if ke.Status == nil || ke.Status.ControlPlaneIpAddress == nil || ke.Status.ApiServerPort == nil || ke.Status.ResolvedKubernetesVersion == nil {
 		return false, fmt.Errorf("KubernetesEngine control plane status is incomplete")
 	}
+	networkKind, err := validatedKubernetesEngineNodeNetworkKind(ke)
+	if err != nil {
+		return false, err
+	}
 	if err := ensureKubernetesEngineNodeSSHAssets(); err != nil {
 		return false, fmt.Errorf("failed to prepare KubernetesEngine node SSH assets: %w", err)
 	}
-	if kubernetesEngineNodeNetworkKind(ke) == kubernetesEngineNetworkKindCilium {
+	if networkKind == kubernetesEngineNetworkKindCilium {
 		if err := EnsureKubernetesEngineCiliumCNI(mkeConf, ke); err != nil {
 			return false, fmt.Errorf("failed to install Cilium CNI: %w", err)
 		}
@@ -133,7 +137,7 @@ func ProvisionKubernetesEngineNodes(database *db.Database, mkeConf *marmotd.MKEC
 		expectedNames = append(expectedNames, server.Metadata.Name)
 	}
 
-	if kubernetesEngineNodeNetworkKind(ke) != kubernetesEngineNetworkKindCilium {
+	if networkKind != kubernetesEngineNetworkKindCilium {
 		if err := reconcileKubernetesEngineNodeRoutes(ke, servers); err != nil {
 			return false, fmt.Errorf("failed to configure pod network routes: %w", err)
 		}
@@ -276,6 +280,9 @@ func kubernetesEngineNodeIndex(name string) (int, error) {
 	n, err := strconv.Atoi(matches[1])
 	if err != nil {
 		return 0, fmt.Errorf("cannot determine node index from name %q: %w", name, err)
+	}
+	if n < 1 {
+		return 0, fmt.Errorf("cannot determine node index from name %q: node number must be >= 1", name)
 	}
 	return n - 1, nil
 }

--- a/pkg/controller/kubernetes-engine-node.go
+++ b/pkg/controller/kubernetes-engine-node.go
@@ -331,7 +331,7 @@ func reconcileKubernetesEngineNodeRoutes(ke api.KubernetesEngine, servers []api.
 		}
 		internalIP, err := kubernetesEngineNodeInternalIP(server, networkName)
 		if err != nil {
-			continue
+			return fmt.Errorf("failed to determine internal IP for node %s: %w", server.Metadata.Name, err)
 		}
 		index, err := kubernetesEngineNodeIndex(server.Metadata.Name)
 		if err != nil {

--- a/pkg/controller/kubernetes-engine-node_test.go
+++ b/pkg/controller/kubernetes-engine-node_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"github.com/takara9/marmot/api"
+	"github.com/takara9/marmot/pkg/db"
 	"github.com/takara9/marmot/pkg/util"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -70,4 +71,97 @@ var _ = Describe("KubernetesEngineNode", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(address).To(Equal("172.16.1.10"))
 	})
+
+	It("rejects an unsupported nodeSpec.network.kind", func() {
+		kind := "flannel"
+		ke := api.KubernetesEngine{
+			Metadata: api.Metadata{Name: "demo"},
+			Spec: api.KubernetesEngineSpec{
+				Nodes:    1,
+				NodeSpec: &api.KubernetesEngineNodeSpec{Network: &api.KubernetesEngineNodeNetwork{Kind: &kind}},
+			},
+		}
+		_, err := buildKubernetesEngineNodeServerSpec(ke, 0, "ssh-rsa AAAA")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("nodeSpec.network.kind"))
+	})
+
+	It("defaults nodeSpec.network.kind to bridge (none) when unset", func() {
+		ke := api.KubernetesEngine{Metadata: api.Metadata{Name: "demo"}}
+		Expect(kubernetesEngineNodeNetworkKind(ke)).To(Equal(kubernetesEngineNetworkKindBridge))
+	})
+
+	It("recognizes cilium as a valid nodeSpec.network.kind", func() {
+		kind := "Cilium"
+		ke := api.KubernetesEngine{
+			Metadata: api.Metadata{Name: "demo"},
+			Spec: api.KubernetesEngineSpec{
+				NodeSpec: &api.KubernetesEngineNodeSpec{Network: &api.KubernetesEngineNodeNetwork{Kind: &kind}},
+			},
+		}
+		Expect(kubernetesEngineNodeNetworkKind(ke)).To(Equal(kubernetesEngineNetworkKindCilium))
+	})
+
+	It("derives the pod CIDR from the node index", func() {
+		Expect(kubernetesEnginePodCIDR(0)).To(Equal("10.244.1.0/24"))
+		Expect(kubernetesEnginePodCIDR(4)).To(Equal("10.244.5.0/24"))
+	})
+
+	It("derives the node index from its name", func() {
+		index, err := kubernetesEngineNodeIndex("mke-demo-node-3")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(index).To(Equal(2))
+
+		_, err = kubernetesEngineNodeIndex("not-a-node-name")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("reconciles cross-node pod routes for every running node when bridge CNI is used", func() {
+		origRouting := runKubernetesEngineNodeRouting
+		DeferCleanup(func() { runKubernetesEngineNodeRouting = origRouting })
+
+		type call struct {
+			address string
+			nodeID  string
+			routes  []kubernetesEngineNodeRoute
+		}
+		var calls []call
+		runKubernetesEngineNodeRouting = func(address, privateKeyPath, namespace, nodeID string, routes []kubernetesEngineNodeRoute) error {
+			calls = append(calls, call{address: address, nodeID: nodeID, routes: routes})
+			return nil
+		}
+
+		ke := api.KubernetesEngine{Metadata: api.Metadata{Name: "demo"}}
+		api.SetKubernetesEngineID(&ke, "ke123")
+		servers := []api.Server{
+			{
+				Metadata: api.Metadata{Name: "mke-demo-node-1"},
+				Spec: api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{
+					{Networkname: "mke-demo", Address: util.StringPtr("172.16.1.10")},
+				}},
+				Status: &api.Status{StatusCode: db.SERVER_RUNNING},
+			},
+			{
+				Metadata: api.Metadata{Name: "mke-demo-node-2"},
+				Spec: api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{
+					{Networkname: "mke-demo", Address: util.StringPtr("172.16.1.11")},
+				}},
+				Status: &api.Status{StatusCode: db.SERVER_RUNNING},
+			},
+			{
+				Metadata: api.Metadata{Name: "mke-demo-node-3"},
+				Spec: api.ServerSpec{NetworkInterface: &[]api.NetworkInterface{
+					{Networkname: "mke-demo", Address: util.StringPtr("172.16.1.12")},
+				}},
+				Status: &api.Status{StatusCode: db.SERVER_PENDING},
+			},
+		}
+
+		Expect(reconcileKubernetesEngineNodeRoutes(ke, servers)).To(Succeed())
+		Expect(calls).To(HaveLen(2))
+		for _, c := range calls {
+			Expect(c.routes).To(HaveLen(1))
+		}
+	})
 })
+

--- a/pkg/marmotd/mke-config.go
+++ b/pkg/marmotd/mke-config.go
@@ -32,6 +32,14 @@ type MKEConfig struct {
 	// 例: "bridge"
 	DefaultCNIType string `json:"default_cni_type"`
 
+	// containernetworking/plugins のリリースバージョン（Bridge CNI選択時にダウンロードする）
+	// 例: "1.4.0"
+	CNIPluginsVersion string `json:"cni_plugins_version"`
+
+	// spec.nodeSpec.network.kind=cilium 選択時に適用するインストールマニフェストのURL。
+	// 未設定の場合、Ciliumを選択したクラスタの構成はエラーになる。
+	CiliumManifestURL string `json:"cilium_manifest_url"`
+
 	// runc のバージョン
 	// 例: "1.4.0"
 	RuncVersion string `json:"runc_version"`
@@ -46,6 +54,7 @@ func defaultMKEConfig() *MKEConfig {
 		EtcdVersion:       "3.6.8",
 		CNIVersion:        "0.4.0",
 		DefaultCNIType:    "bridge",
+		CNIPluginsVersion: "1.4.0",
 		RuncVersion:       "1.4.0",
 	}
 }


### PR DESCRIPTION
## 概要

MKE (Marmot Kubernetes Engine) のフェーズ8「CNI有効化」を実装。`spec.nodeSpec.network.kind` の設定に応じて、Bridge（既定値 `none`）選択時はCNIプラグイン導入・Pod間ルーティング設定を、Cilium選択時は公式マニフェストによるインストールを行う。

参照: MEMO-marmot-kubernetes-engine.md フェーズ8

## 変更内容

### Bridge CNI（`network.kind` 未指定 または `none`）
- `containernetworking/plugins` の公式リリースからCNIプラグインバイナリを導入
- ノードごとに専用Pod CIDR（`10.244.<index+1>.0/24`）を自動採番し、`/etc/cni/net.d/10-bridge.conflist` を生成（host-local IPAM、`ipMasq: false`）
- クラスタ外向け通信のみをMASQUERADEし、Pod間通信はそのままルーティングするiptablesルールを冪等に追加
- 稼働中の全ノードに対して、他ノードのPod CIDR宛の静的経路をSSH経由で `ip route replace` により設定（ノード増減のたびに全ノード分を再構成）

### Cilium CNI（`network.kind: cilium`）
- `mke.json` の新設定 `cilium_manifest_url` で指定した公式Kubernetesインストールマニフェスト（YAML）を、既存のダウンロード機構経由で取得
- マニフェストを `---` 区切りで分割し、各リソースが未存在の場合のみkube-apiserverへ直接POSTして適用（`kubectl apply` 相当、diffベースの更新は行わない）
- 既にCiliumのDaemonSetが存在する場合は何もしない（冪等）
- kube-proxyとの共存モードを前提とし、kube-proxy自体の変更は行わない

### 設定追加（mke-config.go）
- `cni_plugins_version`（既定 `1.4.0`）
- `cilium_manifest_url`（既定は空。`network.kind: cilium` を使う場合は運用者が設定必須。未設定時はエラー）

## 変更ファイル
- kubernetes-engine-node.go: `network.kind` 検証、Pod CIDR採番、ノード間経路の冪等再構成
- kubernetes-engine-node-ssh.go: Bridge CNI導入・NAT設定・経路適用のSSHプロビジョニング処理
- kubernetes-engine-cni-cilium.go（新規）: Ciliumマニフェスト適用ロジック
- mke-config.go: 新規設定フィールド追加
- テスト: kubernetes-engine-node_test.go, kubernetes-engine-node-ssh_test.go
- MEMO-marmot-kubernetes-engine.md: フェーズ8の説明を追記

## 既知の制限
- クラスタが `RUNNING` 状態に遷移した後のノード増減では、経路再設定・Ciliumインストール確認が再実行されない（`ProvisionKubernetesEngineNodes` がRUNNING後は呼ばれないため）。フェーズ12のスケール対応で解消予定。

## 検証
1. **ビルド**: `go build ubuntu.` 成功
2. **静的解析**: `go vet ./pkg/controller/... pkg.` 問題なし
3. **単体テスト**: `go test pkg.`（Ginkgo）→ 73 Passed / 0 Failed / 6 Skipped
   - Bridge CNI導入・conflist生成・NAT設定・クロスノード経路計算のテストを追加
   - Cilium選択時にBridge CNI手順がスキップされることを確認するテストを追加
   - `network.kind` のバリデーション（不正値拒否・大小文字無視でcilium認識）のテストを追加
