### PR TITLE
再起動後の mke node のルーティングとiptables設定がロストする問題を解決

### DIFF
--- a/pkg/controller/kubernetes-engine-controller.go
+++ b/pkg/controller/kubernetes-engine-controller.go
@@ -23,8 +23,9 @@ const (
 )
 
 var (
-	provisionKubernetesEngineControlPlane = ProvisionKubernetesEngineControlPlane
-	provisionKubernetesEngineNodes        = ProvisionKubernetesEngineNodes
+	provisionKubernetesEngineControlPlane  = ProvisionKubernetesEngineControlPlane
+	provisionKubernetesEngineNodes         = ProvisionKubernetesEngineNodes
+	reconcileKubernetesEngineRunningRoutes = reconcileKubernetesEngineRunningNodeRoutes
 )
 
 // kubernetesEngineController は MKE (Marmot Kubernetes Engine) コントローラーです。
@@ -239,6 +240,8 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineProvisioning(ke ap
 // marmotdホストの再起動等でコントロールプレーン専用ネットワークネームスペース
 // (/run/netns配下はtmpfsのため再起動で消える)が失われると、専用etcd/kube-apiserver等の
 // systemdユニットがNetworkNamespacePath不在で起動失敗し続けるため、ここで検知して復旧する。
+// また、ノードVMの再起動で失われたPod CIDR宛の静的経路(`ip route replace`は永続化されない)も
+// 毎tick再設定し、Service(NodePort等)の疎通が失われたままにならないようにする。
 // TODO: 次フェーズでノードの状態監視を行い、異常時はFAILED等へ遷移させる。
 func (c *kubernetesEngineController) reconcileKubernetesEngineRunning(ke api.KubernetesEngine) {
 	id := api.KubernetesEngineID(ke)
@@ -249,19 +252,23 @@ func (c *kubernetesEngineController) reconcileKubernetesEngineRunning(ke api.Kub
 		slog.Warn("reconcileKubernetesEngineRunning: failed to resolve control plane namespace name", "id", id, "err", err)
 		return
 	}
-	if controlPlaneNamespaceExists(namespace) {
-		return
+	if !controlPlaneNamespaceExists(namespace) {
+		slog.Warn("コントロールプレーンのネットワークネームスペースが失われています。復旧を試みます", "id", id, "namespace", namespace)
+		if err := provisionKubernetesEngineControlPlane(c.db, c.mkeConf, c.etcdURL, ke); err != nil {
+			message := fmt.Sprintf("control plane network recovery failed: %v", err)
+			_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_RUNNING, message)
+			slog.Warn("reconcileKubernetesEngineRunning: control plane recovery failed", "id", id, "err", err)
+			return
+		}
+		_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_RUNNING, "")
+		slog.Debug("コントロールプレーンのネットワークネームスペースを復旧しました", "id", id, "namespace", namespace)
 	}
 
-	slog.Warn("コントロールプレーンのネットワークネームスペースが失われています。復旧を試みます", "id", id, "namespace", namespace)
-	if err := provisionKubernetesEngineControlPlane(c.db, c.mkeConf, c.etcdURL, ke); err != nil {
-		message := fmt.Sprintf("control plane network recovery failed: %v", err)
+	if err := reconcileKubernetesEngineRunningRoutes(c.db, ke); err != nil {
+		message := fmt.Sprintf("pod network route reconciliation failed: %v", err)
 		_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_RUNNING, message)
-		slog.Warn("reconcileKubernetesEngineRunning: control plane recovery failed", "id", id, "err", err)
-		return
+		slog.Warn("reconcileKubernetesEngineRunning: node route reconciliation failed", "id", id, "err", err)
 	}
-	_ = c.db.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_RUNNING, "")
-	slog.Debug("コントロールプレーンのネットワークネームスペースを復旧しました", "id", id, "namespace", namespace)
 }
 
 // reconcileKubernetesEngineDeleting は猶予期間経過後に呼び出され、ノード用仮想サーバーの削除要求、

