### PR TITLE
host-bridgeの間違った接続の修正

### DIFF
--- a/pkg/marmotd/server.go
+++ b/pkg/marmotd/server.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -1460,26 +1459,7 @@ func isLibvirtBridgeDeviceMissingError(err error) bool {
 }
 
 func isOVSBridge(bridgeName string) bool {
-	name := strings.TrimSpace(bridgeName)
-	if name == "" {
-		return false
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "ovs-vsctl", "br-exists", name)
-	if err := cmd.Run(); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			slog.Warn("ovs bridge check skipped: ovs-vsctl not found", "bridge", name, "err", err)
-		} else if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			slog.Warn("ovs bridge check timed out", "bridge", name, "timeout", "2s")
-		} else {
-			slog.Warn("ovs bridge check failed", "bridge", name, "err", err)
-		}
-		return false
-	}
-	return true
+	return util.IsOVSBridge(bridgeName)
 }
 
 func shouldAttachOVSInterfaceID(vnet api.VirtualNetwork, bridgeName string) bool {

--- a/pkg/util/hostbridge.go
+++ b/pkg/util/hostbridge.go
@@ -4,6 +4,8 @@
 package util
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log/slog"
@@ -108,6 +110,31 @@ func bridgeExists(bridgeName string) bool {
 	cmd := exec.Command("ip", "link", "show", bridgeName)
 	err := cmd.Run()
 	return err == nil
+}
+
+// IsOVSBridge reports whether bridgeName is a bridge managed by Open vSwitch,
+// as opposed to a plain Linux kernel bridge (e.g. host-bridge/br0).
+func IsOVSBridge(bridgeName string) bool {
+	name := strings.TrimSpace(bridgeName)
+	if name == "" {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ovs-vsctl", "br-exists", name)
+	if err := cmd.Run(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			slog.Warn("ovs bridge check skipped: ovs-vsctl not found", "bridge", name, "err", err)
+		} else if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			slog.Warn("ovs bridge check timed out", "bridge", name, "timeout", "2s")
+		} else {
+			slog.Warn("ovs bridge check failed", "bridge", name, "err", err)
+		}
+		return false
+	}
+	return true
 }
 
 // findPrimaryNIC finds the first physical NIC (excluding loopback and WiFi)

--- a/pkg/util/hostbridge_ovs_test.go
+++ b/pkg/util/hostbridge_ovs_test.go
@@ -41,7 +41,11 @@ func prependPATH(t *testing.T, dir string) {
 	if err := os.Setenv("PATH", dir+":"+old); err != nil {
 		t.Fatalf("failed to set PATH: %v", err)
 	}
-	t.Cleanup(func() { os.Setenv("PATH", old) })
+	t.Cleanup(func() {
+		if err := os.Setenv("PATH", old); err != nil {
+			t.Fatalf("failed to restore PATH: %v", err)
+		}
+	})
 }
 
 func TestIsOVSBridge_EmptyName(t *testing.T) {

--- a/pkg/util/hostbridge_ovs_test.go
+++ b/pkg/util/hostbridge_ovs_test.go
@@ -1,0 +1,81 @@
+//go:build linux
+// +build linux
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeOVSVsctl creates a fake ovs-vsctl script in dir and returns dir.
+// exitCode is the exit code the script will return.
+func writeOVSVsctl(t *testing.T, exitCode int) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "ovs-vsctl")
+	content := "#!/bin/sh\nexit " + itoa(exitCode) + "\n"
+	if err := os.WriteFile(script, []byte(content), 0755); err != nil {
+		t.Fatalf("failed to write fake ovs-vsctl: %v", err)
+	}
+	return dir
+}
+
+// itoa converts an int to its decimal string representation without importing strconv.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	b := make([]byte, 0, 3)
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func prependPATH(t *testing.T, dir string) {
+	t.Helper()
+	old := os.Getenv("PATH")
+	if err := os.Setenv("PATH", dir+":"+old); err != nil {
+		t.Fatalf("failed to set PATH: %v", err)
+	}
+	t.Cleanup(func() { os.Setenv("PATH", old) })
+}
+
+func TestIsOVSBridge_EmptyName(t *testing.T) {
+	if got := IsOVSBridge(""); got {
+		t.Error("IsOVSBridge(\"\") = true, want false")
+	}
+}
+
+func TestIsOVSBridge_OVSVsctlNotFound(t *testing.T) {
+	// Use a temp dir with no ovs-vsctl binary so exec.ErrNotFound is triggered.
+	dir := t.TempDir()
+	prependPATH(t, dir)
+
+	if got := IsOVSBridge("br0"); got {
+		t.Error("IsOVSBridge with missing ovs-vsctl = true, want false")
+	}
+}
+
+func TestIsOVSBridge_BrExistsFails(t *testing.T) {
+	// ovs-vsctl exits with non-zero (bridge not managed by OVS).
+	dir := writeOVSVsctl(t, 2)
+	prependPATH(t, dir)
+
+	if got := IsOVSBridge("br0"); got {
+		t.Error("IsOVSBridge with failing br-exists = true, want false")
+	}
+}
+
+func TestIsOVSBridge_BrExistsSucceeds(t *testing.T) {
+	// ovs-vsctl exits with 0 (bridge is managed by OVS).
+	dir := writeOVSVsctl(t, 0)
+	prependPATH(t, dir)
+
+	if got := IsOVSBridge("ovsbr0"); !got {
+		t.Error("IsOVSBridge with successful br-exists = false, want true")
+	}
+}