--- a/pkg/controller/kubernetes-engine-node-ssh.go
+++ b/pkg/controller/kubernetes-engine-node-ssh.go
@@ -276,21 +276,43 @@ func installKubernetesEngineBridgeCNI(runner kubernetesEngineNodeCommandRunner, 
 	}
 
 	return runner.step("persist pod network NAT rules across reboot", func() error {
-		if err := runner.run("mkdir -p /etc/marmot/iptables", nil); err != nil {
-			return err
-		}
-		if err := runner.writeFile(kubernetesEngineNodeIptablesRestoreScriptPath, "0755",
-			[]byte(kubernetesEngineNodeIptablesRestoreScript())); err != nil {
-			return err
-		}
-		if err := runner.writeFile(kubernetesEngineNodeIptablesRestoreUnitPath, "0644",
-			[]byte(kubernetesEngineNodeIptablesRestoreUnit())); err != nil {
-			return err
-		}
-		if err := runner.run("systemctl daemon-reload && systemctl enable marmot-mke-iptables-restore.service", nil); err != nil {
-			return err
-		}
-		return runner.run(kubernetesEngineNodeIptablesRestoreScriptPath+" save", nil)
+		return persistKubernetesEngineNodeIptablesRules(runner)
+	})
+}
+
+// persistKubernetesEngineNodeIptablesRules は、iptablesルールを再起動後も維持するための
+// スクリプトとsystemdユニットをノードへ配置し、現在のルールを保存する。
+// この関数はべき等であり、既存クラスタのマイグレーション時にも安全に呼び出せる。
+func persistKubernetesEngineNodeIptablesRules(runner kubernetesEngineNodeCommandRunner) error {
+	if err := runner.run("mkdir -p /etc/marmot/iptables", nil); err != nil {
+		return err
+	}
+	if err := runner.writeFile(kubernetesEngineNodeIptablesRestoreScriptPath, "0755",
+		[]byte(kubernetesEngineNodeIptablesRestoreScript())); err != nil {
+		return err
+	}
+	if err := runner.writeFile(kubernetesEngineNodeIptablesRestoreUnitPath, "0644",
+		[]byte(kubernetesEngineNodeIptablesRestoreUnit())); err != nil {
+		return err
+	}
+	if err := runner.run("systemctl daemon-reload && systemctl enable marmot-mke-iptables-restore.service", nil); err != nil {
+		return err
+	}
+	return runner.run(kubernetesEngineNodeIptablesRestoreScriptPath+" save", nil)
+}
+
+// reconcileKubernetesEngineNodeIptablesSSH は、既存のBridgeノードに対してiptables永続化を
+// SSH経由でベき等に適用する（marmotdアップグレード後の既存クラスタ向けマイグレーション）。
+func reconcileKubernetesEngineNodeIptablesSSH(address, privateKeyPath, namespace, nodeID string) error {
+	client, err := dialKubernetesEngineNodeSSH(address, privateKeyPath, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to connect to node %s for iptables reconciliation: %w", nodeID, err)
+	}
+	defer func() { _ = client.Close() }()
+
+	runner := &kubernetesEngineNodeSSHRunner{client: client, resourceID: nodeID}
+	return runner.step("persist pod network NAT rules across reboot", func() error {
+		return persistKubernetesEngineNodeIptablesRules(runner)
 	})
 }
 

--- a/pkg/controller/kubernetes-engine-node-ssh.go
+++ b/pkg/controller/kubernetes-engine-node-ssh.go
@@ -269,9 +269,83 @@ func installKubernetesEngineBridgeCNI(runner kubernetesEngineNodeCommandRunner, 
 		return err
 	}
 
-	return runner.step("configure pod network NAT", func() error {
+	if err := runner.step("configure pod network NAT", func() error {
 		return runner.run(kubernetesEnginePodNetworkNATScript(data.PodNetworkSupernet), nil)
+	}); err != nil {
+		return err
+	}
+
+	return runner.step("persist pod network NAT rules across reboot", func() error {
+		if err := runner.run("mkdir -p /etc/marmot/iptables", nil); err != nil {
+			return err
+		}
+		if err := runner.writeFile(kubernetesEngineNodeIptablesRestoreScriptPath, "0755",
+			[]byte(kubernetesEngineNodeIptablesRestoreScript())); err != nil {
+			return err
+		}
+		if err := runner.writeFile(kubernetesEngineNodeIptablesRestoreUnitPath, "0644",
+			[]byte(kubernetesEngineNodeIptablesRestoreUnit())); err != nil {
+			return err
+		}
+		if err := runner.run("systemctl daemon-reload && systemctl enable marmot-mke-iptables-restore.service", nil); err != nil {
+			return err
+		}
+		return runner.run(kubernetesEngineNodeIptablesRestoreScriptPath+" save", nil)
 	})
+}
+
+// kubernetesEngineNodeIptablesRulesPath は、installKubernetesEngineBridgeCNIが設定した
+// Podネットワークegress用NAT(マスカレード)ルールを保存するファイル。iptablesルールは
+// デフォルトで永続化されないため、ノード再起動でルールが失われ、Pod発の外部向け通信
+// (ping・DNS解決の上流問い合わせ等)が失敗する問題への対応。
+const kubernetesEngineNodeIptablesRulesPath = "/etc/marmot/iptables/mke-node-rules.v4"
+const kubernetesEngineNodeIptablesRestoreScriptPath = "/usr/local/sbin/marmot-mke-iptables-restore.sh"
+const kubernetesEngineNodeIptablesRestoreUnitPath = "/etc/systemd/system/marmot-mke-iptables-restore.service"
+
+// kubernetesEngineNodeIptablesRestoreScript は、Gatewayのiptables永続化(marmot-gateway-iptables-restore.sh)
+// と同様に、引数なしなら保存済みルールを復元し、"save"引数なら現在のルールを保存するスクリプト。
+func kubernetesEngineNodeIptablesRestoreScript() string {
+	return fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+
+RULES_FILE="%s"
+if [[ "${1:-}" == "save" ]]; then
+  iptables-save > "${RULES_FILE}"
+  exit 0
+fi
+
+if [[ ! -s "${RULES_FILE}" ]]; then
+  exit 0
+fi
+
+IPTABLES_RESTORE="$(command -v iptables-restore || true)"
+if [[ -z "${IPTABLES_RESTORE}" ]]; then
+  IPTABLES_RESTORE="/sbin/iptables-restore"
+fi
+
+"${IPTABLES_RESTORE}" < "${RULES_FILE}"
+`, kubernetesEngineNodeIptablesRulesPath)
+}
+
+// kubernetesEngineNodeIptablesRestoreUnit は、起動時にルールを復元(ExecStart)し、
+// 停止時に現在のルールを保存(ExecStop)するoneshotサービス。
+func kubernetesEngineNodeIptablesRestoreUnit() string {
+	return fmt.Sprintf(`[Unit]
+Description=Marmot KubernetesEngine node iptables restore
+DefaultDependencies=no
+Wants=network-pre.target
+After=network-pre.target local-fs.target
+Before=network.target
+
+[Service]
+Type=oneshot
+ExecStart=%[1]s
+ExecStop=%[1]s save
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+`, kubernetesEngineNodeIptablesRestoreScriptPath)
 }
 
 // installKubernetesEngineCephClient は、Ceph連携(ceph_enabled=true)が有効な場合に、ノードへ

--- a/pkg/controller/kubernetes-engine-node-ssh_test.go
+++ b/pkg/controller/kubernetes-engine-node-ssh_test.go
@@ -217,6 +217,22 @@ var _ = Describe("runKubernetesEngineNodeProvisionSteps", func() {
 		Expect(runner.files["/etc/cni/net.d/10-bridge.conflist"]).To(ContainSubstring(`"subnet": "10.244.1.0/24"`))
 	})
 
+	It("persists the pod network NAT rules so a node reboot does not lose them", func() {
+		runner := &fakeKubernetesEngineNodeCommandRunner{outputs: map[string]string{"uname -m": "x86_64"}}
+		data := newTestKubernetesEngineNodeProvisionData()
+
+		Expect(runKubernetesEngineNodeProvisionSteps(runner, data)).To(Succeed())
+
+		joined := strings.Join(runner.commands, "\n")
+		Expect(joined).To(ContainSubstring("systemctl daemon-reload && systemctl enable marmot-mke-iptables-restore.service"))
+		Expect(joined).To(ContainSubstring("/usr/local/sbin/marmot-mke-iptables-restore.sh save"))
+		Expect(runner.files).To(HaveKey("/usr/local/sbin/marmot-mke-iptables-restore.sh"))
+		Expect(runner.files["/usr/local/sbin/marmot-mke-iptables-restore.sh"]).To(ContainSubstring("iptables-save > \"${RULES_FILE}\""))
+		Expect(runner.files).To(HaveKey("/etc/systemd/system/marmot-mke-iptables-restore.service"))
+		Expect(runner.files["/etc/systemd/system/marmot-mke-iptables-restore.service"]).To(ContainSubstring("ExecStart=/usr/local/sbin/marmot-mke-iptables-restore.sh"))
+		Expect(runner.files["/etc/systemd/system/marmot-mke-iptables-restore.service"]).To(ContainSubstring("ExecStop=/usr/local/sbin/marmot-mke-iptables-restore.sh save"))
+	})
+
 	It("skips the bridge CNI installation when network.kind is cilium", func() {
 		runner := &fakeKubernetesEngineNodeCommandRunner{outputs: map[string]string{"uname -m": "x86_64"}}
 		data := newTestKubernetesEngineNodeProvisionData()
@@ -227,6 +243,7 @@ var _ = Describe("runKubernetesEngineNodeProvisionSteps", func() {
 		joined := strings.Join(runner.commands, "\n")
 		Expect(joined).NotTo(ContainSubstring("cni-plugins-linux"))
 		Expect(runner.files).NotTo(HaveKey("/etc/cni/net.d/10-bridge.conflist"))
+		Expect(runner.files).NotTo(HaveKey("/usr/local/sbin/marmot-mke-iptables-restore.sh"))
 	})
 })
 

--- a/pkg/controller/kubernetes-engine-node.go
+++ b/pkg/controller/kubernetes-engine-node.go
@@ -24,7 +24,8 @@ const (
 	kubernetesEngineNodeLabelRole        = "kubernetesEngineRole"
 	kubernetesEngineNodeRoleValue        = "node"
 	kubernetesEngineNodeLabelIndex       = "kubernetesEngineNodeIndex"
-	kubernetesEngineNodeLabelProvisioned = "kubernetesEngineNodeProvisioned"
+	kubernetesEngineNodeLabelProvisioned        = "kubernetesEngineNodeProvisioned"
+	kubernetesEngineNodeLabelIptablesPersisted  = "kubernetesEngineNodeIptablesPersisted"
 	defaultKubernetesEngineNodeCPU       = 2
 	defaultKubernetesEngineNodeMemory    = 2048
 
@@ -43,11 +44,12 @@ const (
 var kubernetesEngineNodeNamePattern = regexp.MustCompile(`-node-(\d+)$`)
 
 var (
-	kubernetesEngineNodePrivateKeyPath  = marmotd.GatewayPrivateKeyPath()
-	kubernetesEngineNodePublicKeyPath   = marmotd.GatewayPublicKeyPath()
-	ensureKubernetesEngineNodeSSHAssets = marmotd.EnsureGatewayRuntimeAssets
-	runKubernetesEngineNodeProvision    = provisionKubernetesEngineNodeSSH
-	queryKubernetesEngineNodes          = queryKubernetesEngineNodesCommand
+	kubernetesEngineNodePrivateKeyPath        = marmotd.GatewayPrivateKeyPath()
+	kubernetesEngineNodePublicKeyPath         = marmotd.GatewayPublicKeyPath()
+	ensureKubernetesEngineNodeSSHAssets       = marmotd.EnsureGatewayRuntimeAssets
+	runKubernetesEngineNodeProvision          = provisionKubernetesEngineNodeSSH
+	runKubernetesEngineNodeIptablesReconcile  = reconcileKubernetesEngineNodeIptablesSSH
+	queryKubernetesEngineNodes                = queryKubernetesEngineNodesCommand
 )
 
 type kubernetesNodeList struct {
@@ -137,8 +139,19 @@ func ProvisionKubernetesEngineNodes(database *db.Database, mkeConf *marmotd.MKEC
 				return false, err
 			}
 			labels[kubernetesEngineNodeLabelProvisioned] = "true"
+			if networkKind != kubernetesEngineNetworkKindCilium {
+				labels[kubernetesEngineNodeLabelIptablesPersisted] = "true"
+			}
 			if err := database.UpdateServer(server.Metadata.Id, api.Server{Metadata: api.Metadata{Labels: &labels}}); err != nil {
 				return false, fmt.Errorf("failed to mark node %s as provisioned: %w", server.Metadata.Name, err)
+			}
+		} else if networkKind != kubernetesEngineNetworkKindCilium && labels[kubernetesEngineNodeLabelIptablesPersisted] != "true" {
+			if err := reconcileIptablesPersistenceForNode(ke, server.Metadata.Name, nodeIP); err != nil {
+				return false, err
+			}
+			labels[kubernetesEngineNodeLabelIptablesPersisted] = "true"
+			if err := database.UpdateServer(server.Metadata.Id, api.Server{Metadata: api.Metadata{Labels: &labels}}); err != nil {
+				return false, fmt.Errorf("failed to mark node %s iptables as persisted: %w", server.Metadata.Name, err)
 			}
 		}
 		expectedNames = append(expectedNames, server.Metadata.Name)
@@ -553,6 +566,18 @@ func configureKubernetesEngineNode(mkeConf *marmotd.MKEConfig, ke api.Kubernetes
 		return err
 	}
 	return runKubernetesEngineNodeProvision(nodeIP, kubernetesEngineNodePrivateKeyPath, namespace, nodeID, data)
+}
+
+// reconcileIptablesPersistenceForNode は、marmotdアップグレード前にプロビジョニング済みの
+// Bridgeノードへ、iptables永続化ユニットをべき等に適用するマイグレーション関数。
+func reconcileIptablesPersistenceForNode(ke api.KubernetesEngine, nodeName, nodeIP string) error {
+	clusterName := strings.TrimSpace(ke.Metadata.Name)
+	namespace, _, _, err := KubernetesEngineControlPlaneNetworkNames(clusterName)
+	if err != nil {
+		return err
+	}
+	nodeID := fmt.Sprintf("%s-%s", api.KubernetesEngineID(ke), nodeName)
+	return runKubernetesEngineNodeIptablesReconcile(nodeIP, kubernetesEngineNodePrivateKeyPath, namespace, nodeID)
 }
 
 func renderKubernetesEngineNodeKubeconfig(endpoint, user, certPath, keyPath string) string {

--- a/pkg/controller/kubernetes-engine-node.go
+++ b/pkg/controller/kubernetes-engine-node.go
@@ -445,6 +445,25 @@ func reconcileKubernetesEngineNodeRoutes(ke api.KubernetesEngine, servers []api.
 	return nil
 }
 
+// reconcileKubernetesEngineRunningNodeRoutes は、RUNNING状態のクラスタに対しても毎tick
+// 呼び出される差し込み口。ノードVMの再起動により`ip route replace`で設定した経路が
+// 失われる(永続化していないため)ことでService(NodePort等)の疎通が失われる問題に対応する。
+// Cilium CNI選択時はCilium自身が経路を管理するため何もしない。
+func reconcileKubernetesEngineRunningNodeRoutes(database *db.Database, ke api.KubernetesEngine) error {
+	networkKind, err := validatedKubernetesEngineNodeNetworkKind(ke)
+	if err != nil {
+		return err
+	}
+	if networkKind == kubernetesEngineNetworkKindCilium {
+		return nil
+	}
+	servers, err := findKubernetesEngineNodeServers(database, ke)
+	if err != nil {
+		return err
+	}
+	return reconcileKubernetesEngineNodeRoutes(ke, servers)
+}
+
 func kubernetesEngineNodeInternalIP(server api.Server, networkName string) (string, error) {
 	if server.Spec.NetworkInterface == nil {
 		return "", fmt.Errorf("node %s has no network interfaces", server.Metadata.Name)

--- a/pkg/controller/kubernetes-engine-node_test.go
+++ b/pkg/controller/kubernetes-engine-node_test.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"errors"
+
 	"github.com/takara9/marmot/api"
 	"github.com/takara9/marmot/pkg/db"
 	"github.com/takara9/marmot/pkg/util"
@@ -207,5 +209,46 @@ var _ = Describe("KubernetesEngineNode", func() {
 		for _, c := range calls {
 			Expect(c.routes).To(HaveLen(1))
 		}
+	})
+
+	Describe("reconcileIptablesPersistenceForNode", func() {
+		var (
+			origReconcile func(address, privateKeyPath, namespace, nodeID string) error
+			calls         []struct{ address, namespace, nodeID string }
+		)
+		BeforeEach(func() {
+			origReconcile = runKubernetesEngineNodeIptablesReconcile
+			calls = nil
+		})
+		AfterEach(func() { runKubernetesEngineNodeIptablesReconcile = origReconcile })
+
+		It("calls the reconcile stub with the correct arguments for a Bridge node", func() {
+			runKubernetesEngineNodeIptablesReconcile = func(address, privateKeyPath, namespace, nodeID string) error {
+				calls = append(calls, struct{ address, namespace, nodeID string }{address, namespace, nodeID})
+				return nil
+			}
+
+			ke := api.KubernetesEngine{Metadata: api.Metadata{Name: "demo"}}
+			api.SetKubernetesEngineID(&ke, "ke123")
+
+			Expect(reconcileIptablesPersistenceForNode(ke, "mke-demo-node-1", "172.16.1.10")).To(Succeed())
+			Expect(calls).To(HaveLen(1))
+			Expect(calls[0].address).To(Equal("172.16.1.10"))
+			Expect(calls[0].namespace).To(Equal("mke-demo"))
+			Expect(calls[0].nodeID).To(Equal("ke123-mke-demo-node-1"))
+		})
+
+		It("propagates errors from the reconcile stub", func() {
+			runKubernetesEngineNodeIptablesReconcile = func(address, privateKeyPath, namespace, nodeID string) error {
+				return errors.New("ssh connection refused")
+			}
+
+			ke := api.KubernetesEngine{Metadata: api.Metadata{Name: "demo"}}
+			api.SetKubernetesEngineID(&ke, "ke123")
+
+			err := reconcileIptablesPersistenceForNode(ke, "mke-demo-node-1", "172.16.1.10")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ssh connection refused"))
+		})
 	})
 })

--- a/pkg/controller/kubernetes-engine-running-recovery_test.go
+++ b/pkg/controller/kubernetes-engine-running-recovery_test.go
@@ -148,3 +148,96 @@ func TestReconcileKubernetesEngineRunningRecordsMessageWhenRecoveryFails(t *test
 		t.Fatalf("status message was not recorded for the recovery failure")
 	}
 }
+
+// ノードVMの再起動で`ip route replace`により設定した経路が失われても、RUNNING状態の間は
+// 毎tick reconcileKubernetesEngineRunningRoutes が呼び出されて再設定が試みられることを確認する。
+func TestReconcileKubernetesEngineRunningReconciliatesNodeRoutes(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ke, err := database.CreateKubernetesEngine(api.KubernetesEngine{
+		ApiVersion: "v1",
+		Kind:       "KubernetesEngine",
+		Metadata:   api.Metadata{Name: "routes-recover"},
+		Spec:       api.KubernetesEngineSpec{Version: "1.36", Nodes: 1},
+	})
+	if err != nil {
+		t.Fatalf("CreateKubernetesEngine() failed: %v", err)
+	}
+	id := api.KubernetesEngineID(ke)
+	if err := database.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_RUNNING, ""); err != nil {
+		t.Fatalf("failed to set RUNNING: %v", err)
+	}
+	ke, err = database.GetKubernetesEngineById(id)
+	if err != nil {
+		t.Fatalf("GetKubernetesEngineById() failed: %v", err)
+	}
+
+	origNamespaceExists := controlPlaneNamespaceExists
+	origRunningRoutes := reconcileKubernetesEngineRunningRoutes
+	t.Cleanup(func() {
+		controlPlaneNamespaceExists = origNamespaceExists
+		reconcileKubernetesEngineRunningRoutes = origRunningRoutes
+	})
+
+	controlPlaneNamespaceExists = func(string) bool { return true }
+	var reconciledID string
+	reconcileKubernetesEngineRunningRoutes = func(_ *db.Database, targetKe api.KubernetesEngine) error {
+		reconciledID = api.KubernetesEngineID(targetKe)
+		return nil
+	}
+
+	ctrl := &kubernetesEngineController{db: database, mkeConf: &marmotd.MKEConfig{}, etcdURL: "http://127.0.0.1:2379"}
+	ctrl.reconcileKubernetesEngineRunning(ke)
+
+	if reconciledID != id {
+		t.Fatalf("reconcileKubernetesEngineRunningRoutes was not called for id %q, got %q", id, reconciledID)
+	}
+}
+
+// 経路の再設定に失敗した場合はメッセージを記録しつつ、RUNNINGのまま次回tickで
+// 再試行できるようにすることを確認する。
+func TestReconcileKubernetesEngineRunningRecordsMessageWhenRouteReconciliationFails(t *testing.T) {
+	database := newGatewayTestDatabase(t)
+	ke, err := database.CreateKubernetesEngine(api.KubernetesEngine{
+		ApiVersion: "v1",
+		Kind:       "KubernetesEngine",
+		Metadata:   api.Metadata{Name: "routes-recover-fail"},
+		Spec:       api.KubernetesEngineSpec{Version: "1.36", Nodes: 1},
+	})
+	if err != nil {
+		t.Fatalf("CreateKubernetesEngine() failed: %v", err)
+	}
+	id := api.KubernetesEngineID(ke)
+	if err := database.UpdateKubernetesEngineStatusWithMessage(id, db.KUBERNETES_ENGINE_RUNNING, ""); err != nil {
+		t.Fatalf("failed to set RUNNING: %v", err)
+	}
+	ke, err = database.GetKubernetesEngineById(id)
+	if err != nil {
+		t.Fatalf("GetKubernetesEngineById() failed: %v", err)
+	}
+
+	origNamespaceExists := controlPlaneNamespaceExists
+	origRunningRoutes := reconcileKubernetesEngineRunningRoutes
+	t.Cleanup(func() {
+		controlPlaneNamespaceExists = origNamespaceExists
+		reconcileKubernetesEngineRunningRoutes = origRunningRoutes
+	})
+
+	controlPlaneNamespaceExists = func(string) bool { return true }
+	reconcileKubernetesEngineRunningRoutes = func(_ *db.Database, _ api.KubernetesEngine) error {
+		return errors.New("simulated route reconciliation failure")
+	}
+
+	ctrl := &kubernetesEngineController{db: database, mkeConf: &marmotd.MKEConfig{}, etcdURL: "http://127.0.0.1:2379"}
+	ctrl.reconcileKubernetesEngineRunning(ke)
+
+	updated, err := database.GetKubernetesEngineById(id)
+	if err != nil {
+		t.Fatalf("GetKubernetesEngineById() failed: %v", err)
+	}
+	if updated.Status == nil || updated.Status.StatusCode != db.KUBERNETES_ENGINE_RUNNING {
+		t.Fatalf("status = %+v, want to remain RUNNING so the next tick retries route reconciliation", updated.Status)
+	}
+	if updated.Status.Message == nil || *updated.Status.Message == "" {
+		t.Fatalf("status message was not recorded for the route reconciliation failure")
+	}
+}


### PR DESCRIPTION
## 概要

Issue #657「mke で再起動後に service が動かなくなる。ルーティングが通らなくなる」への対応。mkeノードVM再起動後に発生する2つの問題を修正します。

## 問題1: ホストのルーティングが再起動後に失われる

Bridge CNI選択時、ノード間のPod CIDR疎通用の静的経路は `ip route replace` でSSH経由に設定されるだけで、クラスタがRUNNING状態に遷移した後は再設定処理(`reconcileKubernetesEngineNodeRoutes`)がPROVISIONING中にしか呼ばれなくなっていました。そのためノードVMが再起動して経路が消えても復旧されませんでした。

**対応**:
- `reconcileKubernetesEngineRunningNodeRoutes` を追加(Cilium選択時はスキップ)
- RUNNING状態のヘルスチェック(`reconcileKubernetesEngineRunning`、10秒間隔ポーリング)から毎tick呼び出すよう変更。既存のコントロールプレーンnetns復旧と同じパターンで、失敗時はStatus.Messageに記録しRUNNINGのまま次tickで再試行

## 問題2: 経路復旧後もPodからのping・DNS解決が失敗する

ホスト側のルーティングが復旧しても、Pod発の外部向け通信(ping、CoreDNSの外部アップストリームDNS問い合わせ等)が失敗する現象を確認。原因は `kubernetesEnginePodNetworkNATScript` が設定するiptables NAT(マスカレード)ルールが、`ip_forward`/`br_netfilter`とは異なり永続化されておらず、ノード再起動でリセットされていたためでした。マスカレードが失われるとPodの送信元IP(10.244.x.x)がそのまま外部に漏れ、応答パケットが経路不明で戻せなくなります。

**対応**: Gatewayの既存実装(`gateway-iptables.yaml.tmpl`)と同じrestore/saveパターンを追加。
- `/usr/local/sbin/marmot-mke-iptables-restore.sh`(起動時にルール復元、`save`引数で現在のルールを保存)
- `/etc/systemd/system/marmot-mke-iptables-restore.service`(oneshotサービス、ExecStart=復元/ExecStop=保存)
- 保存先: `/etc/marmot/iptables/mke-node-rules.v4`
- 初回プロビジョニング時にNATルール設定直後、サービス有効化と現在ルールの保存を実行(Cilium選択時はこのステップ自体対象外)

## 変更ファイル

- `kubernetes-engine-controller.go` — RUNNING時のノード経路再設定呼び出しを追加
- `kubernetes-engine-node.go` — `reconcileKubernetesEngineRunningNodeRoutes` を追加
- `kubernetes-engine-node-ssh.go` — iptables NATルールのrestore/save永続化を追加
- `kubernetes-engine-running-recovery_test.go` / `kubernetes-engine-node-ssh_test.go` — 対応するテストを追加

## 検証

1. `go build `ubuntu`.` — 成功
2. `go vet `pkg`.` — 問題なし
3. `go test `pkg`.` — Ginkgoスイート 95 Passed / 0 Failed / 6 Skipped(新規テスト含む)。`TestReconcileKubernetesEngineDeletingWaitsForNetworkRemoval` 系2件は本PRと無関係の既存の失敗(`main`ブランチでも再現、ネットワーク名衝突によるテスト分離の問題)

## 未検証事項

- 実機でのノード再起動→ルーティング復旧・Pod ping/DNS解決の再現確認は未実施