--- a/pkg/virt/virt_net.go
+++ b/pkg/virt/virt_net.go
@@ -59,15 +59,18 @@ func CreateVirtualNetworkXML(net api.VirtualNetwork) (*libvirtxml.Network, error
 	}
 
 	if net.Spec.Nat == nil || !*net.Spec.Nat {
-		// OVS ブリッジを利用するネットワークは、libvirt へ Open vSwitch virtualport を明示する。
-		// これにより、先行作成済みブリッジを利用し、Linux bridge の新規作成競合を避ける。
 		netxml.Forward = &libvirtxml.NetworkForward{
 			Mode: "bridge",
 		}
-		netxml.VirtualPort = &libvirtxml.NetworkVirtualPort{
-			Params: &libvirtxml.NetworkVirtualPortParams{
-				OpenVSwitch: &libvirtxml.NetworkVirtualPortParamsOpenVSwitch{},
-			},
+		// OVS 管理下のブリッジ(または overlay ネットワーク)の場合のみ、libvirt へ Open vSwitch
+		// virtualport を明示する。host-bridge のような素の Linux bridge に付与すると、
+		// VM の tap が Linux bridge ではなく OVS 側に接続され疎通できなくなるため要判定。
+		if shouldUseOVSVirtualPort(net) {
+			netxml.VirtualPort = &libvirtxml.NetworkVirtualPort{
+				Params: &libvirtxml.NetworkVirtualPortParams{
+					OpenVSwitch: &libvirtxml.NetworkVirtualPortParamsOpenVSwitch{},
+				},
+			}
 		}
 	}
 
@@ -128,6 +131,22 @@ func CreateVirtualNetworkXML(net api.VirtualNetwork) (*libvirtxml.Network, error
 	//fmt.Printf("Generated XML:\n%s\n", xml)
 
 	return netxml, nil
+}
+
+// shouldUseOVSVirtualPort は、libvirt ネットワーク定義に Open vSwitch virtualport を
+// 付与すべきか判定する。overlay(vxlan/geneve) ネットワーク、または BridgeName が実際に
+// OVS ブリッジの場合のみ true を返す。host-bridge 等の素の Linux bridge では false。
+func shouldUseOVSVirtualPort(net api.VirtualNetwork) bool {
+	if net.Spec.OverlayMode != nil {
+		mode := strings.TrimSpace(string(*net.Spec.OverlayMode))
+		if strings.EqualFold(mode, string(api.Vxlan)) || strings.EqualFold(mode, string(api.Geneve)) {
+			return true
+		}
+	}
+	if net.Spec.BridgeName == nil {
+		return false
+	}
+	return util.IsOVSBridge(*net.Spec.BridgeName)
 }
 
 func (l *LibVirtEp) ActivateVirtualNetworks(name string) error {

--- a/pkg/virt/virt_net_test.go
+++ b/pkg/virt/virt_net_test.go
@@ -17,6 +17,54 @@ import (
 	"github.com/takara9/marmot/pkg/virt"
 )
 
+// newTestVirtualNetwork はテスト用の最小限の VirtualNetwork を生成するヘルパー。
+func newTestVirtualNetwork(name, bridge string, overlayMode *api.VirtualNetworkSpecOverlayMode) api.VirtualNetwork {
+	return api.VirtualNetwork{
+		Metadata: api.Metadata{
+			Name: name,
+			Uuid: util.StringPtr(uuid.New().String()),
+		},
+		Spec: api.VirtualNetworkSpec{
+			BridgeName:  util.StringPtr(bridge),
+			OverlayMode: overlayMode,
+		},
+	}
+}
+
+var _ = Describe("CreateVirtualNetworkXML VirtualPort 付与条件", func() {
+	overlayMode := func(m api.VirtualNetworkSpecOverlayMode) *api.VirtualNetworkSpecOverlayMode { return &m }
+
+	Context("host-bridge (素の Linux bridge) の場合", func() {
+		It("VirtualPort が nil であること", func() {
+			// "virbr-unit-test" は OVS ブリッジではないため IsOVSBridge が false を返す
+			net := newTestVirtualNetwork("unit-host-bridge", "virbr-unit-test", nil)
+			netxml, err := virt.CreateVirtualNetworkXML(net)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(netxml.VirtualPort).To(BeNil())
+		})
+	})
+
+	Context("overlay ネットワーク (vxlan) の場合", func() {
+		It("VirtualPort が nil でないこと", func() {
+			mode := overlayMode(api.Vxlan)
+			net := newTestVirtualNetwork("unit-vxlan", "br-vxlan", mode)
+			netxml, err := virt.CreateVirtualNetworkXML(net)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(netxml.VirtualPort).NotTo(BeNil())
+		})
+	})
+
+	Context("overlay ネットワーク (geneve) の場合", func() {
+		It("VirtualPort が nil でないこと", func() {
+			mode := overlayMode(api.Geneve)
+			net := newTestVirtualNetwork("unit-geneve", "br-geneve", mode)
+			netxml, err := virt.CreateVirtualNetworkXML(net)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(netxml.VirtualPort).NotTo(BeNil())
+		})
+	})
+})
+
 var _ = Describe("Networks", Ordered, func() {
 	var l *virt.LibVirtEp
 	var vnet []libvirtxml.Network


### PR DESCRIPTION
## 概要

`host-bridge`（素の Linux bridge、`br0`）に接続した VM が、外部ネットワークと疎通できなくなる不具合を修正しました。

## 問題

`host-bridge` ネットワークに接続した VM の tap インターフェース（`vnetX`）が、実際には `br0`（Linux kernel bridge、物理 NIC `enp4s0` が接続されている）ではなく、Open vSwitch のデータパス (`ovs-system`) 側に接続されてしまい、VM ⇔ 外部ネットワーク間の疎通が失われていました。

- `host-bridge` に繋がった VM 同士は疎通可能（同一 OVS 内でスイッチングされるため）
- VM ⇔ 外部、外部 ⇔ VM は双方向とも疎通不可

## 原因

`CreateVirtualNetworkXML`（`virt_net.go`）が、NAT を使わないブリッジ系ネットワーク（`host-bridge` を含む）に対して、対象ブリッジが実際に OVS 管理下かどうかを判定せず、**無条件に** `<virtualport type='openvswitch'/>` を libvirt ネットワーク定義に付与していました。

一方 `server.go` には VM インターフェース単位で OVS 判定を行う `isOVSBridge`（`ovs-vsctl br-exists` ベース）が既に実装されていましたが、ネットワーク定義生成側では使われておらず、判定ロジックが非対称になっていたことが根本原因です。

## 修正内容

- `hostbridge.go`: `ovs-vsctl br-exists` によるブリッジ種別判定を `IsOVSBridge` として共通化・エクスポート
- `virt_net.go`: `shouldUseOVSVirtualPort` を追加し、overlay (vxlan/geneve) ネットワーク、または実際に OVS 管理下のブリッジの場合のみ `virtualport` を付与するよう変更
- `server.go`: 重複していた `isOVSBridge` の実装を `util.IsOVSBridge` に委譲するよう整理（未使用となった `os/exec` import を削除）

## 影響範囲

- `host-bridge` など素の Linux bridge を使うネットワークの libvirt ネットワーク定義生成
- overlay (vxlan/geneve) ネットワーク、および実際に OVS 管理下のブリッジを使うネットワークの挙動は変更なし

## 検証

1. `go build `ubuntu`.` 成功
2. `go vet ./pkg/virt/... ./pkg/util/... `pkg`.` 問題なし
3. `go test ./pkg/util/... `pkg`.`（Docker/etcd/libvirt 等インフラ依存の既存失敗を除き、本修正による新規失敗なし。修正前後で差分がないことを stash 比較で確認済み）
4. 実機（hv0）で `marmotd` 入れ替え後、`virsh net-dumpxml host-bridge` で `<virtualport>` が付与されなくなることを確認

## 運用上の注意（別途対応が必要）

既に誤った定義で `host-bridge` が作成済みの環境では、本修正の適用（`marmotd` 更新・再起動）だけでは直りません。該当ホストで以下の追加対応が必要です。

1. 既存の `host-bridge` ネットワーク定義の再作成
   ```
   virsh net-destroy host-bridge
   virsh net-undefine host-bridge
   systemctl restart marmot
   ```
2. 環境によっては OVSDB に `br0` という名前の壊れた Bridge エントリが残存し、`ovs-vsctl br-exists br0` が誤って true を返すケースがあるため、その場合は該当エントリの削除が必要
   ```
   ovs-vsctl --if-exists del-port br0 <vnetX>
   ovs-vsctl --if-exists del-br br0
   ```
3. 既に OVS 側に接続されてしまった稼働中 VM は、再起動（`virsh destroy` → `virsh start`）で tap を繋ぎ直す

